### PR TITLE
Restore index.json app config file to maintain backwards compatibility

### DIFF
--- a/cloudprem/logical/kubernetes.tf
+++ b/cloudprem/logical/kubernetes.tf
@@ -124,6 +124,31 @@ resource "kubernetes_config_map" "dozuki_resources" {
       }
     EOF
 
+    "index.json" = <<-EOF
+      {
+        "index": {
+          "legacy": {
+            "filename": "legacy.json"
+          },
+          "s3": {
+            "filename": "s3.json"
+          },
+          "buckets": {
+            "filename": "buckets.json"
+          },
+          "db": {
+            "filename": "db.json"
+          },
+          "memcached": {
+            "filename": "memcached.json"
+          },
+          "aws-resources": {
+            "filename": "aws-resources.json"
+          }
+        }
+      }
+    EOF
+
   }
 
   lifecycle {


### PR DESCRIPTION
The `index.json` file was removed as a configuration dependency in newer versions of the application so we stopped creating it with the infra code but to support older versions of the app, especially during migrations, we need this file to exist. 


Signed-off-by: David Della Vecchia <ddv@dozuki.com>