### PR TITLE
Release v2.0 of Terraform CloudPrem Infra

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,10 @@ jobs:
           tag_name: ${{ github.ref }}
           release_name: Release ${{ github.ref }}
           body: |
-            Bastion Userdata Hotfix
-            - Fixed incorrect spacing in userdata file that prevented utilities from being installed and configured.
+            Major Module Refactor & Scaling
+            - Split Terraform code into 4 separate modules: Network, Compute, Storage, and App
+            - Using Terragrunt to manage configuration, dependencies, and state
+            - Added support for Cluster & Pod autoscaling in Kubernetes
+            - Fixed replicated app sequence targeting to unpin release after initial install
           draft: false
           prerelease: false


### PR DESCRIPTION
This is the changelog for v2.0. I opted for a major version increment as it's consistent with the semver standard. Nothing from v1.x is compatible with the current code so a major version bump is warranted.

Once this PR is approved and merged I will create and push the tag to create the release in GitHub.