### PR TITLE
RDS Parameter Fix

### DIFF
--- a/cloudprem/physical/README.md
+++ b/cloudprem/physical/README.md
@@ -45,7 +45,8 @@
 | [aws_cloudwatch_event_rule.aws_node_termination_handler_spot](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/resources/cloudwatch_event_rule) | resource |
 | [aws_cloudwatch_event_target.aws_node_termination_handler_asg](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/resources/cloudwatch_event_target) | resource |
 | [aws_cloudwatch_event_target.aws_node_termination_handler_spot](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/resources/cloudwatch_event_target) | resource |
-| [aws_db_parameter_group.this](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/resources/db_parameter_group) | resource |
+| [aws_db_parameter_group.bi](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/resources/db_parameter_group) | resource |
+| [aws_db_parameter_group.default](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/resources/db_parameter_group) | resource |
 | [aws_dms_certificate.this](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/resources/dms_certificate) | resource |
 | [aws_dms_endpoint.source](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/resources/dms_endpoint) | resource |
 | [aws_dms_endpoint.target](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/resources/dms_endpoint) | resource |

--- a/cloudprem/physical/main.tf
+++ b/cloudprem/physical/main.tf
@@ -28,7 +28,7 @@ locals {
   is_us_gov = data.aws_partition.current.partition == "aws-us-gov"
 
   # Database
-  rds_parameter_group_name = var.enable_bi ? aws_db_parameter_group.this[0].name : null
+  rds_parameter_group_name = var.enable_bi ? aws_db_parameter_group.bi[0].name : aws_db_parameter_group.default[0].name
   ca_cert_identifier       = local.is_us_gov ? "rds-ca-2017" : "rds-ca-2019"
 
   # S3 Buckets

--- a/cloudprem/physical/rds.tf
+++ b/cloudprem/physical/rds.tf
@@ -21,7 +21,7 @@ resource "random_password" "primary_database" {
   special = false
 }
 
-resource "aws_db_parameter_group" "this" {
+resource "aws_db_parameter_group" "bi" {
   count = var.enable_bi ? 1 : 0
 
   name_prefix = local.identifier
@@ -38,6 +38,22 @@ resource "aws_db_parameter_group" "this" {
   parameter {
     name  = "binlog_checksum"
     value = "NONE"
+  }
+  parameter {
+    name  = "group_concat_max_len"
+    value = "33554432"
+  }
+}
+
+resource "aws_db_parameter_group" "default" {
+  count = var.enable_bi ? 0 : 1
+
+  name_prefix = local.identifier
+  family      = "mysql8.0"
+
+  parameter {
+    name  = "group_concat_max_len"
+    value = "33554432"
   }
 }
 


### PR DESCRIPTION
This is a minor change to our parameter groups to add `group_concat_max_len` parameter to better match with our production cloud configuration. The lack of it was causing an issue with our customers data when migrating from production cloud as we use Persona in production and vanilla MySQL in private cloud. 

Signed-off-by: David Della Vecchia <ddv@dozuki.com>

Fixes https://github.com/iFixit/dozuki/issues/3108