### PR TITLE
Update S3 policy for the EKS workers

### DIFF
--- a/cloudprem/eks.tf
+++ b/cloudprem/eks.tf
@@ -67,7 +67,8 @@ data "aws_iam_policy_document" "eks_worker" {
       "s3:PutObjectAcl",
       "s3:GetObject",
       "s3:GetObjectAcl",
-      "s3:ListObjects"
+      "s3:ListObjects",
+      "s3:CopyObject"
     ]
 
     resources = [

--- a/cloudprem/eks.tf
+++ b/cloudprem/eks.tf
@@ -67,7 +67,7 @@ data "aws_iam_policy_document" "eks_worker" {
       "s3:PutObjectAcl",
       "s3:GetObject",
       "s3:GetObjectAcl",
-      "s3:ListObjects",
+      "s3:ListObjectsV2",
       "s3:CopyObject"
     ]
 

--- a/cloudprem/eks.tf
+++ b/cloudprem/eks.tf
@@ -67,6 +67,7 @@ data "aws_iam_policy_document" "eks_worker" {
       "s3:PutObjectAcl",
       "s3:GetObject",
       "s3:GetObjectAcl",
+      "s3:ListBucket",
       "s3:ListObjectsV2",
       "s3:CopyObject"
     ]

--- a/cloudprem/eks.tf
+++ b/cloudprem/eks.tf
@@ -66,7 +66,8 @@ data "aws_iam_policy_document" "eks_worker" {
       "s3:PutObject",
       "s3:PutObjectAcl",
       "s3:GetObject",
-      "s3:GetObjectAcl"
+      "s3:GetObjectAcl",
+      "s3:ListObjects"
     ]
 
     resources = [


### PR DESCRIPTION
Our site cloning feature relies upon the S3 API calls `ListObjectsV2` and `CopyObject` so we need those actions. In order to use `ListObjectsV2` we also need `ListBucket` so that has been added as well.