### PR TITLE
Adding Machine Translation config

### DIFF
--- a/cloudprem/app/README.md
+++ b/cloudprem/app/README.md
@@ -75,6 +75,7 @@ No modules.
 | <a name="input_eks_cluster_id"></a> [eks\_cluster\_id](#input\_eks\_cluster\_id) | ID of EKS cluster for app provisioning | `string` | n/a | yes |
 | <a name="input_enable_webhooks"></a> [enable\_webhooks](#input\_enable\_webhooks) | This option will spin up a managed Kafka & Redis cluster to support private webhooks. | `bool` | `false` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | Environment of the application | `string` | `"dev"` | no |
+| <a name="input_google_translate_api_token"></a> [google\_translate\_api\_token](#input\_google\_translate\_api\_token) | If using machine translation, enter your google translate API token here. | `string` | `""` | no |
 | <a name="input_identifier"></a> [identifier](#input\_identifier) | A name identifier to use as prefix for all the resources. | `string` | `""` | no |
 | <a name="input_memcached_cluster_address"></a> [memcached\_cluster\_address](#input\_memcached\_cluster\_address) | Address of the deployed memcached cluster | `any` | n/a | yes |
 | <a name="input_nlb_dns_name"></a> [nlb\_dns\_name](#input\_nlb\_dns\_name) | DNS address of the network load balancer | `any` | n/a | yes |

--- a/cloudprem/app/kubernetes.tf
+++ b/cloudprem/app/kubernetes.tf
@@ -138,6 +138,12 @@ resource "kubernetes_config_map" "dozuki_resources" {
 
     "rds-ca.pem" = file(local.is_us_gov ? "vendor/rds-ca-${data.aws_region.current.name}-2017-root.pem" : "vendor/rds-ca-2019-root.pem")
 
+    "google-translate.json" = <<-EOF
+      {
+        "apiToken": "${var.google_translate_api_token}"
+      }
+    EOF
+
   }
 
   lifecycle {

--- a/cloudprem/app/variables.tf
+++ b/cloudprem/app/variables.tf
@@ -92,3 +92,8 @@ variable "s3_pdfs_bucket" {
   type        = string
   default     = ""
 }
+variable "google_translate_api_token" {
+  description = "If using machine translation, enter your google translate API token here."
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
To support google machine translation in cloudprem we needed to add the supporting config values with the google translate api token. This adds that as well as the supporting variable for customers to add to their config.