### PR TITLE
Add memcached test cluster configs

### DIFF
--- a/cloudprem/kubernetes.tf
+++ b/cloudprem/kubernetes.tf
@@ -70,6 +70,14 @@ resource "kubernetes_config_map" "dozuki_resources" {
               "port": ${module.memcached.port}
             }
           ]
+        },
+        "testCluster": {
+          "servers": [
+            {
+              "hostname": "${module.memcached.cluster_address}",
+              "port": ${module.memcached.port}
+            }
+          ]
         }
       }
     EOF


### PR DESCRIPTION
Background
--
This configuration is used to determine how to connect to the memcached server that's used to acquire mutexes for nanosites when running integration tests. This may not get us all the way to being able to run all integration tests in CloudPrem, but it will at least get us one step closer.

QA
--
I'm not sure how QA is being done on CloudPrem these days, but this should have no effect on the application's regular behavior.

CC @scbarber @ddvdozuki 