### PR TITLE
Lock kubectl utility to known good version.

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -59,7 +59,7 @@ jobs:
         reporter: github-pr-review
         filter_mode: nofilter
         fail_on_error: true
-        tfsec_version: 1.15.4
+        tfsec_version: v1.15.4
         tfsec_flags: --exclude-downloaded-modules
 
 

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -59,6 +59,7 @@ jobs:
         reporter: github-pr-review
         filter_mode: nofilter
         fail_on_error: true
+        tfsec_version: 1.15.4
         tfsec_flags: --exclude-downloaded-modules
 
 

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -58,7 +58,6 @@ jobs:
         level: info
         reporter: github-pr-review
         filter_mode: nofilter
-        fail_on_error: true
         tfsec_version: v1.15.4
         tfsec_flags: --exclude-downloaded-modules
 

--- a/cloudprem/physical/static/bastion_userdata.yml
+++ b/cloudprem/physical/static/bastion_userdata.yml
@@ -28,7 +28,7 @@ write_files:
     #!/bin/bash -xe
     set -o xtrace
 
-    curl -L curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.23.6/bin/linux/amd64/kubectl \
+    curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.23.6/bin/linux/amd64/kubectl \
     > /usr/local/bin/kubectl
     chmod 755 /usr/local/bin/kubectl
 

--- a/cloudprem/physical/static/bastion_userdata.yml
+++ b/cloudprem/physical/static/bastion_userdata.yml
@@ -28,7 +28,7 @@ write_files:
     #!/bin/bash -xe
     set -o xtrace
 
-    curl -L https://storage.googleapis.com/kubernetes-release/release/`curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt`/bin/linux/amd64/kubectl \
+    curl -L curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.23.6/bin/linux/amd64/kubectl \
     > /usr/local/bin/kubectl
     chmod 755 /usr/local/bin/kubectl
 


### PR DESCRIPTION
The `kubectl` utility had an update that made it incompatible with the current available versions of EKS which ended up breaking our bastion's ability to access customer EKS instances. This change locks the `kubectl` version to a known good one instead of just always downloading the latest version.

Additionally I've done some fixing of the tfsec and reviewdog configuration in the GitHub action workflow to improve it's functionality and reliability.