### PR TITLE
BI Database VPN Access & VPN Module

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Setup Terraform
       uses: hashicorp/setup-terraform@v1
       with:
-        terraform_version: 1.0.11
+        terraform_version: 1.1.8
 
     - name: Terraform ${{ matrix.module }} Module Init
       run: terraform init

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -58,7 +58,7 @@ jobs:
         level: info
         reporter: github-pr-review
         filter_mode: nofilter
-        tfsec_version: v1.15.4
+        tfsec_version: v1.21.2
         tfsec_flags: --exclude-downloaded-modules
 
 

--- a/cloudprem/physical/README.md
+++ b/cloudprem/physical/README.md
@@ -23,19 +23,21 @@
 | <a name="module_bastion"></a> [bastion](#module\_bastion) | terraform-aws-modules/autoscaling/aws | 3.8.0 |
 | <a name="module_bastion_role"></a> [bastion\_role](#module\_bastion\_role) | terraform-aws-modules/iam/aws//modules/iam-assumable-role | 4.7.0 |
 | <a name="module_bastion_sg"></a> [bastion\_sg](#module\_bastion\_sg) | terraform-aws-modules/security-group/aws | 4.7.0 |
+| <a name="module_bi_database_sg"></a> [bi\_database\_sg](#module\_bi\_database\_sg) | terraform-aws-modules/security-group/aws | 4.7.0 |
 | <a name="module_cluster_access_role"></a> [cluster\_access\_role](#module\_cluster\_access\_role) | terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc | 4.7.0 |
 | <a name="module_cluster_access_role_assumable"></a> [cluster\_access\_role\_assumable](#module\_cluster\_access\_role\_assumable) | terraform-aws-modules/iam/aws//modules/iam-assumable-role | 4.7.0 |
 | <a name="module_cpu_alarm"></a> [cpu\_alarm](#module\_cpu\_alarm) | terraform-aws-modules/cloudwatch/aws//modules/metric-alarm | 2.1.0 |
-| <a name="module_database_sg"></a> [database\_sg](#module\_database\_sg) | terraform-aws-modules/security-group/aws | 4.7.0 |
 | <a name="module_eks_cluster"></a> [eks\_cluster](#module\_eks\_cluster) | terraform-aws-modules/eks/aws | 17.24.0 |
 | <a name="module_memory_alarm"></a> [memory\_alarm](#module\_memory\_alarm) | terraform-aws-modules/cloudwatch/aws//modules/metric-alarm | 2.1.0 |
 | <a name="module_nlb"></a> [nlb](#module\_nlb) | terraform-aws-modules/alb/aws | 6.6.1 |
 | <a name="module_nodes_alarm"></a> [nodes\_alarm](#module\_nodes\_alarm) | terraform-aws-modules/cloudwatch/aws//modules/metric-alarm | 2.1.0 |
 | <a name="module_primary_database"></a> [primary\_database](#module\_primary\_database) | terraform-aws-modules/rds/aws | 3.4.1 |
+| <a name="module_primary_database_sg"></a> [primary\_database\_sg](#module\_primary\_database\_sg) | terraform-aws-modules/security-group/aws | 4.7.0 |
 | <a name="module_replica_database"></a> [replica\_database](#module\_replica\_database) | terraform-aws-modules/rds/aws | 3.4.1 |
 | <a name="module_sns"></a> [sns](#module\_sns) | terraform-aws-modules/sns/aws | 2.1.0 |
 | <a name="module_status_alarm"></a> [status\_alarm](#module\_status\_alarm) | terraform-aws-modules/cloudwatch/aws//modules/metric-alarm | 2.1.0 |
-| <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | 3.11.0 |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | 3.14.1 |
+| <a name="module_vpn"></a> [vpn](#module\_vpn) | ./modules/vpn | n/a |
 
 ## Resources
 
@@ -75,9 +77,9 @@
 | [aws_s3_bucket_public_access_block.guide_pdfs_acl_block](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/resources/s3_bucket_public_access_block) | resource |
 | [aws_s3_bucket_public_access_block.logging_bucket_acl_block](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/resources/s3_bucket_public_access_block) | resource |
 | [aws_secretsmanager_secret.primary_database_credentials](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/resources/secretsmanager_secret) | resource |
-| [aws_secretsmanager_secret.replica_database](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/resources/secretsmanager_secret) | resource |
+| [aws_secretsmanager_secret.replica_database_credentials](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/resources/secretsmanager_secret) | resource |
 | [aws_secretsmanager_secret_version.primary_database_credentials](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/resources/secretsmanager_secret_version) | resource |
-| [aws_secretsmanager_secret_version.replica_database](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/resources/secretsmanager_secret_version) | resource |
+| [aws_secretsmanager_secret_version.replica_database_credentials](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/resources/secretsmanager_secret_version) | resource |
 | [aws_security_group.elasticache](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/resources/security_group) | resource |
 | [aws_security_group.kafka](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/resources/security_group) | resource |
 | [aws_security_group_rule.app_access_http](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/resources/security_group_rule) | resource |
@@ -121,8 +123,11 @@
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_app_access_cidr"></a> [app\_access\_cidr](#input\_app\_access\_cidr) | This CIDR will be allowed to connect to Dozuki. If running a public site, use the default value. Otherwise you probably want to lock this down to the VPC or your VPN CIDR. | `string` | `"0.0.0.0/0"` | no |
+| <a name="input_app_public_access"></a> [app\_public\_access](#input\_app\_public\_access) | Should the app and dashboard be accessible via a publicly routable IP and domain? | `bool` | `true` | no |
 | <a name="input_aws_profile"></a> [aws\_profile](#input\_aws\_profile) | If running terraform from a workstation, which AWS CLI profile should we use for asset provisioning. | `string` | `""` | no |
 | <a name="input_azs_count"></a> [azs\_count](#input\_azs\_count) | The number of availability zones we should use for deployment. | `number` | `3` | no |
+| <a name="input_bi_access_cidrs"></a> [bi\_access\_cidrs](#input\_bi\_access\_cidrs) | If BI is enabled, these CIDRs will be permitted through the firewall to access it. | `list(string)` | <pre>[<br>  "127.0.0.1/32"<br>]</pre> | no |
+| <a name="input_bi_vpn_access"></a> [bi\_vpn\_access](#input\_bi\_vpn\_access) | If BI is enabled we can create an OpenVPN connection to the BI database for secure internet access to the server. | `bool` | `false` | no |
 | <a name="input_create_s3_buckets"></a> [create\_s3\_buckets](#input\_create\_s3\_buckets) | Wheter to create the dozuki S3 buckets or not. | `bool` | `true` | no |
 | <a name="input_eks_desired_capacity"></a> [eks\_desired\_capacity](#input\_eks\_desired\_capacity) | This is what the node count will start out as. | `number` | `"3"` | no |
 | <a name="input_eks_instance_types"></a> [eks\_instance\_types](#input\_eks\_instance\_types) | The instance type of each node in the application's EKS worker node group. | `list(string)` | <pre>[<br>  "m5.large",<br>  "m5a.large",<br>  "m5d.large",<br>  "m5ad.large"<br>]</pre> | no |
@@ -138,7 +143,6 @@
 | <a name="input_highly_available_nat_gateway"></a> [highly\_available\_nat\_gateway](#input\_highly\_available\_nat\_gateway) | Should be true if you want to provision a highly available NAT Gateway across all of your private networks | `bool` | `true` | no |
 | <a name="input_identifier"></a> [identifier](#input\_identifier) | A name identifier to use as prefix for all the resources. | `string` | `""` | no |
 | <a name="input_protect_resources"></a> [protect\_resources](#input\_protect\_resources) | Specifies whether data protection settings are enabled. If true they will prevent stack deletion until protections have been manually disabled. | `bool` | `true` | no |
-| <a name="input_public_access"></a> [public\_access](#input\_public\_access) | Should the app and dashboard be accessible via a publicly routable IP and domain? | `bool` | `true` | no |
 | <a name="input_rds_allocated_storage"></a> [rds\_allocated\_storage](#input\_rds\_allocated\_storage) | The initial size of the database (Gb) | `number` | `100` | no |
 | <a name="input_rds_backup_retention_period"></a> [rds\_backup\_retention\_period](#input\_rds\_backup\_retention\_period) | The number of days to keep automatic database backups. Setting this value to 0 disables automatic backups. | `number` | `30` | no |
 | <a name="input_rds_instance_type"></a> [rds\_instance\_type](#input\_rds\_instance\_type) | The instance type to use for your database. See this page for a breakdown of the performance and cost differences between the different instance types: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.DBInstanceClass.html | `string` | `"db.m4.large"` | no |
@@ -161,6 +165,8 @@
 | Name | Description |
 |------|-------------|
 | <a name="output_azs_count"></a> [azs\_count](#output\_azs\_count) | n/a |
+| <a name="output_bi_database_credential_secret"></a> [bi\_database\_credential\_secret](#output\_bi\_database\_credential\_secret) | If BI is enabled, this is the ARN to the AWS SecretsManager secret that contains the connection information for the BI database. |
+| <a name="output_bi_vpn_configuration_bucket"></a> [bi\_vpn\_configuration\_bucket](#output\_bi\_vpn\_configuration\_bucket) | If BI is enabled, this is the S3 bucket that stores the OpenVPN configuration files for clients to connect to the BI database from the internet. |
 | <a name="output_cluster_primary_sg"></a> [cluster\_primary\_sg](#output\_cluster\_primary\_sg) | Primary security group for EKS cluster |
 | <a name="output_dms_task_arn"></a> [dms\_task\_arn](#output\_dms\_task\_arn) | DMS Replication Task ARN for BI |
 | <a name="output_documents_bucket"></a> [documents\_bucket](#output\_documents\_bucket) | n/a |

--- a/cloudprem/physical/main.tf
+++ b/cloudprem/physical/main.tf
@@ -47,6 +47,7 @@ locals {
   public_subnet_ids  = local.create_vpc ? module.vpc[0].public_subnets : data.aws_subnet_ids.public[0].ids
   private_subnet_ids = local.create_vpc ? module.vpc[0].private_subnets : data.aws_subnet_ids.private[0].ids
 
+  bi_access_cidrs = length(var.bi_access_cidrs) == 0 ? [var.vpc_cidr] : var.bi_access_cidrs
 }
 data "aws_eks_cluster" "main" {
   name = module.eks_cluster.cluster_id

--- a/cloudprem/physical/modules/vpn/acm_ca.tf
+++ b/cloudprem/physical/modules/vpn/acm_ca.tf
@@ -1,4 +1,3 @@
-# AWS ACM certificate CA
 resource "tls_private_key" "ca" {
   algorithm = "RSA"
 }
@@ -18,7 +17,6 @@ resource "tls_self_signed_cert" "ca" {
   ]
 }
 
-# AWS ACM certificate
 resource "aws_acm_certificate" "ca" {
   private_key      = tls_private_key.ca.private_key_pem
   certificate_body = tls_self_signed_cert.ca.cert_pem
@@ -32,14 +30,10 @@ resource "aws_ssm_parameter" "vpn_ca_key" {
   description = "VPN CA key"
   type        = "SecureString"
   value       = tls_private_key.ca.private_key_pem
-
-  #  tags = local.tags
 }
 resource "aws_ssm_parameter" "vpn_ca_cert" {
   name        = "${local.ssm_prefix}/acm/vpn/ca_cert"
   description = "VPN CA cert"
   type        = "SecureString"
   value       = tls_self_signed_cert.ca.cert_pem
-
-  #  tags = local.tags
 }

--- a/cloudprem/physical/modules/vpn/acm_ca.tf
+++ b/cloudprem/physical/modules/vpn/acm_ca.tf
@@ -1,0 +1,45 @@
+# AWS ACM certificate CA
+resource "tls_private_key" "ca" {
+  algorithm = "RSA"
+}
+resource "tls_self_signed_cert" "ca" {
+  key_algorithm   = "RSA"
+  private_key_pem = tls_private_key.ca.private_key_pem
+
+  subject {
+    common_name  = "${local.identifier}.${data.aws_region.current.name}.vpn.ca"
+    organization = local.identifier
+  }
+  validity_period_hours = 87600
+  is_ca_certificate     = true
+  allowed_uses = [
+    "cert_signing",
+    "crl_signing",
+  ]
+}
+
+# AWS ACM certificate
+resource "aws_acm_certificate" "ca" {
+  private_key      = tls_private_key.ca.private_key_pem
+  certificate_body = tls_self_signed_cert.ca.cert_pem
+
+  tags = local.tags
+}
+
+# AWS SSM records
+resource "aws_ssm_parameter" "vpn_ca_key" {
+  name        = "${local.ssm_prefix}/acm/vpn/ca_key"
+  description = "VPN CA key"
+  type        = "SecureString"
+  value       = tls_private_key.ca.private_key_pem
+
+  #  tags = local.tags
+}
+resource "aws_ssm_parameter" "vpn_ca_cert" {
+  name        = "${local.ssm_prefix}/acm/vpn/ca_cert"
+  description = "VPN CA cert"
+  type        = "SecureString"
+  value       = tls_self_signed_cert.ca.cert_pem
+
+  #  tags = local.tags
+}

--- a/cloudprem/physical/modules/vpn/acm_server.tf
+++ b/cloudprem/physical/modules/vpn/acm_server.tf
@@ -1,4 +1,3 @@
-# AWS ACM certificate
 resource "aws_acm_certificate" "server" {
   private_key       = tls_private_key.server.private_key_pem
   certificate_body  = tls_locally_signed_cert.server.cert_pem
@@ -7,7 +6,6 @@ resource "aws_acm_certificate" "server" {
   tags = local.tags
 }
 
-# TLS certificate and key
 resource "tls_private_key" "server" {
   algorithm = "RSA"
 }
@@ -32,20 +30,15 @@ resource "tls_locally_signed_cert" "server" {
   ]
 }
 
-# AWS SSM records
 resource "aws_ssm_parameter" "vpn_server_key" {
   name        = "${local.ssm_prefix}/acm/vpn/server_key"
   description = "VPN server key"
   type        = "SecureString"
   value       = tls_private_key.server.private_key_pem
-
-  #  tags = local.tags
 }
 resource "aws_ssm_parameter" "vpn_server_cert" {
   name        = "${local.ssm_prefix}/acm/vpn/server_cert"
   description = "VPN server cert"
   type        = "SecureString"
   value       = tls_locally_signed_cert.server.cert_pem
-
-  #  tags = local.tags
 }

--- a/cloudprem/physical/modules/vpn/acm_server.tf
+++ b/cloudprem/physical/modules/vpn/acm_server.tf
@@ -1,0 +1,51 @@
+# AWS ACM certificate
+resource "aws_acm_certificate" "server" {
+  private_key       = tls_private_key.server.private_key_pem
+  certificate_body  = tls_locally_signed_cert.server.cert_pem
+  certificate_chain = tls_self_signed_cert.ca.cert_pem
+
+  tags = local.tags
+}
+
+# TLS certificate and key
+resource "tls_private_key" "server" {
+  algorithm = "RSA"
+}
+resource "tls_cert_request" "server" {
+  key_algorithm   = "RSA"
+  private_key_pem = tls_private_key.server.private_key_pem
+  subject {
+    common_name  = "${local.identifier}.${data.aws_region.current.name}.vpn.server"
+    organization = local.identifier
+  }
+}
+resource "tls_locally_signed_cert" "server" {
+  cert_request_pem      = tls_cert_request.server.cert_request_pem
+  ca_key_algorithm      = "RSA"
+  ca_private_key_pem    = tls_private_key.ca.private_key_pem
+  ca_cert_pem           = tls_self_signed_cert.ca.cert_pem
+  validity_period_hours = 87600
+  allowed_uses = [
+    "key_encipherment",
+    "digital_signature",
+    "server_auth",
+  ]
+}
+
+# AWS SSM records
+resource "aws_ssm_parameter" "vpn_server_key" {
+  name        = "${local.ssm_prefix}/acm/vpn/server_key"
+  description = "VPN server key"
+  type        = "SecureString"
+  value       = tls_private_key.server.private_key_pem
+
+  #  tags = local.tags
+}
+resource "aws_ssm_parameter" "vpn_server_cert" {
+  name        = "${local.ssm_prefix}/acm/vpn/server_cert"
+  description = "VPN server cert"
+  type        = "SecureString"
+  value       = tls_locally_signed_cert.server.cert_pem
+
+  #  tags = local.tags
+}

--- a/cloudprem/physical/modules/vpn/config.tf
+++ b/cloudprem/physical/modules/vpn/config.tf
@@ -1,0 +1,117 @@
+# TLS certificate and key
+resource "tls_private_key" "client" {
+  count     = length(var.vpn-client-list)
+  algorithm = "RSA"
+}
+resource "tls_cert_request" "client" {
+  count           = length(var.vpn-client-list)
+  key_algorithm   = "RSA"
+  private_key_pem = tls_private_key.client[count.index].private_key_pem
+  subject {
+    common_name  = "${local.identifier}.${data.aws_region.current.name}.vpn.${var.vpn-client-list[count.index]}-client"
+    organization = local.identifier
+  }
+}
+resource "tls_locally_signed_cert" "client" {
+  count                 = length(var.vpn-client-list)
+  cert_request_pem      = tls_cert_request.client[count.index].cert_request_pem
+  ca_key_algorithm      = "RSA"
+  ca_private_key_pem    = tls_private_key.ca.private_key_pem
+  ca_cert_pem           = tls_self_signed_cert.ca.cert_pem
+  validity_period_hours = 87600
+  allowed_uses = [
+    "key_encipherment",
+    "digital_signature",
+    "client_auth",
+  ]
+}
+
+# AWS ACM certificate
+resource "aws_acm_certificate" "client" {
+  count             = length(var.vpn-client-list)
+  private_key       = tls_private_key.client[count.index].private_key_pem
+  certificate_body  = tls_locally_signed_cert.client[count.index].cert_pem
+  certificate_chain = tls_self_signed_cert.ca.cert_pem
+
+  tags = merge(
+    local.tags,
+    {
+      Tier         = "Private"
+      CostType     = "AlwaysCreated"
+      BackupPolicy = "n/a"
+    }
+  )
+}
+
+# AWS VPN config files generated to s3 bucket *.ovpn
+resource "aws_s3_bucket_object" "vpn-config-file" {
+  count                  = length(var.vpn-client-list)
+  bucket                 = aws_s3_bucket.vpn-config-files.id
+  server_side_encryption = "aws:kms"
+  key                    = "${var.vpn-client-list[count.index]}-vpn.ovpn"
+  content_base64 = base64encode(<<-EOT
+client
+dev tun
+proto udp
+remote ${aws_ec2_client_vpn_endpoint.vpn-client.id}.prod.clientvpn.${data.aws_region.current.name}.amazonaws.com 443
+remote-random-hostname
+resolv-retry infinite
+nobind
+remote-cert-tls server
+cipher AES-256-GCM
+--inactive 300 100
+verb 3
+
+<ca>
+${aws_ssm_parameter.vpn_ca_cert.value}
+</ca>
+
+reneg-sec 0
+
+<cert>
+${aws_ssm_parameter.vpn_client_cert[count.index].value}
+</cert>
+
+<key>
+${aws_ssm_parameter.vpn_client_key[count.index].value}
+</key>
+    EOT
+  )
+}
+
+# AWS SSM records
+resource "aws_ssm_parameter" "vpn_client_key" {
+  count       = length(var.vpn-client-list)
+  name        = "${local.ssm_prefix}/acm/vpn/${var.vpn-client-list[count.index]}_client_key"
+  description = "VPN ${var.vpn-client-list[count.index]} client key"
+  type        = "SecureString"
+  value       = tls_private_key.client[count.index].private_key_pem
+
+  #  tags = merge(
+  #    local.tags,
+  #    {
+  #      Name         = "VPN ${var.vpn-client-list[count.index]} client key imported in AWS ACM"
+  #      Tier         = "Private"
+  #      CostType     = "AlwaysCreated"
+  #      BackupPolicy = "n/a"
+  #    }
+  #  )
+}
+resource "aws_ssm_parameter" "vpn_client_cert" {
+  count       = length(var.vpn-client-list)
+  name        = "${local.ssm_prefix}/acm/vpn/${var.vpn-client-list[count.index]}_client_cert"
+  description = "VPN ${var.vpn-client-list[count.index]} client cert"
+  type        = "SecureString"
+  value       = tls_locally_signed_cert.client[count.index].cert_pem
+
+  #  tags = local.tags
+  #  tags = merge(
+  #    local.tags,
+  #    {
+  #      Name         = "VPN ${var.vpn-client-list[count.index]} client cert imported in AWS ACM"
+  #      Tier         = "Private"
+  #      CostType     = "AlwaysCreated"
+  #      BackupPolicy = "n/a"
+  #    }
+  #  )
+}

--- a/cloudprem/physical/modules/vpn/endpoint.tf
+++ b/cloudprem/physical/modules/vpn/endpoint.tf
@@ -1,0 +1,40 @@
+# AWS vpn client endpoint
+resource "aws_ec2_client_vpn_endpoint" "vpn-client" {
+  description            = "${local.identifier}-vpn-client"
+  server_certificate_arn = aws_acm_certificate.server.arn
+  #  vpc_id                 = var.vpc_id
+  #  security_group_ids     = [aws_security_group.vpn.id]
+  client_cidr_block = var.client_cidr_block
+  #  session_timeout_hours  = var.session_timeout_hours
+
+  split_tunnel = true
+  authentication_options {
+    type                       = "certificate-authentication"
+    root_certificate_chain_arn = aws_acm_certificate.client[0].arn
+  }
+  connection_log_options {
+    enabled               = true
+    cloudwatch_log_group  = aws_cloudwatch_log_group.vpn-logs.name
+    cloudwatch_log_stream = aws_cloudwatch_log_stream.vpn-logs-stream.name
+  }
+  tags = merge(
+    local.tags,
+    {
+      Name = "${local.identifier}-vpn-client"
+    }
+  )
+}
+resource "aws_ec2_client_vpn_network_association" "vpn-client" {
+  client_vpn_endpoint_id = aws_ec2_client_vpn_endpoint.vpn-client.id
+  subnet_id              = var.subnet_id
+  security_groups        = [aws_security_group.vpn.id]
+}
+resource "aws_ec2_client_vpn_authorization_rule" "vpn-client" {
+  client_vpn_endpoint_id = aws_ec2_client_vpn_endpoint.vpn-client.id
+  target_network_cidr    = "0.0.0.0/0"
+  authorize_all_groups   = true
+  depends_on = [
+    aws_ec2_client_vpn_endpoint.vpn-client,
+    aws_ec2_client_vpn_network_association.vpn-client
+  ]
+}

--- a/cloudprem/physical/modules/vpn/endpoint.tf
+++ b/cloudprem/physical/modules/vpn/endpoint.tf
@@ -1,11 +1,7 @@
-# AWS vpn client endpoint
 resource "aws_ec2_client_vpn_endpoint" "vpn-client" {
   description            = "${local.identifier}-vpn-client"
   server_certificate_arn = aws_acm_certificate.server.arn
-  #  vpc_id                 = var.vpc_id
-  #  security_group_ids     = [aws_security_group.vpn.id]
-  client_cidr_block = var.client_cidr_block
-  #  session_timeout_hours  = var.session_timeout_hours
+  client_cidr_block      = var.client_cidr_block
 
   split_tunnel = true
   authentication_options {

--- a/cloudprem/physical/modules/vpn/logs.tf
+++ b/cloudprem/physical/modules/vpn/logs.tf
@@ -1,0 +1,37 @@
+# AWS cloudwatch log group
+data "aws_iam_policy_document" "vpn-logs-kms" {
+  statement {
+    sid    = "Enable IAM User Permissions"
+    effect = "Allow"
+    principals {
+      identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
+      type        = "AWS"
+    }
+    actions   = ["kms:*"]
+    resources = ["*"]
+  }
+  statement {
+    effect = "Allow"
+    principals {
+      identifiers = ["logs.${data.aws_region.current.name}.amazonaws.com"]
+      type        = "Service"
+    }
+    actions   = ["kms:*"]
+    resources = ["*"]
+  }
+}
+resource "aws_kms_key" "vpn-logs" {
+  description         = "VPN Log Secret Encryption Key"
+  enable_key_rotation = true
+
+  policy = data.aws_iam_policy_document.vpn-logs-kms.json
+}
+resource "aws_cloudwatch_log_group" "vpn-logs" {
+  name              = "${local.identifier}-vpn/logs/"
+  retention_in_days = 30
+  kms_key_id        = aws_kms_key.vpn-logs.arn
+}
+resource "aws_cloudwatch_log_stream" "vpn-logs-stream" {
+  name           = "connection_logs"
+  log_group_name = aws_cloudwatch_log_group.vpn-logs.name
+}

--- a/cloudprem/physical/modules/vpn/logs.tf
+++ b/cloudprem/physical/modules/vpn/logs.tf
@@ -1,4 +1,3 @@
-# AWS cloudwatch log group
 data "aws_iam_policy_document" "vpn-logs-kms" {
   statement {
     sid    = "Enable IAM User Permissions"

--- a/cloudprem/physical/modules/vpn/main.tf
+++ b/cloudprem/physical/modules/vpn/main.tf
@@ -1,0 +1,32 @@
+terraform {
+  required_version = ">= 1.1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "3.70.0"
+    }
+    tls = {
+      source  = "hashicorp/tls"
+      version = "3.1.0"
+    }
+  }
+}
+
+
+locals {
+  identifier = var.identifier == "" ? "dozuki-${var.environment}" : "${var.identifier}-dozuki-${var.environment}"
+
+  ssm_prefix = "/dozuki/${local.identifier}/${data.aws_region.current.name}"
+
+  tags = {
+    Terraform   = "true"
+    Project     = "Dozuki"
+    Identifier  = var.identifier
+    Environment = var.environment
+  }
+}
+
+data "aws_region" "current" {}
+data "aws_partition" "current" {}
+data "aws_caller_identity" "current" {}

--- a/cloudprem/physical/modules/vpn/outputs.tf
+++ b/cloudprem/physical/modules/vpn/outputs.tf
@@ -1,0 +1,9 @@
+output "aws_ec2_client_vpn_endpoint" {
+  value = aws_ec2_client_vpn_endpoint.vpn-client
+}
+output "aws_vpn_security_group" {
+  value = aws_security_group.vpn
+}
+output "aws_vpn_configuration_bucket" {
+  value = aws_s3_bucket.vpn-config-files.bucket
+}

--- a/cloudprem/physical/modules/vpn/s3.tf
+++ b/cloudprem/physical/modules/vpn/s3.tf
@@ -1,4 +1,3 @@
-# AWS S3 bucket for VPN config files
 #tfsec:ignore:aws-s3-enable-bucket-logging
 resource "aws_s3_bucket" "vpn-config-files" {
   bucket        = "${local.identifier}-${data.aws_region.current.name}-vpn-credentials"

--- a/cloudprem/physical/modules/vpn/s3.tf
+++ b/cloudprem/physical/modules/vpn/s3.tf
@@ -1,0 +1,55 @@
+# AWS S3 bucket for VPN config files
+#tfsec:ignore:aws-s3-enable-bucket-logging
+resource "aws_s3_bucket" "vpn-config-files" {
+  bucket        = "${local.identifier}-${data.aws_region.current.name}-vpn-credentials"
+  force_destroy = true
+
+  versioning {
+    enabled = true
+  }
+
+  server_side_encryption_configuration {
+
+    rule {
+      bucket_key_enabled = true
+      apply_server_side_encryption_by_default {
+        kms_master_key_id = var.s3_kms_key_id
+        sse_algorithm     = "aws:kms"
+      }
+    }
+
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "vpn-config-files" {
+  bucket                  = aws_s3_bucket.vpn-config-files.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_policy" "vpn-config-files" {
+  bucket = aws_s3_bucket.vpn-config-files.id
+  policy = data.aws_iam_policy_document.vpn-config-files.json
+}
+
+data "aws_iam_policy_document" "vpn-config-files" {
+  statement {
+    actions = ["s3:*"]
+    effect  = "Deny"
+    resources = [
+      "arn:${data.aws_partition.current.partition}:s3:::${local.identifier}-${data.aws_region.current.name}-vpn-credentials",
+      "arn:${data.aws_partition.current.partition}:s3:::${local.identifier}-${data.aws_region.current.name}-vpn-credentials/*"
+    ]
+    condition {
+      test     = "Bool"
+      variable = "aws:SecureTransport"
+      values   = ["false"]
+    }
+    principals {
+      type        = "*"
+      identifiers = ["*"]
+    }
+  }
+}

--- a/cloudprem/physical/modules/vpn/sg.tf
+++ b/cloudprem/physical/modules/vpn/sg.tf
@@ -1,4 +1,3 @@
-# AWS security group
 #tfsec:ignore:aws-vpc-no-public-egress-sgr
 resource "aws_security_group" "vpn" {
   name        = "${local.identifier}-vpn-security-group"

--- a/cloudprem/physical/modules/vpn/sg.tf
+++ b/cloudprem/physical/modules/vpn/sg.tf
@@ -1,0 +1,28 @@
+# AWS security group
+#tfsec:ignore:aws-vpc-no-public-egress-sgr
+resource "aws_security_group" "vpn" {
+  name        = "${local.identifier}-vpn-security-group"
+  description = "Allows access to connect to the VPN and unlimited egress."
+
+  vpc_id = var.vpc_id
+  ingress {
+    description = "Allow VPN connection from specified CIDRs"
+    from_port   = 443
+    to_port     = 443
+    protocol    = "udp"
+    cidr_blocks = var.allowed_ingress_cidrs
+  }
+  egress {
+    description = "Allow egress to internet"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+  tags = merge(
+    local.tags,
+    {
+      Name = "${local.identifier}-vpn-security-group"
+    }
+  )
+}

--- a/cloudprem/physical/modules/vpn/variables.tf
+++ b/cloudprem/physical/modules/vpn/variables.tf
@@ -1,0 +1,65 @@
+variable "identifier" {
+  description = "A name identifier to use as prefix for all the resources."
+  type        = string
+
+  validation {
+    condition     = length(var.identifier) <= 10
+    error_message = "The length of the identifier must be less than 11 characters."
+  }
+}
+
+variable "environment" {
+  description = "Environment of the application"
+  type        = string
+
+  validation {
+    condition     = length(var.environment) <= 5
+    error_message = "The length of the Environment must be less than 6 characters."
+  }
+}
+variable "vpn-client-list" {
+  description = "List of VPN Users"
+  type        = list(string)
+}
+variable "session_timeout_hours" {
+  description = "Session timeout hours"
+  type        = number
+  default     = 8
+}
+variable "vpc_id" {
+  description = "The VPC ID where we'll be deploying our resources. (If creating a new VPC leave this field and subnets blank). When using an existing VPC be sure to tag at least 2 subnets with type = public and another 2 with tag type = private"
+  type        = string
+}
+variable "vpc_cidr" {
+  description = "The CIDR block for the VPC"
+  type        = string
+  default     = "172.16.0.0/16"
+}
+variable "azs_count" {
+  description = "The number of availability zones we should use for deployment."
+  type        = number
+  default     = 3
+
+  validation {
+    condition     = var.azs_count >= 3 && var.azs_count <= 10
+    error_message = "AZ count must be between 3 and 10."
+  }
+}
+variable "client_cidr_block" {
+  description = "AWS VPN client cidr block"
+  type        = string
+  default     = "172.0.0.0/22"
+}
+variable "subnet_id" {
+  description = "Subnet for client vpn network association"
+  type        = string
+}
+variable "allowed_ingress_cidrs" {
+  description = "Allowed CIDRs for VPN connections"
+  type        = list(string)
+}
+variable "s3_kms_key_id" {
+  description = "AWS KMS key identifier for S3 encryption. The identifier can be one of the following format: Key id, key ARN, alias name or alias ARN"
+  type        = string
+  default     = "alias/aws/s3"
+}

--- a/cloudprem/physical/nlb.tf
+++ b/cloudprem/physical/nlb.tf
@@ -36,7 +36,7 @@ module "nlb" {
   name = local.identifier
 
   load_balancer_type = "network"
-  internal           = !var.public_access
+  internal           = !var.app_public_access
 
   vpc_id  = local.vpc_id
   subnets = local.public_subnet_ids

--- a/cloudprem/physical/outputs.tf
+++ b/cloudprem/physical/outputs.tf
@@ -68,3 +68,12 @@ output "dms_task_arn" {
   description = "DMS Replication Task ARN for BI"
   value       = try(aws_dms_replication_task.this[0].replication_task_arn, "")
 }
+output "bi_database_credential_secret" {
+  description = "If BI is enabled, this is the ARN to the AWS SecretsManager secret that contains the connection information for the BI database."
+  value       = try(aws_secretsmanager_secret.replica_database_credentials[0].arn, "")
+}
+
+output "bi_vpn_configuration_bucket" {
+  description = "If BI is enabled, this is the S3 bucket that stores the OpenVPN configuration files for clients to connect to the BI database from the internet."
+  value       = try(module.vpn[0].aws_vpn_configuration_bucket, "")
+}

--- a/cloudprem/physical/s3.tf
+++ b/cloudprem/physical/s3.tf
@@ -35,7 +35,7 @@ resource "aws_s3_bucket_public_access_block" "logging_bucket_acl_block" {
 resource "aws_s3_bucket" "logging_bucket" {
   count = var.create_s3_buckets ? 1 : 0
 
-  bucket_prefix = "dozuki-bucket-access-logs"
+  bucket        = "dozuki-bucket-access-logs-${local.identifier}-${data.aws_region.current.name}"
   acl           = "private"
   force_destroy = !var.protect_resources
 
@@ -68,7 +68,7 @@ resource "aws_s3_bucket_public_access_block" "guide_images_acl_block" {
 resource "aws_s3_bucket" "guide_images" {
   count = var.create_s3_buckets ? 1 : 0
 
-  bucket_prefix = "dozuki-guide-images"
+  bucket        = "dozuki-guide-images-${local.identifier}-${data.aws_region.current.name}"
   acl           = "private"
   force_destroy = !var.protect_resources
 
@@ -106,7 +106,7 @@ resource "aws_s3_bucket_public_access_block" "guide_objects_acl_block" {
 resource "aws_s3_bucket" "guide_objects" {
   count = var.create_s3_buckets ? 1 : 0
 
-  bucket_prefix = "dozuki-guide-objects"
+  bucket        = "dozuki-guide-objects-${local.identifier}-${data.aws_region.current.name}"
   acl           = "private"
   force_destroy = !var.protect_resources
 
@@ -144,7 +144,7 @@ resource "aws_s3_bucket_public_access_block" "guide_pdfs_acl_block" {
 resource "aws_s3_bucket" "guide_pdfs" {
   count = var.create_s3_buckets ? 1 : 0
 
-  bucket_prefix = "dozuki-guide-pdfs"
+  bucket        = "dozuki-guide-pdfs-${local.identifier}-${data.aws_region.current.name}"
   acl           = "private"
   force_destroy = !var.protect_resources
 
@@ -182,7 +182,7 @@ resource "aws_s3_bucket_public_access_block" "guide_documents_acl_block" {
 resource "aws_s3_bucket" "guide_documents" {
   count = var.create_s3_buckets ? 1 : 0
 
-  bucket_prefix = "dozuki-guide-documents"
+  bucket        = "dozuki-guide-documents-${local.identifier}-${data.aws_region.current.name}"
   acl           = "private"
   force_destroy = !var.protect_resources
 

--- a/cloudprem/physical/static/bastion_userdata.yml
+++ b/cloudprem/physical/static/bastion_userdata.yml
@@ -28,9 +28,14 @@ write_files:
     #!/bin/bash -xe
     set -o xtrace
 
-    curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.23.6/bin/linux/amd64/kubectl \
+    curl -L https://storage.googleapis.com/kubernetes-release/release/v1.23.6/bin/linux/amd64/kubectl \
     > /usr/local/bin/kubectl
     chmod 755 /usr/local/bin/kubectl
+    
+    curl -L https://get.helm.sh/helm-v3.8.1-linux-amd64.tar.gz > /tmp/helm.tar.gz
+    tar -xzvf /tmp/helm.tar.gz
+    cp /tmp/linux-amd64/helm /usr/local/bin/helm
+    chmod 755 /usr/local/bin/helm
 
     mkdir -p /home/ssm-user/.kube
 

--- a/cloudprem/physical/util/dms-stop.sh
+++ b/cloudprem/physical/util/dms-stop.sh
@@ -32,6 +32,9 @@ function waitforStoppedDMS() {
     STATUS=$(getDMSStatus)
   done
 
+  # Sleep to make sure the DMS task is reported as stopped to the next terraform destroy step which is destroying the task itself.
+  sleep 300
+
   echo -e "DMS Task Stopped Successfully."
 }
 

--- a/cloudprem/physical/variables.tf
+++ b/cloudprem/physical/variables.tf
@@ -145,7 +145,17 @@ variable "enable_bi" {
   type        = bool
   default     = false
 }
-variable "public_access" {
+variable "bi_vpn_access" {
+  description = "If BI is enabled we can create an OpenVPN connection to the BI database for secure internet access to the server."
+  type        = bool
+  default     = false
+}
+variable "bi_access_cidrs" {
+  description = "If BI is enabled, these CIDRs will be permitted through the firewall to access it."
+  type        = list(string)
+  default     = ["127.0.0.1/32"]
+}
+variable "app_public_access" {
   description = "Should the app and dashboard be accessible via a publicly routable IP and domain?"
   type        = bool
   default     = true

--- a/cloudprem/physical/vpc.tf
+++ b/cloudprem/physical/vpc.tf
@@ -1,6 +1,6 @@
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
-  version = "3.11.0"
+  version = "3.14.1"
 
   count = local.create_vpc ? 1 : 0
 
@@ -12,6 +12,7 @@ module "vpc" {
   single_nat_gateway   = !var.highly_available_nat_gateway
   enable_dns_hostnames = true
   enable_dns_support   = true
+  enable_vpn_gateway   = var.bi_vpn_access
 
   # VPC Flow Logs (Cloudwatch log group and IAM role will be created)
   enable_flow_log                      = true
@@ -36,4 +37,18 @@ module "vpc" {
   }
 
   tags = local.tags
+}
+module "vpn" {
+  source = "./modules/vpn"
+
+  count = var.bi_vpn_access ? 1 : 0
+
+  environment = var.environment
+  identifier  = var.identifier
+  vpc_id      = local.vpc_id
+
+  subnet_id       = local.private_subnet_ids[0]
+  vpn-client-list = ["root"]
+
+  allowed_ingress_cidrs = local.bi_access_cidrs
 }

--- a/live/gov/us-gov-west-1/bi/env.hcl
+++ b/live/gov/us-gov-west-1/bi/env.hcl
@@ -8,4 +8,6 @@ locals {
   highly_available_nat_gateway = false
   dozuki_license_parameter_name = "/dozuki/workstation/beta/license"
   protect_resources = false
+  bi_access_cidrs = ["0.0.0.0/0"]
+  bi_vpn_access = false
 }

--- a/live/standard/eu-central-1/bi/env.hcl
+++ b/live/standard/eu-central-1/bi/env.hcl
@@ -8,4 +8,6 @@ locals {
   highly_available_nat_gateway = false
   dozuki_license_parameter_name = "/dozuki/workstation/beta/license"
   protect_resources = false
+  bi_access_cidrs = ["0.0.0.0/0"]
+  bi_vpn_access = false
 }

--- a/live/standard/eu-west-1/bi/env.hcl
+++ b/live/standard/eu-west-1/bi/env.hcl
@@ -8,4 +8,6 @@ locals {
   highly_available_nat_gateway = false
   dozuki_license_parameter_name = "/dozuki/workstation/beta/license"
   protect_resources = false
+  bi_access_cidrs = ["0.0.0.0/0"]
+  bi_vpn_access = false
 }

--- a/live/standard/eu-west-2/bi/env.hcl
+++ b/live/standard/eu-west-2/bi/env.hcl
@@ -8,4 +8,6 @@ locals {
   highly_available_nat_gateway = false
   dozuki_license_parameter_name = "/dozuki/workstation/beta/license"
   protect_resources = false
+  bi_access_cidrs = ["0.0.0.0/0"]
+  bi_vpn_access = false
 }

--- a/live/standard/eu-west-3/bi/env.hcl
+++ b/live/standard/eu-west-3/bi/env.hcl
@@ -8,4 +8,6 @@ locals {
   highly_available_nat_gateway = false
   dozuki_license_parameter_name = "/dozuki/workstation/beta/license"
   protect_resources = false
+  bi_access_cidrs = ["0.0.0.0/0"]
+  bi_vpn_access = false
 }

--- a/live/standard/us-east-1/bi/env.hcl
+++ b/live/standard/us-east-1/bi/env.hcl
@@ -8,4 +8,6 @@ locals {
   highly_available_nat_gateway = false
   dozuki_license_parameter_name = "/dozuki/workstation/beta/license"
   protect_resources = false
+  bi_access_cidrs = ["0.0.0.0/0"]
+  bi_vpn_access = true
 }

--- a/live/standard/us-east-2/bi/env.hcl
+++ b/live/standard/us-east-2/bi/env.hcl
@@ -8,4 +8,6 @@ locals {
   highly_available_nat_gateway = false
   dozuki_license_parameter_name = "/dozuki/workstation/beta/license"
   protect_resources = false
+  bi_access_cidrs = ["0.0.0.0/0"]
+  bi_vpn_access = false
 }

--- a/live/standard/us-west-2/bi/env.hcl
+++ b/live/standard/us-west-2/bi/env.hcl
@@ -8,4 +8,6 @@ locals {
   highly_available_nat_gateway = false
   dozuki_license_parameter_name = "/dozuki/workstation/beta/license"
   protect_resources = false
+  bi_access_cidrs = ["0.0.0.0/0"]
+  bi_vpn_access = false
 }


### PR DESCRIPTION
# Background
Customers will likely need access to their BI database from outside the AWS network. Our existing configuration relies on their account having an existing transit gateway managed outside the terraform. 

# Solution
We will now conditionally provision a VPN endpoint to the VPC which will allow access to authenticated users. The VPN configuration is such that only the BI database will be accessible from within the VPN and the user may configure which CIDRs they want to allow to connect to the VPN. Our VPN uses mutual authentication which relies on 2048 bit RSA self-signed TLS certificates. We generate and upload the certificates embedded in an OpenVPN configuration file to a secure S3 bucket for distribution. The bucket name and BI Database secret containing the connection information is output after the successful application of the physical module.

# QA
To test this change, download the `bi-vpn` branch, navigate to a `bi` testing environment folder in your account and region of choice, be sure the `bi_vpn_access` variable is set to `true` and the `bi_access_cidrs` variable is set to a cidr you can connect from and then apply the stack as usual. 

Once application is complete you can query the outputs for the physical module, grab the `bi_database_credential_secret` and `bi_vpn_configuration_bucket` values. The secret contains the mysql endpoint and credentials for the bi database and the configuration bucket contains the OpenVPN configuration file. Download that file to your workstation and load it into your VPN program of choice and connect. Once successfully connected you should be able to make a MySQL connection to the BI database using the credentials in the secret.

# Notable Changes
Along with the main VPN additions there are some other minor fixes as well including the following:

1. Complete S3 bucket names
   * We no longer use generic bucket prefixes, we will use the identifier and region to name the buckets something that can be easily found in the S3 dashboard
2. DMS stop script race condition mitigation
   * There seems to be some lag in the API between when a DMS task is stopped vs when it's actually reported as stopped in subsequent API calls so I added a 5 minute sleep to the end of the script to give the API time to update. This seems to have fixed this issue in my tests.
3. Bastion broken Curl & Helm Install
   * kubectl install has been broken so I fixed that. I also added helm install since that is a helpful utility to have available for debugging.
4. Tighter security for databases
   * To facilitate secure VPN usage I tightened up the security groups for the databases. We now only allow access to what's necessary instead of just allowing the entire VPC. 