### PR TITLE
Add the Sentry configuration file

### DIFF
--- a/cloudprem/kubernetes.tf
+++ b/cloudprem/kubernetes.tf
@@ -109,31 +109,6 @@ resource "kubernetes_config_map" "dozuki_resources" {
     EOF
 
     "rds-ca.pem" = file(local.is_us_gov ? "vendor/rds-ca-${data.aws_region.current.name}-2017-root.pem" : "vendor/rds-ca-2019-root.pem")
-
-    "index.json" = <<-EOF
-      {
-        "index": {
-          "legacy": {
-            "filename": "legacy.json"
-          },
-          "s3": {
-            "filename": "s3.json"
-          },
-          "buckets": {
-            "filename": "buckets.json"
-          },
-          "db": {
-            "filename": "db.json"
-          },
-          "memcached": {
-            "filename": "memcached.json"
-          },
-          "aws-resources": {
-            "filename": "aws-resources.json"
-          }
-        }
-      }
-    EOF
   }
 
 }

--- a/cloudprem/kubernetes.tf
+++ b/cloudprem/kubernetes.tf
@@ -79,6 +79,14 @@ resource "kubernetes_config_map" "dozuki_resources" {
       }
     EOF
 
+    "sentry.json" = <<-EOF
+      {
+        "tags": {
+          "deployment": "CloudPrem",
+        }
+      }
+    EOF
+
     "db.json" = <<-EOF
       {
         "generic": {


### PR DESCRIPTION
Our app code can consume a `/etc/dozuki/sentry.json` file to add a list of tags when sending exceptions to Sentry. This adds the `deployment` tag.