### PR TITLE
Refactor logical terragrunt config

### DIFF
--- a/cloudprem/logical/README.md
+++ b/cloudprem/logical/README.md
@@ -15,7 +15,6 @@
 | <a name="provider_aws"></a> [aws](#provider\_aws) | 3.70.0 |
 | <a name="provider_helm"></a> [helm](#provider\_helm) | 2.3.0 |
 | <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | 2.4.1 |
-| <a name="provider_local"></a> [local](#provider\_local) | 2.1.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | 3.1.0 |
 
 ## Modules
@@ -43,17 +42,6 @@ No modules.
 | [kubernetes_job.database_update](https://registry.terraform.io/providers/hashicorp/kubernetes/2.4.1/docs/resources/job) | resource |
 | [kubernetes_job.dms_start](https://registry.terraform.io/providers/hashicorp/kubernetes/2.4.1/docs/resources/job) | resource |
 | [kubernetes_job.replicated_sequence_reset](https://registry.terraform.io/providers/hashicorp/kubernetes/2.4.1/docs/resources/job) | resource |
-| [local_file.api_helmignore](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/file) | resource |
-| [local_file.aws_node_termination_handler_helmignore](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/file) | resource |
-| [local_file.cluster_autoscaler_helmignore](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/file) | resource |
-| [local_file.connectors_helmignore](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/file) | resource |
-| [local_file.default_helmignore](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/file) | resource |
-| [local_file.event_helmignore](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/file) | resource |
-| [local_file.integrations_helmignore](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/file) | resource |
-| [local_file.metrics_server_helmignore](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/file) | resource |
-| [local_file.mongodb_helmignore](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/file) | resource |
-| [local_file.redis_helmignore](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/file) | resource |
-| [local_file.webhook_helmignore](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/file) | resource |
 | [random_password.dashboard_password](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/data-sources/caller_identity) | data source |
 | [aws_eks_cluster.main](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/data-sources/eks_cluster) | data source |

--- a/cloudprem/logical/scaling.tf
+++ b/cloudprem/logical/scaling.tf
@@ -1,7 +1,5 @@
 
 resource "helm_release" "cluster_autoscaler" {
-  depends_on = [local_file.cluster_autoscaler_helmignore]
-
   name      = "cluster-autoscaler"
   chart     = "charts/cluster-autoscaler"
   namespace = "kube-system"
@@ -25,8 +23,6 @@ resource "helm_release" "cluster_autoscaler" {
 }
 
 resource "helm_release" "metrics_server" {
-  depends_on = [local_file.metrics_server_helmignore]
-
   name  = "metrics-server"
   chart = "charts/metrics-server"
 }
@@ -116,15 +112,4 @@ resource "kubernetes_horizontal_pod_autoscaler" "queueworkerd" {
       }
     }
   }
-}
-
-resource "local_file" "cluster_autoscaler_helmignore" {
-  content         = file("${path.module}/charts/helmignore")
-  filename        = "${path.module}/charts/cluster-autoscaler/.helmignore"
-  file_permission = "0644"
-}
-resource "local_file" "metrics_server_helmignore" {
-  content         = file("${path.module}/charts/helmignore")
-  filename        = "${path.module}/charts/metrics-server/.helmignore"
-  file_permission = "0644"
 }

--- a/cloudprem/logical/termination.tf
+++ b/cloudprem/logical/termination.tf
@@ -1,8 +1,6 @@
 
 
 resource "helm_release" "aws_node_termination_handler" {
-  depends_on = [local_file.aws_node_termination_handler_helmignore]
-
   name             = "aws-node-termination-handler"
   namespace        = "kube-system"
   chart            = "charts/aws-node-termination-handler"
@@ -49,10 +47,4 @@ resource "aws_autoscaling_lifecycle_hook" "aws_node_termination_handler" {
   lifecycle_transition   = "autoscaling:EC2_INSTANCE_TERMINATING"
   heartbeat_timeout      = 300
   default_result         = "CONTINUE"
-}
-
-resource "local_file" "aws_node_termination_handler_helmignore" {
-  content         = file("${path.module}/charts/helmignore")
-  filename        = "${path.module}/charts/aws-node-termination-handler/.helmignore"
-  file_permission = "0644"
 }

--- a/cloudprem/logical/webhooks.tf
+++ b/cloudprem/logical/webhooks.tf
@@ -12,8 +12,6 @@ data "kubernetes_secret" "frontegg" {
 resource "kubernetes_job" "database_update" {
   count = var.enable_webhooks ? 1 : 0
 
-  depends_on = [helm_release.replicated]
-
   metadata {
     name = "frontegg-db-update"
   }
@@ -44,8 +42,6 @@ resource "kubernetes_job" "database_update" {
 resource "helm_release" "mongodb" {
   count = var.enable_webhooks ? 1 : 0
 
-  depends_on = [local_file.mongodb_helmignore]
-
   name  = "frontegg-documents"
   chart = "charts/mongodb"
 
@@ -57,8 +53,6 @@ resource "helm_release" "mongodb" {
 
 resource "helm_release" "redis" {
   count = var.enable_webhooks ? 1 : 0
-
-  depends_on = [local_file.redis_helmignore]
 
   name  = "frontegg-kvstore"
   chart = "charts/redis"
@@ -82,10 +76,6 @@ resource "helm_release" "frontegg" {
   count = var.enable_webhooks ? 1 : 0
 
   depends_on = [
-    local_file.default_helmignore,
-    local_file.api_helmignore,
-    local_file.event_helmignore,
-    local_file.webhook_helmignore,
     helm_release.mongodb,
     helm_release.redis,
     kubernetes_job.database_update
@@ -168,61 +158,4 @@ resource "helm_release" "frontegg" {
     value = local.db_master_password
   }
 
-}
-# Necessary hackery to prevent generated terraform/terragrunt files from being included by helm and blowing up the deploy.
-resource "local_file" "default_helmignore" {
-  count = var.enable_webhooks ? 1 : 0
-
-  content         = file("${path.module}/charts/helmignore")
-  filename        = "${path.module}/charts/connectivity/.helmignore"
-  file_permission = "0644"
-}
-resource "local_file" "event_helmignore" {
-  count = var.enable_webhooks ? 1 : 0
-
-  content         = file("${path.module}/charts/helmignore")
-  filename        = "${path.module}/charts/connectivity/charts/event-service/.helmignore"
-  file_permission = "0644"
-}
-resource "local_file" "api_helmignore" {
-  count = var.enable_webhooks ? 1 : 0
-
-  content         = file("${path.module}/charts/helmignore")
-  filename        = "${path.module}/charts/connectivity/charts/api-gateway/.helmignore"
-  file_permission = "0644"
-}
-resource "local_file" "webhook_helmignore" {
-  count = var.enable_webhooks ? 1 : 0
-
-  content         = file("${path.module}/charts/helmignore")
-  filename        = "${path.module}/charts/connectivity/charts/webhook-service/.helmignore"
-  file_permission = "0644"
-}
-resource "local_file" "connectors_helmignore" {
-  count = var.enable_webhooks ? 1 : 0
-
-  content         = file("${path.module}/charts/helmignore")
-  filename        = "${path.module}/charts/connectivity/charts/connectors-worker/.helmignore"
-  file_permission = "0644"
-}
-resource "local_file" "integrations_helmignore" {
-  count = var.enable_webhooks ? 1 : 0
-
-  content         = file("${path.module}/charts/helmignore")
-  filename        = "${path.module}/charts/connectivity/charts/integrations-service/.helmignore"
-  file_permission = "0644"
-}
-resource "local_file" "mongodb_helmignore" {
-  count = var.enable_webhooks ? 1 : 0
-
-  content         = file("${path.module}/charts/helmignore")
-  filename        = "${path.module}/charts/mongodb/.helmignore"
-  file_permission = "0644"
-}
-resource "local_file" "redis_helmignore" {
-  count = var.enable_webhooks ? 1 : 0
-
-  content         = file("${path.module}/charts/helmignore")
-  filename        = "${path.module}/charts/redis/.helmignore"
-  file_permission = "0644"
 }

--- a/live/common.hcl
+++ b/live/common.hcl
@@ -1,0 +1,134 @@
+locals {
+  helmignore = <<EOF
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/
+.terragrunt-source-manifest
+.terragrunt-source-manifest/
+  EOF
+}
+
+generate "webhooks_default_helmignore" {
+  path      = "charts/connectivity/.helmignore"
+  if_exists = "overwrite_terragrunt"
+  contents  = local.helmignore
+}
+generate "webhooks_event_helmignore" {
+  path      = "charts/connectivity/charts/event-service/.helmignore"
+  if_exists = "overwrite_terragrunt"
+  contents  = local.helmignore
+}
+generate "webhooks_api_helmignore" {
+  path      = "charts/connectivity/charts/api-gateway/.helmignore"
+  if_exists = "overwrite_terragrunt"
+  contents  = local.helmignore
+}
+generate "webhooks_webhook_helmignore" {
+  path      = "charts/connectivity/charts/webhook-service/.helmignore"
+  if_exists = "overwrite_terragrunt"
+  contents  = local.helmignore
+}
+generate "webhooks_connectors_helmignore" {
+  path      = "charts/connectivity/charts/connectors-worker/.helmignore"
+  if_exists = "overwrite_terragrunt"
+  contents  = local.helmignore
+}
+generate "webhooks_integrations_helmignore" {
+  path      = "charts/connectivity/charts/integrations-service/.helmignore"
+  if_exists = "overwrite_terragrunt"
+  contents  = local.helmignore
+}
+generate "webhooks_mongodb_helmignore" {
+  path      = "charts/mongodb/.helmignore"
+  if_exists = "overwrite_terragrunt"
+  contents  = local.helmignore
+}
+generate "webhooks_redis_helmignore" {
+  path      = "charts/redis/.helmignore"
+  if_exists = "overwrite_terragrunt"
+  contents  = local.helmignore
+}
+generate "aws_node_termination_handler_helmignore" {
+  path      = "charts/aws-node-termination-handler/.helmignore"
+  if_exists = "overwrite_terragrunt"
+  contents  = local.helmignore
+}
+generate "cluster_autoscaler_helmignore" {
+  path      = "charts/cluster-autoscaler/.helmignore"
+  if_exists = "overwrite_terragrunt"
+  contents  = local.helmignore
+}
+generate "metrics_server_helmignore" {
+  path      = "charts/metrics-server/.helmignore"
+  if_exists = "overwrite_terragrunt"
+  contents  = local.helmignore
+}
+
+dependency "physical" {
+  config_path = "${get_terragrunt_dir()}/../physical"
+
+  mock_outputs = {
+    vpc_id = "temporary-dummy-id"
+    azs_count = 3
+    msk_bootstrap_brokers = "bootstrap-brokers"
+    eks_worker_asg_arns = "dummy-arn1,dummy-arn2"
+    eks_worker_asg_names = "dummy-name1,dummy-name2"
+    eks_cluster_id = "dummy-cluster-id"
+    eks_cluster_access_role_arn = "dummy-arn"
+    eks_oidc_cluster_access_role_name = "dummy-ca-role-arn"
+    termination_handler_role_arn = "dummy-termination-handler-role-arn"
+    termination_handler_sqs_queue_id = "dummy-sqs-id"
+    nlb_dns_name = "dummy-lb-dns"
+    cluster_primary_sg = "dummy-sg"
+    primary_db_secret = "dummy-secret-id"
+    guide_images_bucket = "dummy-images-bucket"
+    guide_objects_bucket = "dummy-objects-bucket"
+    documents_bucket = "dummy-documents-bucket"
+    guide_pdfs_bucket = "dummy-pdfs-bucket"
+    memcached_cluster_address = "dummy-memcache"
+    dms_task_arn = "dummy-dms-arn"
+  }
+  mock_outputs_merge_strategy_with_state = "shallow"
+}
+
+inputs = {
+  vpc_id = dependency.physical.outputs.vpc_id
+  azs_count = dependency.physical.outputs.azs_count
+
+  msk_bootstrap_brokers = dependency.physical.outputs.msk_bootstrap_brokers
+
+  eks_cluster_id = dependency.physical.outputs.eks_cluster_id
+  eks_cluster_access_role_arn = dependency.physical.outputs.eks_cluster_access_role_arn
+  eks_oidc_cluster_access_role_name = dependency.physical.outputs.eks_oidc_cluster_access_role_name
+  termination_handler_role_arn = dependency.physical.outputs.termination_handler_role_arn
+  termination_handler_sqs_queue_id = dependency.physical.outputs.termination_handler_sqs_queue_id
+  eks_worker_asg_arns = dependency.physical.outputs.eks_worker_asg_arns
+  eks_worker_asg_names = dependency.physical.outputs.eks_worker_asg_names
+  nlb_dns_name = dependency.physical.outputs.nlb_dns_name
+  cluster_primary_sg = dependency.physical.outputs.cluster_primary_sg
+
+  primary_db_secret = dependency.physical.outputs.primary_db_secret
+  s3_images_bucket = dependency.physical.outputs.guide_images_bucket
+  s3_objects_bucket = dependency.physical.outputs.guide_objects_bucket
+  s3_documents_bucket = dependency.physical.outputs.documents_bucket
+  s3_pdfs_bucket = dependency.physical.outputs.guide_pdfs_bucket
+  memcached_cluster_address = dependency.physical.outputs.memcached_cluster_address
+  dms_task_arn = dependency.physical.outputs.dms_task_arn
+}

--- a/live/gov/us-gov-west-1/bi/logical/terragrunt.hcl
+++ b/live/gov/us-gov-west-1/bi/logical/terragrunt.hcl
@@ -6,62 +6,10 @@ terraform {
 }
 
 # Include all settings from the root terragrunt.hcl file
-include {
+include "root" {
   path = find_in_parent_folders()
 }
 
-dependency "physical" {
-  config_path = "../physical"
-
-  mock_outputs = {
-    vpc_id = "temporary-dummy-id"
-    azs_count = 3
-    msk_bootstrap_brokers = "bootstrap-brokers"
-    eks_worker_asg_arns = "dummy-arn1,dummy-arn2"
-    eks_worker_asg_names = "dummy-name1,dummy-name2"
-    eks_cluster_id = "dummy-cluster-id"
-    eks_cluster_access_role_arn = "dummy-arn"
-    eks_oidc_cluster_access_role_name = "dummy-ca-role-arn"
-    termination_handler_role_arn = "dummy-termination-handler-role-arn"
-    termination_handler_sqs_queue_id = "dummy-sqs-id"
-    nlb_dns_name = "dummy-lb-dns"
-    cluster_primary_sg = "dummy-sg"
-    primary_db_secret = "dummy-secret-id"
-    guide_images_bucket = "dummy-images-bucket"
-    guide_objects_bucket = "dummy-objects-bucket"
-    documents_bucket = "dummy-documents-bucket"
-    guide_pdfs_bucket = "dummy-pdfs-bucket"
-    memcached_cluster_address = "dummy-memcache"
-    dms_task_arn = "dummy-dms-arn"
-  }
-  mock_outputs_allowed_terraform_commands = ["validate","destroy"]
-}
-
-retryable_errors = [
-  "(?s).*frontegg-db-update is in failed state.*"
-]
-
-inputs = {
-  vpc_id = dependency.physical.outputs.vpc_id
-  azs_count = dependency.physical.outputs.azs_count
-
-  msk_bootstrap_brokers = dependency.physical.outputs.msk_bootstrap_brokers
-
-  eks_cluster_id = dependency.physical.outputs.eks_cluster_id
-  eks_cluster_access_role_arn = dependency.physical.outputs.eks_cluster_access_role_arn
-  eks_oidc_cluster_access_role_name = dependency.physical.outputs.eks_oidc_cluster_access_role_name
-  termination_handler_role_arn = dependency.physical.outputs.termination_handler_role_arn
-  termination_handler_sqs_queue_id = dependency.physical.outputs.termination_handler_sqs_queue_id
-  eks_worker_asg_arns = dependency.physical.outputs.eks_worker_asg_arns
-  eks_worker_asg_names = dependency.physical.outputs.eks_worker_asg_names
-  nlb_dns_name = dependency.physical.outputs.nlb_dns_name
-  cluster_primary_sg = dependency.physical.outputs.cluster_primary_sg
-
-  primary_db_secret = dependency.physical.outputs.primary_db_secret
-  s3_images_bucket = dependency.physical.outputs.guide_images_bucket
-  s3_objects_bucket = dependency.physical.outputs.guide_objects_bucket
-  s3_documents_bucket = dependency.physical.outputs.documents_bucket
-  s3_pdfs_bucket = dependency.physical.outputs.guide_pdfs_bucket
-  memcached_cluster_address = dependency.physical.outputs.memcached_cluster_address
-  dms_task_arn = dependency.physical.outputs.dms_task_arn
+include "common" {
+  path = find_in_parent_folders("common.hcl")
 }

--- a/live/gov/us-gov-west-1/full/logical/terragrunt.hcl
+++ b/live/gov/us-gov-west-1/full/logical/terragrunt.hcl
@@ -1,4 +1,4 @@
-skip = get_env("SKIP_FULL", false)
+skip = get_env("SKIP_LOGICAL", false)
 # Terragrunt will copy the Terraform configurations specified by the source parameter, along with any files in the
 # working directory, into a temporary folder, and execute your Terraform commands in that folder.
 terraform {
@@ -6,61 +6,10 @@ terraform {
 }
 
 # Include all settings from the root terragrunt.hcl file
-include {
+include "root" {
   path = find_in_parent_folders()
 }
 
-dependency "physical" {
-  config_path = "../physical"
-
-  mock_outputs = {
-    vpc_id = "temporary-dummy-id"
-    azs_count = 3
-    msk_bootstrap_brokers = "bootstrap-brokers"
-    eks_worker_asg_arns = "dummy-arn1,dummy-arn2"
-    eks_worker_asg_names = "dummy-name1,dummy-name2"
-    eks_cluster_id = "dummy-cluster-id"
-    eks_cluster_access_role_arn = "dummy-arn"
-    eks_oidc_cluster_access_role_name = "dummy-ca-role-arn"
-    termination_handler_role_arn = "dummy-termination-handler-role-arn"
-    termination_handler_sqs_queue_id = "dummy-sqs-id"
-    nlb_dns_name = "dummy-lb-dns"
-    cluster_primary_sg = "dummy-sg"
-    primary_db_secret = "dummy-secret-id"
-    guide_images_bucket = "dummy-images-bucket"
-    guide_objects_bucket = "dummy-objects-bucket"
-    documents_bucket = "dummy-documents-bucket"
-    guide_pdfs_bucket = "dummy-pdfs-bucket"
-    memcached_cluster_address = "dummy-memcache"
-    dms_task_arn = "dummy-dms-arn"
-  }
-}
-
-retryable_errors = [
-  "(?s).*frontegg-db-update is in failed state.*"
-]
-
-inputs = {
-  vpc_id = dependency.physical.outputs.vpc_id
-  azs_count = dependency.physical.outputs.azs_count
-
-  msk_bootstrap_brokers = dependency.physical.outputs.msk_bootstrap_brokers
-
-  eks_cluster_id = dependency.physical.outputs.eks_cluster_id
-  eks_cluster_access_role_arn = dependency.physical.outputs.eks_cluster_access_role_arn
-  eks_oidc_cluster_access_role_name = dependency.physical.outputs.eks_oidc_cluster_access_role_name
-  termination_handler_role_arn = dependency.physical.outputs.termination_handler_role_arn
-  termination_handler_sqs_queue_id = dependency.physical.outputs.termination_handler_sqs_queue_id
-  eks_worker_asg_arns = dependency.physical.outputs.eks_worker_asg_arns
-  eks_worker_asg_names = dependency.physical.outputs.eks_worker_asg_names
-  nlb_dns_name = dependency.physical.outputs.nlb_dns_name
-  cluster_primary_sg = dependency.physical.outputs.cluster_primary_sg
-
-  primary_db_secret = dependency.physical.outputs.primary_db_secret
-  s3_images_bucket = dependency.physical.outputs.guide_images_bucket
-  s3_objects_bucket = dependency.physical.outputs.guide_objects_bucket
-  s3_documents_bucket = dependency.physical.outputs.documents_bucket
-  s3_pdfs_bucket = dependency.physical.outputs.guide_pdfs_bucket
-  memcached_cluster_address = dependency.physical.outputs.memcached_cluster_address
-  dms_task_arn = dependency.physical.outputs.dms_task_arn
+include "common" {
+  path = find_in_parent_folders("common.hcl")
 }

--- a/live/gov/us-gov-west-1/min/logical/terragrunt.hcl
+++ b/live/gov/us-gov-west-1/min/logical/terragrunt.hcl
@@ -6,62 +6,10 @@ terraform {
 }
 
 # Include all settings from the root terragrunt.hcl file
-include {
+include "root" {
   path = find_in_parent_folders()
 }
 
-dependency "physical" {
-  config_path = "../physical"
-
-  mock_outputs = {
-    vpc_id = "temporary-dummy-id"
-    azs_count = 3
-    msk_bootstrap_brokers = "bootstrap-brokers"
-    eks_worker_asg_arns = "dummy-arn1,dummy-arn2"
-    eks_worker_asg_names = "dummy-name1,dummy-name2"
-    eks_cluster_id = "dummy-cluster-id"
-    eks_cluster_access_role_arn = "dummy-arn"
-    eks_oidc_cluster_access_role_name = "dummy-ca-role-arn"
-    termination_handler_role_arn = "dummy-termination-handler-role-arn"
-    termination_handler_sqs_queue_id = "dummy-sqs-id"
-    nlb_dns_name = "dummy-lb-dns"
-    cluster_primary_sg = "dummy-sg"
-    primary_db_secret = "dummy-secret-id"
-    guide_images_bucket = "dummy-images-bucket"
-    guide_objects_bucket = "dummy-objects-bucket"
-    documents_bucket = "dummy-documents-bucket"
-    guide_pdfs_bucket = "dummy-pdfs-bucket"
-    memcached_cluster_address = "dummy-memcache"
-    dms_task_arn = "dummy-dms-arn"
-  }
-  mock_outputs_allowed_terraform_commands = ["validate","destroy"]
-}
-
-retryable_errors = [
-  "(?s).*frontegg-db-update is in failed state.*"
-]
-
-inputs = {
-  vpc_id = dependency.physical.outputs.vpc_id
-  azs_count = dependency.physical.outputs.azs_count
-
-  msk_bootstrap_brokers = dependency.physical.outputs.msk_bootstrap_brokers
-
-  eks_cluster_id = dependency.physical.outputs.eks_cluster_id
-  eks_cluster_access_role_arn = dependency.physical.outputs.eks_cluster_access_role_arn
-  eks_oidc_cluster_access_role_name = dependency.physical.outputs.eks_oidc_cluster_access_role_name
-  termination_handler_role_arn = dependency.physical.outputs.termination_handler_role_arn
-  termination_handler_sqs_queue_id = dependency.physical.outputs.termination_handler_sqs_queue_id
-  eks_worker_asg_arns = dependency.physical.outputs.eks_worker_asg_arns
-  eks_worker_asg_names = dependency.physical.outputs.eks_worker_asg_names
-  nlb_dns_name = dependency.physical.outputs.nlb_dns_name
-  cluster_primary_sg = dependency.physical.outputs.cluster_primary_sg
-
-  primary_db_secret = dependency.physical.outputs.primary_db_secret
-  s3_images_bucket = dependency.physical.outputs.guide_images_bucket
-  s3_objects_bucket = dependency.physical.outputs.guide_objects_bucket
-  s3_documents_bucket = dependency.physical.outputs.documents_bucket
-  s3_pdfs_bucket = dependency.physical.outputs.guide_pdfs_bucket
-  memcached_cluster_address = dependency.physical.outputs.memcached_cluster_address
-  dms_task_arn = dependency.physical.outputs.dms_task_arn
+include "common" {
+  path = find_in_parent_folders("common.hcl")
 }

--- a/live/gov/us-gov-west-1/webhooks/logical/terragrunt.hcl
+++ b/live/gov/us-gov-west-1/webhooks/logical/terragrunt.hcl
@@ -6,62 +6,10 @@ terraform {
 }
 
 # Include all settings from the root terragrunt.hcl file
-include {
+include "root" {
   path = find_in_parent_folders()
 }
 
-dependency "physical" {
-  config_path = "../physical"
-
-  mock_outputs = {
-    vpc_id = "temporary-dummy-id"
-    azs_count = 3
-    msk_bootstrap_brokers = "bootstrap-brokers"
-    eks_worker_asg_arns = "dummy-arn1,dummy-arn2"
-    eks_worker_asg_names = "dummy-name1,dummy-name2"
-    eks_cluster_id = "dummy-cluster-id"
-    eks_cluster_access_role_arn = "dummy-arn"
-    eks_oidc_cluster_access_role_name = "dummy-ca-role-arn"
-    termination_handler_role_arn = "dummy-termination-handler-role-arn"
-    termination_handler_sqs_queue_id = "dummy-sqs-id"
-    nlb_dns_name = "dummy-lb-dns"
-    cluster_primary_sg = "dummy-sg"
-    primary_db_secret = "dummy-secret-id"
-    guide_images_bucket = "dummy-images-bucket"
-    guide_objects_bucket = "dummy-objects-bucket"
-    documents_bucket = "dummy-documents-bucket"
-    guide_pdfs_bucket = "dummy-pdfs-bucket"
-    memcached_cluster_address = "dummy-memcache"
-    dms_task_arn = "dummy-dms-arn"
-  }
-  mock_outputs_allowed_terraform_commands = ["validate","destroy"]
-}
-
-retryable_errors = [
-  "(?s).*frontegg-db-update is in failed state.*"
-]
-
-inputs = {
-  vpc_id = dependency.physical.outputs.vpc_id
-  azs_count = dependency.physical.outputs.azs_count
-
-  msk_bootstrap_brokers = dependency.physical.outputs.msk_bootstrap_brokers
-
-  eks_cluster_id = dependency.physical.outputs.eks_cluster_id
-  eks_cluster_access_role_arn = dependency.physical.outputs.eks_cluster_access_role_arn
-  eks_oidc_cluster_access_role_name = dependency.physical.outputs.eks_oidc_cluster_access_role_name
-  termination_handler_role_arn = dependency.physical.outputs.termination_handler_role_arn
-  termination_handler_sqs_queue_id = dependency.physical.outputs.termination_handler_sqs_queue_id
-  eks_worker_asg_arns = dependency.physical.outputs.eks_worker_asg_arns
-  eks_worker_asg_names = dependency.physical.outputs.eks_worker_asg_names
-  nlb_dns_name = dependency.physical.outputs.nlb_dns_name
-  cluster_primary_sg = dependency.physical.outputs.cluster_primary_sg
-
-  primary_db_secret = dependency.physical.outputs.primary_db_secret
-  s3_images_bucket = dependency.physical.outputs.guide_images_bucket
-  s3_objects_bucket = dependency.physical.outputs.guide_objects_bucket
-  s3_documents_bucket = dependency.physical.outputs.documents_bucket
-  s3_pdfs_bucket = dependency.physical.outputs.guide_pdfs_bucket
-  memcached_cluster_address = dependency.physical.outputs.memcached_cluster_address
-  dms_task_arn = dependency.physical.outputs.dms_task_arn
+include "common" {
+  path = find_in_parent_folders("common.hcl")
 }

--- a/live/standard/eu-central-1/bi/logical/terragrunt.hcl
+++ b/live/standard/eu-central-1/bi/logical/terragrunt.hcl
@@ -6,62 +6,10 @@ terraform {
 }
 
 # Include all settings from the root terragrunt.hcl file
-include {
+include "root" {
   path = find_in_parent_folders()
 }
 
-dependency "physical" {
-  config_path = "../physical"
-
-  mock_outputs = {
-    vpc_id = "temporary-dummy-id"
-    azs_count = 3
-    msk_bootstrap_brokers = "bootstrap-brokers"
-    eks_worker_asg_arns = "dummy-arn1,dummy-arn2"
-    eks_worker_asg_names = "dummy-name1,dummy-name2"
-    eks_cluster_id = "dummy-cluster-id"
-    eks_cluster_access_role_arn = "dummy-arn"
-    eks_oidc_cluster_access_role_name = "dummy-ca-role-arn"
-    termination_handler_role_arn = "dummy-termination-handler-role-arn"
-    termination_handler_sqs_queue_id = "dummy-sqs-id"
-    nlb_dns_name = "dummy-lb-dns"
-    cluster_primary_sg = "dummy-sg"
-    primary_db_secret = "dummy-secret-id"
-    guide_images_bucket = "dummy-images-bucket"
-    guide_objects_bucket = "dummy-objects-bucket"
-    documents_bucket = "dummy-documents-bucket"
-    guide_pdfs_bucket = "dummy-pdfs-bucket"
-    memcached_cluster_address = "dummy-memcache"
-    dms_task_arn = "dummy-dms-arn"
-  }
-  mock_outputs_allowed_terraform_commands = ["validate","destroy"]
-}
-
-retryable_errors = [
-  "(?s).*frontegg-db-update is in failed state.*"
-]
-
-inputs = {
-  vpc_id = dependency.physical.outputs.vpc_id
-  azs_count = dependency.physical.outputs.azs_count
-
-  msk_bootstrap_brokers = dependency.physical.outputs.msk_bootstrap_brokers
-
-  eks_cluster_id = dependency.physical.outputs.eks_cluster_id
-  eks_cluster_access_role_arn = dependency.physical.outputs.eks_cluster_access_role_arn
-  eks_oidc_cluster_access_role_name = dependency.physical.outputs.eks_oidc_cluster_access_role_name
-  termination_handler_role_arn = dependency.physical.outputs.termination_handler_role_arn
-  termination_handler_sqs_queue_id = dependency.physical.outputs.termination_handler_sqs_queue_id
-  eks_worker_asg_arns = dependency.physical.outputs.eks_worker_asg_arns
-  eks_worker_asg_names = dependency.physical.outputs.eks_worker_asg_names
-  nlb_dns_name = dependency.physical.outputs.nlb_dns_name
-  cluster_primary_sg = dependency.physical.outputs.cluster_primary_sg
-
-  primary_db_secret = dependency.physical.outputs.primary_db_secret
-  s3_images_bucket = dependency.physical.outputs.guide_images_bucket
-  s3_objects_bucket = dependency.physical.outputs.guide_objects_bucket
-  s3_documents_bucket = dependency.physical.outputs.documents_bucket
-  s3_pdfs_bucket = dependency.physical.outputs.guide_pdfs_bucket
-  memcached_cluster_address = dependency.physical.outputs.memcached_cluster_address
-  dms_task_arn = dependency.physical.outputs.dms_task_arn
+include "common" {
+  path = find_in_parent_folders("common.hcl")
 }

--- a/live/standard/eu-central-1/full/logical/terragrunt.hcl
+++ b/live/standard/eu-central-1/full/logical/terragrunt.hcl
@@ -1,4 +1,4 @@
-skip = get_env("SKIP_FULL", false)
+skip = get_env("SKIP_LOGICAL", false)
 # Terragrunt will copy the Terraform configurations specified by the source parameter, along with any files in the
 # working directory, into a temporary folder, and execute your Terraform commands in that folder.
 terraform {
@@ -6,61 +6,10 @@ terraform {
 }
 
 # Include all settings from the root terragrunt.hcl file
-include {
+include "root" {
   path = find_in_parent_folders()
 }
 
-dependency "physical" {
-  config_path = "../physical"
-
-  mock_outputs = {
-    vpc_id = "temporary-dummy-id"
-    azs_count = 3
-    msk_bootstrap_brokers = "bootstrap-brokers"
-    eks_worker_asg_arns = "dummy-arn1,dummy-arn2"
-    eks_worker_asg_names = "dummy-name1,dummy-name2"
-    eks_cluster_id = "dummy-cluster-id"
-    eks_cluster_access_role_arn = "dummy-arn"
-    eks_oidc_cluster_access_role_name = "dummy-ca-role-arn"
-    termination_handler_role_arn = "dummy-termination-handler-role-arn"
-    termination_handler_sqs_queue_id = "dummy-sqs-id"
-    nlb_dns_name = "dummy-lb-dns"
-    cluster_primary_sg = "dummy-sg"
-    primary_db_secret = "dummy-secret-id"
-    guide_images_bucket = "dummy-images-bucket"
-    guide_objects_bucket = "dummy-objects-bucket"
-    documents_bucket = "dummy-documents-bucket"
-    guide_pdfs_bucket = "dummy-pdfs-bucket"
-    memcached_cluster_address = "dummy-memcache"
-    dms_task_arn = "dummy-dms-arn"
-  }
-}
-
-retryable_errors = [
-  "(?s).*frontegg-db-update is in failed state.*"
-]
-
-inputs = {
-  vpc_id = dependency.physical.outputs.vpc_id
-  azs_count = dependency.physical.outputs.azs_count
-
-  msk_bootstrap_brokers = dependency.physical.outputs.msk_bootstrap_brokers
-
-  eks_cluster_id = dependency.physical.outputs.eks_cluster_id
-  eks_cluster_access_role_arn = dependency.physical.outputs.eks_cluster_access_role_arn
-  eks_oidc_cluster_access_role_name = dependency.physical.outputs.eks_oidc_cluster_access_role_name
-  termination_handler_role_arn = dependency.physical.outputs.termination_handler_role_arn
-  termination_handler_sqs_queue_id = dependency.physical.outputs.termination_handler_sqs_queue_id
-  eks_worker_asg_arns = dependency.physical.outputs.eks_worker_asg_arns
-  eks_worker_asg_names = dependency.physical.outputs.eks_worker_asg_names
-  nlb_dns_name = dependency.physical.outputs.nlb_dns_name
-  cluster_primary_sg = dependency.physical.outputs.cluster_primary_sg
-
-  primary_db_secret = dependency.physical.outputs.primary_db_secret
-  s3_images_bucket = dependency.physical.outputs.guide_images_bucket
-  s3_objects_bucket = dependency.physical.outputs.guide_objects_bucket
-  s3_documents_bucket = dependency.physical.outputs.documents_bucket
-  s3_pdfs_bucket = dependency.physical.outputs.guide_pdfs_bucket
-  memcached_cluster_address = dependency.physical.outputs.memcached_cluster_address
-  dms_task_arn = dependency.physical.outputs.dms_task_arn
+include "common" {
+  path = find_in_parent_folders("common.hcl")
 }

--- a/live/standard/eu-central-1/min/logical/terragrunt.hcl
+++ b/live/standard/eu-central-1/min/logical/terragrunt.hcl
@@ -6,62 +6,10 @@ terraform {
 }
 
 # Include all settings from the root terragrunt.hcl file
-include {
+include "root" {
   path = find_in_parent_folders()
 }
 
-dependency "physical" {
-  config_path = "../physical"
-
-  mock_outputs = {
-    vpc_id = "temporary-dummy-id"
-    azs_count = 3
-    msk_bootstrap_brokers = "bootstrap-brokers"
-    eks_worker_asg_arns = "dummy-arn1,dummy-arn2"
-    eks_worker_asg_names = "dummy-name1,dummy-name2"
-    eks_cluster_id = "dummy-cluster-id"
-    eks_cluster_access_role_arn = "dummy-arn"
-    eks_oidc_cluster_access_role_name = "dummy-ca-role-arn"
-    termination_handler_role_arn = "dummy-termination-handler-role-arn"
-    termination_handler_sqs_queue_id = "dummy-sqs-id"
-    nlb_dns_name = "dummy-lb-dns"
-    cluster_primary_sg = "dummy-sg"
-    primary_db_secret = "dummy-secret-id"
-    guide_images_bucket = "dummy-images-bucket"
-    guide_objects_bucket = "dummy-objects-bucket"
-    documents_bucket = "dummy-documents-bucket"
-    guide_pdfs_bucket = "dummy-pdfs-bucket"
-    memcached_cluster_address = "dummy-memcache"
-    dms_task_arn = "dummy-dms-arn"
-  }
-  mock_outputs_allowed_terraform_commands = ["validate","destroy"]
-}
-
-retryable_errors = [
-  "(?s).*frontegg-db-update is in failed state.*"
-]
-
-inputs = {
-  vpc_id = dependency.physical.outputs.vpc_id
-  azs_count = dependency.physical.outputs.azs_count
-
-  msk_bootstrap_brokers = dependency.physical.outputs.msk_bootstrap_brokers
-
-  eks_cluster_id = dependency.physical.outputs.eks_cluster_id
-  eks_cluster_access_role_arn = dependency.physical.outputs.eks_cluster_access_role_arn
-  eks_oidc_cluster_access_role_name = dependency.physical.outputs.eks_oidc_cluster_access_role_name
-  termination_handler_role_arn = dependency.physical.outputs.termination_handler_role_arn
-  termination_handler_sqs_queue_id = dependency.physical.outputs.termination_handler_sqs_queue_id
-  eks_worker_asg_arns = dependency.physical.outputs.eks_worker_asg_arns
-  eks_worker_asg_names = dependency.physical.outputs.eks_worker_asg_names
-  nlb_dns_name = dependency.physical.outputs.nlb_dns_name
-  cluster_primary_sg = dependency.physical.outputs.cluster_primary_sg
-
-  primary_db_secret = dependency.physical.outputs.primary_db_secret
-  s3_images_bucket = dependency.physical.outputs.guide_images_bucket
-  s3_objects_bucket = dependency.physical.outputs.guide_objects_bucket
-  s3_documents_bucket = dependency.physical.outputs.documents_bucket
-  s3_pdfs_bucket = dependency.physical.outputs.guide_pdfs_bucket
-  memcached_cluster_address = dependency.physical.outputs.memcached_cluster_address
-  dms_task_arn = dependency.physical.outputs.dms_task_arn
+include "common" {
+  path = find_in_parent_folders("common.hcl")
 }

--- a/live/standard/eu-central-1/webhooks/logical/terragrunt.hcl
+++ b/live/standard/eu-central-1/webhooks/logical/terragrunt.hcl
@@ -6,62 +6,10 @@ terraform {
 }
 
 # Include all settings from the root terragrunt.hcl file
-include {
+include "root" {
   path = find_in_parent_folders()
 }
 
-dependency "physical" {
-  config_path = "../physical"
-
-  mock_outputs = {
-    vpc_id = "temporary-dummy-id"
-    azs_count = 3
-    msk_bootstrap_brokers = "bootstrap-brokers"
-    eks_worker_asg_arns = "dummy-arn1,dummy-arn2"
-    eks_worker_asg_names = "dummy-name1,dummy-name2"
-    eks_cluster_id = "dummy-cluster-id"
-    eks_cluster_access_role_arn = "dummy-arn"
-    eks_oidc_cluster_access_role_name = "dummy-ca-role-arn"
-    termination_handler_role_arn = "dummy-termination-handler-role-arn"
-    termination_handler_sqs_queue_id = "dummy-sqs-id"
-    nlb_dns_name = "dummy-lb-dns"
-    cluster_primary_sg = "dummy-sg"
-    primary_db_secret = "dummy-secret-id"
-    guide_images_bucket = "dummy-images-bucket"
-    guide_objects_bucket = "dummy-objects-bucket"
-    documents_bucket = "dummy-documents-bucket"
-    guide_pdfs_bucket = "dummy-pdfs-bucket"
-    memcached_cluster_address = "dummy-memcache"
-    dms_task_arn = "dummy-dms-arn"
-  }
-  mock_outputs_allowed_terraform_commands = ["validate","destroy"]
-}
-
-retryable_errors = [
-  "(?s).*frontegg-db-update is in failed state.*"
-]
-
-inputs = {
-  vpc_id = dependency.physical.outputs.vpc_id
-  azs_count = dependency.physical.outputs.azs_count
-
-  msk_bootstrap_brokers = dependency.physical.outputs.msk_bootstrap_brokers
-
-  eks_cluster_id = dependency.physical.outputs.eks_cluster_id
-  eks_cluster_access_role_arn = dependency.physical.outputs.eks_cluster_access_role_arn
-  eks_oidc_cluster_access_role_name = dependency.physical.outputs.eks_oidc_cluster_access_role_name
-  termination_handler_role_arn = dependency.physical.outputs.termination_handler_role_arn
-  termination_handler_sqs_queue_id = dependency.physical.outputs.termination_handler_sqs_queue_id
-  eks_worker_asg_arns = dependency.physical.outputs.eks_worker_asg_arns
-  eks_worker_asg_names = dependency.physical.outputs.eks_worker_asg_names
-  nlb_dns_name = dependency.physical.outputs.nlb_dns_name
-  cluster_primary_sg = dependency.physical.outputs.cluster_primary_sg
-
-  primary_db_secret = dependency.physical.outputs.primary_db_secret
-  s3_images_bucket = dependency.physical.outputs.guide_images_bucket
-  s3_objects_bucket = dependency.physical.outputs.guide_objects_bucket
-  s3_documents_bucket = dependency.physical.outputs.documents_bucket
-  s3_pdfs_bucket = dependency.physical.outputs.guide_pdfs_bucket
-  memcached_cluster_address = dependency.physical.outputs.memcached_cluster_address
-  dms_task_arn = dependency.physical.outputs.dms_task_arn
+include "common" {
+  path = find_in_parent_folders("common.hcl")
 }

--- a/live/standard/eu-west-1/bi/logical/terragrunt.hcl
+++ b/live/standard/eu-west-1/bi/logical/terragrunt.hcl
@@ -6,62 +6,10 @@ terraform {
 }
 
 # Include all settings from the root terragrunt.hcl file
-include {
+include "root" {
   path = find_in_parent_folders()
 }
 
-dependency "physical" {
-  config_path = "../physical"
-
-  mock_outputs = {
-    vpc_id = "temporary-dummy-id"
-    azs_count = 3
-    msk_bootstrap_brokers = "bootstrap-brokers"
-    eks_worker_asg_arns = "dummy-arn1,dummy-arn2"
-    eks_worker_asg_names = "dummy-name1,dummy-name2"
-    eks_cluster_id = "dummy-cluster-id"
-    eks_cluster_access_role_arn = "dummy-arn"
-    eks_oidc_cluster_access_role_name = "dummy-ca-role-arn"
-    termination_handler_role_arn = "dummy-termination-handler-role-arn"
-    termination_handler_sqs_queue_id = "dummy-sqs-id"
-    nlb_dns_name = "dummy-lb-dns"
-    cluster_primary_sg = "dummy-sg"
-    primary_db_secret = "dummy-secret-id"
-    guide_images_bucket = "dummy-images-bucket"
-    guide_objects_bucket = "dummy-objects-bucket"
-    documents_bucket = "dummy-documents-bucket"
-    guide_pdfs_bucket = "dummy-pdfs-bucket"
-    memcached_cluster_address = "dummy-memcache"
-    dms_task_arn = "dummy-dms-arn"
-  }
-  mock_outputs_allowed_terraform_commands = ["validate","destroy"]
-}
-
-retryable_errors = [
-  "(?s).*frontegg-db-update is in failed state.*"
-]
-
-inputs = {
-  vpc_id = dependency.physical.outputs.vpc_id
-  azs_count = dependency.physical.outputs.azs_count
-
-  msk_bootstrap_brokers = dependency.physical.outputs.msk_bootstrap_brokers
-
-  eks_cluster_id = dependency.physical.outputs.eks_cluster_id
-  eks_cluster_access_role_arn = dependency.physical.outputs.eks_cluster_access_role_arn
-  eks_oidc_cluster_access_role_name = dependency.physical.outputs.eks_oidc_cluster_access_role_name
-  termination_handler_role_arn = dependency.physical.outputs.termination_handler_role_arn
-  termination_handler_sqs_queue_id = dependency.physical.outputs.termination_handler_sqs_queue_id
-  eks_worker_asg_arns = dependency.physical.outputs.eks_worker_asg_arns
-  eks_worker_asg_names = dependency.physical.outputs.eks_worker_asg_names
-  nlb_dns_name = dependency.physical.outputs.nlb_dns_name
-  cluster_primary_sg = dependency.physical.outputs.cluster_primary_sg
-
-  primary_db_secret = dependency.physical.outputs.primary_db_secret
-  s3_images_bucket = dependency.physical.outputs.guide_images_bucket
-  s3_objects_bucket = dependency.physical.outputs.guide_objects_bucket
-  s3_documents_bucket = dependency.physical.outputs.documents_bucket
-  s3_pdfs_bucket = dependency.physical.outputs.guide_pdfs_bucket
-  memcached_cluster_address = dependency.physical.outputs.memcached_cluster_address
-  dms_task_arn = dependency.physical.outputs.dms_task_arn
+include "common" {
+  path = find_in_parent_folders("common.hcl")
 }

--- a/live/standard/eu-west-1/full/logical/terragrunt.hcl
+++ b/live/standard/eu-west-1/full/logical/terragrunt.hcl
@@ -1,4 +1,4 @@
-skip = get_env("SKIP_FULL", false)
+skip = get_env("SKIP_LOGICAL", false)
 # Terragrunt will copy the Terraform configurations specified by the source parameter, along with any files in the
 # working directory, into a temporary folder, and execute your Terraform commands in that folder.
 terraform {
@@ -6,61 +6,10 @@ terraform {
 }
 
 # Include all settings from the root terragrunt.hcl file
-include {
+include "root" {
   path = find_in_parent_folders()
 }
 
-dependency "physical" {
-  config_path = "../physical"
-
-  mock_outputs = {
-    vpc_id = "temporary-dummy-id"
-    azs_count = 3
-    msk_bootstrap_brokers = "bootstrap-brokers"
-    eks_worker_asg_arns = "dummy-arn1,dummy-arn2"
-    eks_worker_asg_names = "dummy-name1,dummy-name2"
-    eks_cluster_id = "dummy-cluster-id"
-    eks_cluster_access_role_arn = "dummy-arn"
-    eks_oidc_cluster_access_role_name = "dummy-ca-role-arn"
-    termination_handler_role_arn = "dummy-termination-handler-role-arn"
-    termination_handler_sqs_queue_id = "dummy-sqs-id"
-    nlb_dns_name = "dummy-lb-dns"
-    cluster_primary_sg = "dummy-sg"
-    primary_db_secret = "dummy-secret-id"
-    guide_images_bucket = "dummy-images-bucket"
-    guide_objects_bucket = "dummy-objects-bucket"
-    documents_bucket = "dummy-documents-bucket"
-    guide_pdfs_bucket = "dummy-pdfs-bucket"
-    memcached_cluster_address = "dummy-memcache"
-    dms_task_arn = "dummy-dms-arn"
-  }
-}
-
-retryable_errors = [
-  "(?s).*frontegg-db-update is in failed state.*"
-]
-
-inputs = {
-  vpc_id = dependency.physical.outputs.vpc_id
-  azs_count = dependency.physical.outputs.azs_count
-
-  msk_bootstrap_brokers = dependency.physical.outputs.msk_bootstrap_brokers
-
-  eks_cluster_id = dependency.physical.outputs.eks_cluster_id
-  eks_cluster_access_role_arn = dependency.physical.outputs.eks_cluster_access_role_arn
-  eks_oidc_cluster_access_role_name = dependency.physical.outputs.eks_oidc_cluster_access_role_name
-  termination_handler_role_arn = dependency.physical.outputs.termination_handler_role_arn
-  termination_handler_sqs_queue_id = dependency.physical.outputs.termination_handler_sqs_queue_id
-  eks_worker_asg_arns = dependency.physical.outputs.eks_worker_asg_arns
-  eks_worker_asg_names = dependency.physical.outputs.eks_worker_asg_names
-  nlb_dns_name = dependency.physical.outputs.nlb_dns_name
-  cluster_primary_sg = dependency.physical.outputs.cluster_primary_sg
-
-  primary_db_secret = dependency.physical.outputs.primary_db_secret
-  s3_images_bucket = dependency.physical.outputs.guide_images_bucket
-  s3_objects_bucket = dependency.physical.outputs.guide_objects_bucket
-  s3_documents_bucket = dependency.physical.outputs.documents_bucket
-  s3_pdfs_bucket = dependency.physical.outputs.guide_pdfs_bucket
-  memcached_cluster_address = dependency.physical.outputs.memcached_cluster_address
-  dms_task_arn = dependency.physical.outputs.dms_task_arn
+include "common" {
+  path = find_in_parent_folders("common.hcl")
 }

--- a/live/standard/eu-west-1/min/logical/terragrunt.hcl
+++ b/live/standard/eu-west-1/min/logical/terragrunt.hcl
@@ -6,62 +6,10 @@ terraform {
 }
 
 # Include all settings from the root terragrunt.hcl file
-include {
+include "root" {
   path = find_in_parent_folders()
 }
 
-dependency "physical" {
-  config_path = "../physical"
-
-  mock_outputs = {
-    vpc_id = "temporary-dummy-id"
-    azs_count = 3
-    msk_bootstrap_brokers = "bootstrap-brokers"
-    eks_worker_asg_arns = "dummy-arn1,dummy-arn2"
-    eks_worker_asg_names = "dummy-name1,dummy-name2"
-    eks_cluster_id = "dummy-cluster-id"
-    eks_cluster_access_role_arn = "dummy-arn"
-    eks_oidc_cluster_access_role_name = "dummy-ca-role-arn"
-    termination_handler_role_arn = "dummy-termination-handler-role-arn"
-    termination_handler_sqs_queue_id = "dummy-sqs-id"
-    nlb_dns_name = "dummy-lb-dns"
-    cluster_primary_sg = "dummy-sg"
-    primary_db_secret = "dummy-secret-id"
-    guide_images_bucket = "dummy-images-bucket"
-    guide_objects_bucket = "dummy-objects-bucket"
-    documents_bucket = "dummy-documents-bucket"
-    guide_pdfs_bucket = "dummy-pdfs-bucket"
-    memcached_cluster_address = "dummy-memcache"
-    dms_task_arn = "dummy-dms-arn"
-  }
-  mock_outputs_allowed_terraform_commands = ["validate","destroy"]
-}
-
-retryable_errors = [
-  "(?s).*frontegg-db-update is in failed state.*"
-]
-
-inputs = {
-  vpc_id = dependency.physical.outputs.vpc_id
-  azs_count = dependency.physical.outputs.azs_count
-
-  msk_bootstrap_brokers = dependency.physical.outputs.msk_bootstrap_brokers
-
-  eks_cluster_id = dependency.physical.outputs.eks_cluster_id
-  eks_cluster_access_role_arn = dependency.physical.outputs.eks_cluster_access_role_arn
-  eks_oidc_cluster_access_role_name = dependency.physical.outputs.eks_oidc_cluster_access_role_name
-  termination_handler_role_arn = dependency.physical.outputs.termination_handler_role_arn
-  termination_handler_sqs_queue_id = dependency.physical.outputs.termination_handler_sqs_queue_id
-  eks_worker_asg_arns = dependency.physical.outputs.eks_worker_asg_arns
-  eks_worker_asg_names = dependency.physical.outputs.eks_worker_asg_names
-  nlb_dns_name = dependency.physical.outputs.nlb_dns_name
-  cluster_primary_sg = dependency.physical.outputs.cluster_primary_sg
-
-  primary_db_secret = dependency.physical.outputs.primary_db_secret
-  s3_images_bucket = dependency.physical.outputs.guide_images_bucket
-  s3_objects_bucket = dependency.physical.outputs.guide_objects_bucket
-  s3_documents_bucket = dependency.physical.outputs.documents_bucket
-  s3_pdfs_bucket = dependency.physical.outputs.guide_pdfs_bucket
-  memcached_cluster_address = dependency.physical.outputs.memcached_cluster_address
-  dms_task_arn = dependency.physical.outputs.dms_task_arn
+include "common" {
+  path = find_in_parent_folders("common.hcl")
 }

--- a/live/standard/eu-west-1/webhooks/logical/terragrunt.hcl
+++ b/live/standard/eu-west-1/webhooks/logical/terragrunt.hcl
@@ -6,62 +6,10 @@ terraform {
 }
 
 # Include all settings from the root terragrunt.hcl file
-include {
+include "root" {
   path = find_in_parent_folders()
 }
 
-dependency "physical" {
-  config_path = "../physical"
-
-  mock_outputs = {
-    vpc_id = "temporary-dummy-id"
-    azs_count = 3
-    msk_bootstrap_brokers = "bootstrap-brokers"
-    eks_worker_asg_arns = "dummy-arn1,dummy-arn2"
-    eks_worker_asg_names = "dummy-name1,dummy-name2"
-    eks_cluster_id = "dummy-cluster-id"
-    eks_cluster_access_role_arn = "dummy-arn"
-    eks_oidc_cluster_access_role_name = "dummy-ca-role-arn"
-    termination_handler_role_arn = "dummy-termination-handler-role-arn"
-    termination_handler_sqs_queue_id = "dummy-sqs-id"
-    nlb_dns_name = "dummy-lb-dns"
-    cluster_primary_sg = "dummy-sg"
-    primary_db_secret = "dummy-secret-id"
-    guide_images_bucket = "dummy-images-bucket"
-    guide_objects_bucket = "dummy-objects-bucket"
-    documents_bucket = "dummy-documents-bucket"
-    guide_pdfs_bucket = "dummy-pdfs-bucket"
-    memcached_cluster_address = "dummy-memcache"
-    dms_task_arn = "dummy-dms-arn"
-  }
-  mock_outputs_allowed_terraform_commands = ["validate","destroy"]
-}
-
-retryable_errors = [
-  "(?s).*frontegg-db-update is in failed state.*"
-]
-
-inputs = {
-  vpc_id = dependency.physical.outputs.vpc_id
-  azs_count = dependency.physical.outputs.azs_count
-
-  msk_bootstrap_brokers = dependency.physical.outputs.msk_bootstrap_brokers
-
-  eks_cluster_id = dependency.physical.outputs.eks_cluster_id
-  eks_cluster_access_role_arn = dependency.physical.outputs.eks_cluster_access_role_arn
-  eks_oidc_cluster_access_role_name = dependency.physical.outputs.eks_oidc_cluster_access_role_name
-  termination_handler_role_arn = dependency.physical.outputs.termination_handler_role_arn
-  termination_handler_sqs_queue_id = dependency.physical.outputs.termination_handler_sqs_queue_id
-  eks_worker_asg_arns = dependency.physical.outputs.eks_worker_asg_arns
-  eks_worker_asg_names = dependency.physical.outputs.eks_worker_asg_names
-  nlb_dns_name = dependency.physical.outputs.nlb_dns_name
-  cluster_primary_sg = dependency.physical.outputs.cluster_primary_sg
-
-  primary_db_secret = dependency.physical.outputs.primary_db_secret
-  s3_images_bucket = dependency.physical.outputs.guide_images_bucket
-  s3_objects_bucket = dependency.physical.outputs.guide_objects_bucket
-  s3_documents_bucket = dependency.physical.outputs.documents_bucket
-  s3_pdfs_bucket = dependency.physical.outputs.guide_pdfs_bucket
-  memcached_cluster_address = dependency.physical.outputs.memcached_cluster_address
-  dms_task_arn = dependency.physical.outputs.dms_task_arn
+include "common" {
+  path = find_in_parent_folders("common.hcl")
 }

--- a/live/standard/eu-west-2/bi/logical/terragrunt.hcl
+++ b/live/standard/eu-west-2/bi/logical/terragrunt.hcl
@@ -6,62 +6,10 @@ terraform {
 }
 
 # Include all settings from the root terragrunt.hcl file
-include {
+include "root" {
   path = find_in_parent_folders()
 }
 
-dependency "physical" {
-  config_path = "../physical"
-
-  mock_outputs = {
-    vpc_id = "temporary-dummy-id"
-    azs_count = 3
-    msk_bootstrap_brokers = "bootstrap-brokers"
-    eks_worker_asg_arns = "dummy-arn1,dummy-arn2"
-    eks_worker_asg_names = "dummy-name1,dummy-name2"
-    eks_cluster_id = "dummy-cluster-id"
-    eks_cluster_access_role_arn = "dummy-arn"
-    eks_oidc_cluster_access_role_name = "dummy-ca-role-arn"
-    termination_handler_role_arn = "dummy-termination-handler-role-arn"
-    termination_handler_sqs_queue_id = "dummy-sqs-id"
-    nlb_dns_name = "dummy-lb-dns"
-    cluster_primary_sg = "dummy-sg"
-    primary_db_secret = "dummy-secret-id"
-    guide_images_bucket = "dummy-images-bucket"
-    guide_objects_bucket = "dummy-objects-bucket"
-    documents_bucket = "dummy-documents-bucket"
-    guide_pdfs_bucket = "dummy-pdfs-bucket"
-    memcached_cluster_address = "dummy-memcache"
-    dms_task_arn = "dummy-dms-arn"
-  }
-  mock_outputs_allowed_terraform_commands = ["validate","destroy"]
-}
-
-retryable_errors = [
-  "(?s).*frontegg-db-update is in failed state.*"
-]
-
-inputs = {
-  vpc_id = dependency.physical.outputs.vpc_id
-  azs_count = dependency.physical.outputs.azs_count
-
-  msk_bootstrap_brokers = dependency.physical.outputs.msk_bootstrap_brokers
-
-  eks_cluster_id = dependency.physical.outputs.eks_cluster_id
-  eks_cluster_access_role_arn = dependency.physical.outputs.eks_cluster_access_role_arn
-  eks_oidc_cluster_access_role_name = dependency.physical.outputs.eks_oidc_cluster_access_role_name
-  termination_handler_role_arn = dependency.physical.outputs.termination_handler_role_arn
-  termination_handler_sqs_queue_id = dependency.physical.outputs.termination_handler_sqs_queue_id
-  eks_worker_asg_arns = dependency.physical.outputs.eks_worker_asg_arns
-  eks_worker_asg_names = dependency.physical.outputs.eks_worker_asg_names
-  nlb_dns_name = dependency.physical.outputs.nlb_dns_name
-  cluster_primary_sg = dependency.physical.outputs.cluster_primary_sg
-
-  primary_db_secret = dependency.physical.outputs.primary_db_secret
-  s3_images_bucket = dependency.physical.outputs.guide_images_bucket
-  s3_objects_bucket = dependency.physical.outputs.guide_objects_bucket
-  s3_documents_bucket = dependency.physical.outputs.documents_bucket
-  s3_pdfs_bucket = dependency.physical.outputs.guide_pdfs_bucket
-  memcached_cluster_address = dependency.physical.outputs.memcached_cluster_address
-  dms_task_arn = dependency.physical.outputs.dms_task_arn
+include "common" {
+  path = find_in_parent_folders("common.hcl")
 }

--- a/live/standard/eu-west-2/full/logical/terragrunt.hcl
+++ b/live/standard/eu-west-2/full/logical/terragrunt.hcl
@@ -1,4 +1,4 @@
-skip = get_env("SKIP_FULL", false)
+skip = get_env("SKIP_LOGICAL", false)
 # Terragrunt will copy the Terraform configurations specified by the source parameter, along with any files in the
 # working directory, into a temporary folder, and execute your Terraform commands in that folder.
 terraform {
@@ -6,61 +6,10 @@ terraform {
 }
 
 # Include all settings from the root terragrunt.hcl file
-include {
+include "root" {
   path = find_in_parent_folders()
 }
 
-dependency "physical" {
-  config_path = "../physical"
-
-  mock_outputs = {
-    vpc_id = "temporary-dummy-id"
-    azs_count = 3
-    msk_bootstrap_brokers = "bootstrap-brokers"
-    eks_worker_asg_arns = "dummy-arn1,dummy-arn2"
-    eks_worker_asg_names = "dummy-name1,dummy-name2"
-    eks_cluster_id = "dummy-cluster-id"
-    eks_cluster_access_role_arn = "dummy-arn"
-    eks_oidc_cluster_access_role_name = "dummy-ca-role-arn"
-    termination_handler_role_arn = "dummy-termination-handler-role-arn"
-    termination_handler_sqs_queue_id = "dummy-sqs-id"
-    nlb_dns_name = "dummy-lb-dns"
-    cluster_primary_sg = "dummy-sg"
-    primary_db_secret = "dummy-secret-id"
-    guide_images_bucket = "dummy-images-bucket"
-    guide_objects_bucket = "dummy-objects-bucket"
-    documents_bucket = "dummy-documents-bucket"
-    guide_pdfs_bucket = "dummy-pdfs-bucket"
-    memcached_cluster_address = "dummy-memcache"
-    dms_task_arn = "dummy-dms-arn"
-  }
-}
-
-retryable_errors = [
-  "(?s).*frontegg-db-update is in failed state.*"
-]
-
-inputs = {
-  vpc_id = dependency.physical.outputs.vpc_id
-  azs_count = dependency.physical.outputs.azs_count
-
-  msk_bootstrap_brokers = dependency.physical.outputs.msk_bootstrap_brokers
-
-  eks_cluster_id = dependency.physical.outputs.eks_cluster_id
-  eks_cluster_access_role_arn = dependency.physical.outputs.eks_cluster_access_role_arn
-  eks_oidc_cluster_access_role_name = dependency.physical.outputs.eks_oidc_cluster_access_role_name
-  termination_handler_role_arn = dependency.physical.outputs.termination_handler_role_arn
-  termination_handler_sqs_queue_id = dependency.physical.outputs.termination_handler_sqs_queue_id
-  eks_worker_asg_arns = dependency.physical.outputs.eks_worker_asg_arns
-  eks_worker_asg_names = dependency.physical.outputs.eks_worker_asg_names
-  nlb_dns_name = dependency.physical.outputs.nlb_dns_name
-  cluster_primary_sg = dependency.physical.outputs.cluster_primary_sg
-
-  primary_db_secret = dependency.physical.outputs.primary_db_secret
-  s3_images_bucket = dependency.physical.outputs.guide_images_bucket
-  s3_objects_bucket = dependency.physical.outputs.guide_objects_bucket
-  s3_documents_bucket = dependency.physical.outputs.documents_bucket
-  s3_pdfs_bucket = dependency.physical.outputs.guide_pdfs_bucket
-  memcached_cluster_address = dependency.physical.outputs.memcached_cluster_address
-  dms_task_arn = dependency.physical.outputs.dms_task_arn
+include "common" {
+  path = find_in_parent_folders("common.hcl")
 }

--- a/live/standard/eu-west-2/min/logical/terragrunt.hcl
+++ b/live/standard/eu-west-2/min/logical/terragrunt.hcl
@@ -6,62 +6,10 @@ terraform {
 }
 
 # Include all settings from the root terragrunt.hcl file
-include {
+include "root" {
   path = find_in_parent_folders()
 }
 
-dependency "physical" {
-  config_path = "../physical"
-
-  mock_outputs = {
-    vpc_id = "temporary-dummy-id"
-    azs_count = 3
-    msk_bootstrap_brokers = "bootstrap-brokers"
-    eks_worker_asg_arns = "dummy-arn1,dummy-arn2"
-    eks_worker_asg_names = "dummy-name1,dummy-name2"
-    eks_cluster_id = "dummy-cluster-id"
-    eks_cluster_access_role_arn = "dummy-arn"
-    eks_oidc_cluster_access_role_name = "dummy-ca-role-arn"
-    termination_handler_role_arn = "dummy-termination-handler-role-arn"
-    termination_handler_sqs_queue_id = "dummy-sqs-id"
-    nlb_dns_name = "dummy-lb-dns"
-    cluster_primary_sg = "dummy-sg"
-    primary_db_secret = "dummy-secret-id"
-    guide_images_bucket = "dummy-images-bucket"
-    guide_objects_bucket = "dummy-objects-bucket"
-    documents_bucket = "dummy-documents-bucket"
-    guide_pdfs_bucket = "dummy-pdfs-bucket"
-    memcached_cluster_address = "dummy-memcache"
-    dms_task_arn = "dummy-dms-arn"
-  }
-  mock_outputs_allowed_terraform_commands = ["validate","destroy"]
-}
-
-retryable_errors = [
-  "(?s).*frontegg-db-update is in failed state.*"
-]
-
-inputs = {
-  vpc_id = dependency.physical.outputs.vpc_id
-  azs_count = dependency.physical.outputs.azs_count
-
-  msk_bootstrap_brokers = dependency.physical.outputs.msk_bootstrap_brokers
-
-  eks_cluster_id = dependency.physical.outputs.eks_cluster_id
-  eks_cluster_access_role_arn = dependency.physical.outputs.eks_cluster_access_role_arn
-  eks_oidc_cluster_access_role_name = dependency.physical.outputs.eks_oidc_cluster_access_role_name
-  termination_handler_role_arn = dependency.physical.outputs.termination_handler_role_arn
-  termination_handler_sqs_queue_id = dependency.physical.outputs.termination_handler_sqs_queue_id
-  eks_worker_asg_arns = dependency.physical.outputs.eks_worker_asg_arns
-  eks_worker_asg_names = dependency.physical.outputs.eks_worker_asg_names
-  nlb_dns_name = dependency.physical.outputs.nlb_dns_name
-  cluster_primary_sg = dependency.physical.outputs.cluster_primary_sg
-
-  primary_db_secret = dependency.physical.outputs.primary_db_secret
-  s3_images_bucket = dependency.physical.outputs.guide_images_bucket
-  s3_objects_bucket = dependency.physical.outputs.guide_objects_bucket
-  s3_documents_bucket = dependency.physical.outputs.documents_bucket
-  s3_pdfs_bucket = dependency.physical.outputs.guide_pdfs_bucket
-  memcached_cluster_address = dependency.physical.outputs.memcached_cluster_address
-  dms_task_arn = dependency.physical.outputs.dms_task_arn
+include "common" {
+  path = find_in_parent_folders("common.hcl")
 }

--- a/live/standard/eu-west-2/webhooks/logical/terragrunt.hcl
+++ b/live/standard/eu-west-2/webhooks/logical/terragrunt.hcl
@@ -6,62 +6,10 @@ terraform {
 }
 
 # Include all settings from the root terragrunt.hcl file
-include {
+include "root" {
   path = find_in_parent_folders()
 }
 
-dependency "physical" {
-  config_path = "../physical"
-
-  mock_outputs = {
-    vpc_id = "temporary-dummy-id"
-    azs_count = 3
-    msk_bootstrap_brokers = "bootstrap-brokers"
-    eks_worker_asg_arns = "dummy-arn1,dummy-arn2"
-    eks_worker_asg_names = "dummy-name1,dummy-name2"
-    eks_cluster_id = "dummy-cluster-id"
-    eks_cluster_access_role_arn = "dummy-arn"
-    eks_oidc_cluster_access_role_name = "dummy-ca-role-arn"
-    termination_handler_role_arn = "dummy-termination-handler-role-arn"
-    termination_handler_sqs_queue_id = "dummy-sqs-id"
-    nlb_dns_name = "dummy-lb-dns"
-    cluster_primary_sg = "dummy-sg"
-    primary_db_secret = "dummy-secret-id"
-    guide_images_bucket = "dummy-images-bucket"
-    guide_objects_bucket = "dummy-objects-bucket"
-    documents_bucket = "dummy-documents-bucket"
-    guide_pdfs_bucket = "dummy-pdfs-bucket"
-    memcached_cluster_address = "dummy-memcache"
-    dms_task_arn = "dummy-dms-arn"
-  }
-  mock_outputs_allowed_terraform_commands = ["validate","destroy"]
-}
-
-retryable_errors = [
-  "(?s).*frontegg-db-update is in failed state.*"
-]
-
-inputs = {
-  vpc_id = dependency.physical.outputs.vpc_id
-  azs_count = dependency.physical.outputs.azs_count
-
-  msk_bootstrap_brokers = dependency.physical.outputs.msk_bootstrap_brokers
-
-  eks_cluster_id = dependency.physical.outputs.eks_cluster_id
-  eks_cluster_access_role_arn = dependency.physical.outputs.eks_cluster_access_role_arn
-  eks_oidc_cluster_access_role_name = dependency.physical.outputs.eks_oidc_cluster_access_role_name
-  termination_handler_role_arn = dependency.physical.outputs.termination_handler_role_arn
-  termination_handler_sqs_queue_id = dependency.physical.outputs.termination_handler_sqs_queue_id
-  eks_worker_asg_arns = dependency.physical.outputs.eks_worker_asg_arns
-  eks_worker_asg_names = dependency.physical.outputs.eks_worker_asg_names
-  nlb_dns_name = dependency.physical.outputs.nlb_dns_name
-  cluster_primary_sg = dependency.physical.outputs.cluster_primary_sg
-
-  primary_db_secret = dependency.physical.outputs.primary_db_secret
-  s3_images_bucket = dependency.physical.outputs.guide_images_bucket
-  s3_objects_bucket = dependency.physical.outputs.guide_objects_bucket
-  s3_documents_bucket = dependency.physical.outputs.documents_bucket
-  s3_pdfs_bucket = dependency.physical.outputs.guide_pdfs_bucket
-  memcached_cluster_address = dependency.physical.outputs.memcached_cluster_address
-  dms_task_arn = dependency.physical.outputs.dms_task_arn
+include "common" {
+  path = find_in_parent_folders("common.hcl")
 }

--- a/live/standard/eu-west-3/bi/logical/terragrunt.hcl
+++ b/live/standard/eu-west-3/bi/logical/terragrunt.hcl
@@ -6,62 +6,10 @@ terraform {
 }
 
 # Include all settings from the root terragrunt.hcl file
-include {
+include "root" {
   path = find_in_parent_folders()
 }
 
-dependency "physical" {
-  config_path = "../physical"
-
-  mock_outputs = {
-    vpc_id = "temporary-dummy-id"
-    azs_count = 3
-    msk_bootstrap_brokers = "bootstrap-brokers"
-    eks_worker_asg_arns = "dummy-arn1,dummy-arn2"
-    eks_worker_asg_names = "dummy-name1,dummy-name2"
-    eks_cluster_id = "dummy-cluster-id"
-    eks_cluster_access_role_arn = "dummy-arn"
-    eks_oidc_cluster_access_role_name = "dummy-ca-role-arn"
-    termination_handler_role_arn = "dummy-termination-handler-role-arn"
-    termination_handler_sqs_queue_id = "dummy-sqs-id"
-    nlb_dns_name = "dummy-lb-dns"
-    cluster_primary_sg = "dummy-sg"
-    primary_db_secret = "dummy-secret-id"
-    guide_images_bucket = "dummy-images-bucket"
-    guide_objects_bucket = "dummy-objects-bucket"
-    documents_bucket = "dummy-documents-bucket"
-    guide_pdfs_bucket = "dummy-pdfs-bucket"
-    memcached_cluster_address = "dummy-memcache"
-    dms_task_arn = "dummy-dms-arn"
-  }
-  mock_outputs_allowed_terraform_commands = ["validate","destroy"]
-}
-
-retryable_errors = [
-  "(?s).*frontegg-db-update is in failed state.*"
-]
-
-inputs = {
-  vpc_id = dependency.physical.outputs.vpc_id
-  azs_count = dependency.physical.outputs.azs_count
-
-  msk_bootstrap_brokers = dependency.physical.outputs.msk_bootstrap_brokers
-
-  eks_cluster_id = dependency.physical.outputs.eks_cluster_id
-  eks_cluster_access_role_arn = dependency.physical.outputs.eks_cluster_access_role_arn
-  eks_oidc_cluster_access_role_name = dependency.physical.outputs.eks_oidc_cluster_access_role_name
-  termination_handler_role_arn = dependency.physical.outputs.termination_handler_role_arn
-  termination_handler_sqs_queue_id = dependency.physical.outputs.termination_handler_sqs_queue_id
-  eks_worker_asg_arns = dependency.physical.outputs.eks_worker_asg_arns
-  eks_worker_asg_names = dependency.physical.outputs.eks_worker_asg_names
-  nlb_dns_name = dependency.physical.outputs.nlb_dns_name
-  cluster_primary_sg = dependency.physical.outputs.cluster_primary_sg
-
-  primary_db_secret = dependency.physical.outputs.primary_db_secret
-  s3_images_bucket = dependency.physical.outputs.guide_images_bucket
-  s3_objects_bucket = dependency.physical.outputs.guide_objects_bucket
-  s3_documents_bucket = dependency.physical.outputs.documents_bucket
-  s3_pdfs_bucket = dependency.physical.outputs.guide_pdfs_bucket
-  memcached_cluster_address = dependency.physical.outputs.memcached_cluster_address
-  dms_task_arn = dependency.physical.outputs.dms_task_arn
+include "common" {
+  path = find_in_parent_folders("common.hcl")
 }

--- a/live/standard/eu-west-3/full/logical/terragrunt.hcl
+++ b/live/standard/eu-west-3/full/logical/terragrunt.hcl
@@ -1,4 +1,4 @@
-skip = get_env("SKIP_FULL", false)
+skip = get_env("SKIP_LOGICAL", false)
 # Terragrunt will copy the Terraform configurations specified by the source parameter, along with any files in the
 # working directory, into a temporary folder, and execute your Terraform commands in that folder.
 terraform {
@@ -6,61 +6,10 @@ terraform {
 }
 
 # Include all settings from the root terragrunt.hcl file
-include {
+include "root" {
   path = find_in_parent_folders()
 }
 
-dependency "physical" {
-  config_path = "../physical"
-
-  mock_outputs = {
-    vpc_id = "temporary-dummy-id"
-    azs_count = 3
-    msk_bootstrap_brokers = "bootstrap-brokers"
-    eks_worker_asg_arns = "dummy-arn1,dummy-arn2"
-    eks_worker_asg_names = "dummy-name1,dummy-name2"
-    eks_cluster_id = "dummy-cluster-id"
-    eks_cluster_access_role_arn = "dummy-arn"
-    eks_oidc_cluster_access_role_name = "dummy-ca-role-arn"
-    termination_handler_role_arn = "dummy-termination-handler-role-arn"
-    termination_handler_sqs_queue_id = "dummy-sqs-id"
-    nlb_dns_name = "dummy-lb-dns"
-    cluster_primary_sg = "dummy-sg"
-    primary_db_secret = "dummy-secret-id"
-    guide_images_bucket = "dummy-images-bucket"
-    guide_objects_bucket = "dummy-objects-bucket"
-    documents_bucket = "dummy-documents-bucket"
-    guide_pdfs_bucket = "dummy-pdfs-bucket"
-    memcached_cluster_address = "dummy-memcache"
-    dms_task_arn = "dummy-dms-arn"
-  }
-}
-
-retryable_errors = [
-  "(?s).*frontegg-db-update is in failed state.*"
-]
-
-inputs = {
-  vpc_id = dependency.physical.outputs.vpc_id
-  azs_count = dependency.physical.outputs.azs_count
-
-  msk_bootstrap_brokers = dependency.physical.outputs.msk_bootstrap_brokers
-
-  eks_cluster_id = dependency.physical.outputs.eks_cluster_id
-  eks_cluster_access_role_arn = dependency.physical.outputs.eks_cluster_access_role_arn
-  eks_oidc_cluster_access_role_name = dependency.physical.outputs.eks_oidc_cluster_access_role_name
-  termination_handler_role_arn = dependency.physical.outputs.termination_handler_role_arn
-  termination_handler_sqs_queue_id = dependency.physical.outputs.termination_handler_sqs_queue_id
-  eks_worker_asg_arns = dependency.physical.outputs.eks_worker_asg_arns
-  eks_worker_asg_names = dependency.physical.outputs.eks_worker_asg_names
-  nlb_dns_name = dependency.physical.outputs.nlb_dns_name
-  cluster_primary_sg = dependency.physical.outputs.cluster_primary_sg
-
-  primary_db_secret = dependency.physical.outputs.primary_db_secret
-  s3_images_bucket = dependency.physical.outputs.guide_images_bucket
-  s3_objects_bucket = dependency.physical.outputs.guide_objects_bucket
-  s3_documents_bucket = dependency.physical.outputs.documents_bucket
-  s3_pdfs_bucket = dependency.physical.outputs.guide_pdfs_bucket
-  memcached_cluster_address = dependency.physical.outputs.memcached_cluster_address
-  dms_task_arn = dependency.physical.outputs.dms_task_arn
+include "common" {
+  path = find_in_parent_folders("common.hcl")
 }

--- a/live/standard/eu-west-3/min/logical/terragrunt.hcl
+++ b/live/standard/eu-west-3/min/logical/terragrunt.hcl
@@ -6,62 +6,10 @@ terraform {
 }
 
 # Include all settings from the root terragrunt.hcl file
-include {
+include "root" {
   path = find_in_parent_folders()
 }
 
-dependency "physical" {
-  config_path = "../physical"
-
-  mock_outputs = {
-    vpc_id = "temporary-dummy-id"
-    azs_count = 3
-    msk_bootstrap_brokers = "bootstrap-brokers"
-    eks_worker_asg_arns = "dummy-arn1,dummy-arn2"
-    eks_worker_asg_names = "dummy-name1,dummy-name2"
-    eks_cluster_id = "dummy-cluster-id"
-    eks_cluster_access_role_arn = "dummy-arn"
-    eks_oidc_cluster_access_role_name = "dummy-ca-role-arn"
-    termination_handler_role_arn = "dummy-termination-handler-role-arn"
-    termination_handler_sqs_queue_id = "dummy-sqs-id"
-    nlb_dns_name = "dummy-lb-dns"
-    cluster_primary_sg = "dummy-sg"
-    primary_db_secret = "dummy-secret-id"
-    guide_images_bucket = "dummy-images-bucket"
-    guide_objects_bucket = "dummy-objects-bucket"
-    documents_bucket = "dummy-documents-bucket"
-    guide_pdfs_bucket = "dummy-pdfs-bucket"
-    memcached_cluster_address = "dummy-memcache"
-    dms_task_arn = "dummy-dms-arn"
-  }
-  mock_outputs_allowed_terraform_commands = ["validate","destroy"]
-}
-
-retryable_errors = [
-  "(?s).*frontegg-db-update is in failed state.*"
-]
-
-inputs = {
-  vpc_id = dependency.physical.outputs.vpc_id
-  azs_count = dependency.physical.outputs.azs_count
-
-  msk_bootstrap_brokers = dependency.physical.outputs.msk_bootstrap_brokers
-
-  eks_cluster_id = dependency.physical.outputs.eks_cluster_id
-  eks_cluster_access_role_arn = dependency.physical.outputs.eks_cluster_access_role_arn
-  eks_oidc_cluster_access_role_name = dependency.physical.outputs.eks_oidc_cluster_access_role_name
-  termination_handler_role_arn = dependency.physical.outputs.termination_handler_role_arn
-  termination_handler_sqs_queue_id = dependency.physical.outputs.termination_handler_sqs_queue_id
-  eks_worker_asg_arns = dependency.physical.outputs.eks_worker_asg_arns
-  eks_worker_asg_names = dependency.physical.outputs.eks_worker_asg_names
-  nlb_dns_name = dependency.physical.outputs.nlb_dns_name
-  cluster_primary_sg = dependency.physical.outputs.cluster_primary_sg
-
-  primary_db_secret = dependency.physical.outputs.primary_db_secret
-  s3_images_bucket = dependency.physical.outputs.guide_images_bucket
-  s3_objects_bucket = dependency.physical.outputs.guide_objects_bucket
-  s3_documents_bucket = dependency.physical.outputs.documents_bucket
-  s3_pdfs_bucket = dependency.physical.outputs.guide_pdfs_bucket
-  memcached_cluster_address = dependency.physical.outputs.memcached_cluster_address
-  dms_task_arn = dependency.physical.outputs.dms_task_arn
+include "common" {
+  path = find_in_parent_folders("common.hcl")
 }

--- a/live/standard/eu-west-3/webhooks/logical/terragrunt.hcl
+++ b/live/standard/eu-west-3/webhooks/logical/terragrunt.hcl
@@ -6,62 +6,10 @@ terraform {
 }
 
 # Include all settings from the root terragrunt.hcl file
-include {
+include "root" {
   path = find_in_parent_folders()
 }
 
-dependency "physical" {
-  config_path = "../physical"
-
-  mock_outputs = {
-    vpc_id = "temporary-dummy-id"
-    azs_count = 3
-    msk_bootstrap_brokers = "bootstrap-brokers"
-    eks_worker_asg_arns = "dummy-arn1,dummy-arn2"
-    eks_worker_asg_names = "dummy-name1,dummy-name2"
-    eks_cluster_id = "dummy-cluster-id"
-    eks_cluster_access_role_arn = "dummy-arn"
-    eks_oidc_cluster_access_role_name = "dummy-ca-role-arn"
-    termination_handler_role_arn = "dummy-termination-handler-role-arn"
-    termination_handler_sqs_queue_id = "dummy-sqs-id"
-    nlb_dns_name = "dummy-lb-dns"
-    cluster_primary_sg = "dummy-sg"
-    primary_db_secret = "dummy-secret-id"
-    guide_images_bucket = "dummy-images-bucket"
-    guide_objects_bucket = "dummy-objects-bucket"
-    documents_bucket = "dummy-documents-bucket"
-    guide_pdfs_bucket = "dummy-pdfs-bucket"
-    memcached_cluster_address = "dummy-memcache"
-    dms_task_arn = "dummy-dms-arn"
-  }
-  mock_outputs_allowed_terraform_commands = ["validate","destroy"]
-}
-
-retryable_errors = [
-  "(?s).*frontegg-db-update is in failed state.*"
-]
-
-inputs = {
-  vpc_id = dependency.physical.outputs.vpc_id
-  azs_count = dependency.physical.outputs.azs_count
-
-  msk_bootstrap_brokers = dependency.physical.outputs.msk_bootstrap_brokers
-
-  eks_cluster_id = dependency.physical.outputs.eks_cluster_id
-  eks_cluster_access_role_arn = dependency.physical.outputs.eks_cluster_access_role_arn
-  eks_oidc_cluster_access_role_name = dependency.physical.outputs.eks_oidc_cluster_access_role_name
-  termination_handler_role_arn = dependency.physical.outputs.termination_handler_role_arn
-  termination_handler_sqs_queue_id = dependency.physical.outputs.termination_handler_sqs_queue_id
-  eks_worker_asg_arns = dependency.physical.outputs.eks_worker_asg_arns
-  eks_worker_asg_names = dependency.physical.outputs.eks_worker_asg_names
-  nlb_dns_name = dependency.physical.outputs.nlb_dns_name
-  cluster_primary_sg = dependency.physical.outputs.cluster_primary_sg
-
-  primary_db_secret = dependency.physical.outputs.primary_db_secret
-  s3_images_bucket = dependency.physical.outputs.guide_images_bucket
-  s3_objects_bucket = dependency.physical.outputs.guide_objects_bucket
-  s3_documents_bucket = dependency.physical.outputs.documents_bucket
-  s3_pdfs_bucket = dependency.physical.outputs.guide_pdfs_bucket
-  memcached_cluster_address = dependency.physical.outputs.memcached_cluster_address
-  dms_task_arn = dependency.physical.outputs.dms_task_arn
+include "common" {
+  path = find_in_parent_folders("common.hcl")
 }

--- a/live/standard/us-east-1/bi/logical/terragrunt.hcl
+++ b/live/standard/us-east-1/bi/logical/terragrunt.hcl
@@ -6,62 +6,10 @@ terraform {
 }
 
 # Include all settings from the root terragrunt.hcl file
-include {
+include "root" {
   path = find_in_parent_folders()
 }
 
-dependency "physical" {
-  config_path = "../physical"
-
-  mock_outputs = {
-    vpc_id = "temporary-dummy-id"
-    azs_count = 3
-    msk_bootstrap_brokers = "bootstrap-brokers"
-    eks_worker_asg_arns = "dummy-arn1,dummy-arn2"
-    eks_worker_asg_names = "dummy-name1,dummy-name2"
-    eks_cluster_id = "dummy-cluster-id"
-    eks_cluster_access_role_arn = "dummy-arn"
-    eks_oidc_cluster_access_role_name = "dummy-ca-role-arn"
-    termination_handler_role_arn = "dummy-termination-handler-role-arn"
-    termination_handler_sqs_queue_id = "dummy-sqs-id"
-    nlb_dns_name = "dummy-lb-dns"
-    cluster_primary_sg = "dummy-sg"
-    primary_db_secret = "dummy-secret-id"
-    guide_images_bucket = "dummy-images-bucket"
-    guide_objects_bucket = "dummy-objects-bucket"
-    documents_bucket = "dummy-documents-bucket"
-    guide_pdfs_bucket = "dummy-pdfs-bucket"
-    memcached_cluster_address = "dummy-memcache"
-    dms_task_arn = "dummy-dms-arn"
-  }
-  mock_outputs_allowed_terraform_commands = ["validate","destroy"]
-}
-
-retryable_errors = [
-  "(?s).*frontegg-db-update is in failed state.*"
-]
-
-inputs = {
-  vpc_id = dependency.physical.outputs.vpc_id
-  azs_count = dependency.physical.outputs.azs_count
-
-  msk_bootstrap_brokers = dependency.physical.outputs.msk_bootstrap_brokers
-
-  eks_cluster_id = dependency.physical.outputs.eks_cluster_id
-  eks_cluster_access_role_arn = dependency.physical.outputs.eks_cluster_access_role_arn
-  eks_oidc_cluster_access_role_name = dependency.physical.outputs.eks_oidc_cluster_access_role_name
-  termination_handler_role_arn = dependency.physical.outputs.termination_handler_role_arn
-  termination_handler_sqs_queue_id = dependency.physical.outputs.termination_handler_sqs_queue_id
-  eks_worker_asg_arns = dependency.physical.outputs.eks_worker_asg_arns
-  eks_worker_asg_names = dependency.physical.outputs.eks_worker_asg_names
-  nlb_dns_name = dependency.physical.outputs.nlb_dns_name
-  cluster_primary_sg = dependency.physical.outputs.cluster_primary_sg
-
-  primary_db_secret = dependency.physical.outputs.primary_db_secret
-  s3_images_bucket = dependency.physical.outputs.guide_images_bucket
-  s3_objects_bucket = dependency.physical.outputs.guide_objects_bucket
-  s3_documents_bucket = dependency.physical.outputs.documents_bucket
-  s3_pdfs_bucket = dependency.physical.outputs.guide_pdfs_bucket
-  memcached_cluster_address = dependency.physical.outputs.memcached_cluster_address
-  dms_task_arn = dependency.physical.outputs.dms_task_arn
+include "common" {
+  path = find_in_parent_folders("common.hcl")
 }

--- a/live/standard/us-east-1/full/logical/terragrunt.hcl
+++ b/live/standard/us-east-1/full/logical/terragrunt.hcl
@@ -1,4 +1,4 @@
-skip = get_env("SKIP_FULL", false)
+skip = get_env("SKIP_LOGICAL", false)
 # Terragrunt will copy the Terraform configurations specified by the source parameter, along with any files in the
 # working directory, into a temporary folder, and execute your Terraform commands in that folder.
 terraform {
@@ -6,61 +6,10 @@ terraform {
 }
 
 # Include all settings from the root terragrunt.hcl file
-include {
+include "root" {
   path = find_in_parent_folders()
 }
 
-dependency "physical" {
-  config_path = "../physical"
-
-  mock_outputs = {
-    vpc_id = "temporary-dummy-id"
-    azs_count = 3
-    msk_bootstrap_brokers = "bootstrap-brokers"
-    eks_worker_asg_arns = "dummy-arn1,dummy-arn2"
-    eks_worker_asg_names = "dummy-name1,dummy-name2"
-    eks_cluster_id = "dummy-cluster-id"
-    eks_cluster_access_role_arn = "dummy-arn"
-    eks_oidc_cluster_access_role_name = "dummy-ca-role-arn"
-    termination_handler_role_arn = "dummy-termination-handler-role-arn"
-    termination_handler_sqs_queue_id = "dummy-sqs-id"
-    nlb_dns_name = "dummy-lb-dns"
-    cluster_primary_sg = "dummy-sg"
-    primary_db_secret = "dummy-secret-id"
-    guide_images_bucket = "dummy-images-bucket"
-    guide_objects_bucket = "dummy-objects-bucket"
-    documents_bucket = "dummy-documents-bucket"
-    guide_pdfs_bucket = "dummy-pdfs-bucket"
-    memcached_cluster_address = "dummy-memcache"
-    dms_task_arn = "dummy-dms-arn"
-  }
-}
-
-retryable_errors = [
-  "(?s).*frontegg-db-update is in failed state.*"
-]
-
-inputs = {
-  vpc_id = dependency.physical.outputs.vpc_id
-  azs_count = dependency.physical.outputs.azs_count
-
-  msk_bootstrap_brokers = dependency.physical.outputs.msk_bootstrap_brokers
-
-  eks_cluster_id = dependency.physical.outputs.eks_cluster_id
-  eks_cluster_access_role_arn = dependency.physical.outputs.eks_cluster_access_role_arn
-  eks_oidc_cluster_access_role_name = dependency.physical.outputs.eks_oidc_cluster_access_role_name
-  termination_handler_role_arn = dependency.physical.outputs.termination_handler_role_arn
-  termination_handler_sqs_queue_id = dependency.physical.outputs.termination_handler_sqs_queue_id
-  eks_worker_asg_arns = dependency.physical.outputs.eks_worker_asg_arns
-  eks_worker_asg_names = dependency.physical.outputs.eks_worker_asg_names
-  nlb_dns_name = dependency.physical.outputs.nlb_dns_name
-  cluster_primary_sg = dependency.physical.outputs.cluster_primary_sg
-
-  primary_db_secret = dependency.physical.outputs.primary_db_secret
-  s3_images_bucket = dependency.physical.outputs.guide_images_bucket
-  s3_objects_bucket = dependency.physical.outputs.guide_objects_bucket
-  s3_documents_bucket = dependency.physical.outputs.documents_bucket
-  s3_pdfs_bucket = dependency.physical.outputs.guide_pdfs_bucket
-  memcached_cluster_address = dependency.physical.outputs.memcached_cluster_address
-  dms_task_arn = dependency.physical.outputs.dms_task_arn
+include "common" {
+  path = find_in_parent_folders("common.hcl")
 }

--- a/live/standard/us-east-1/min/logical/terragrunt.hcl
+++ b/live/standard/us-east-1/min/logical/terragrunt.hcl
@@ -6,62 +6,10 @@ terraform {
 }
 
 # Include all settings from the root terragrunt.hcl file
-include {
+include "root" {
   path = find_in_parent_folders()
 }
 
-dependency "physical" {
-  config_path = "../physical"
-
-  mock_outputs = {
-    vpc_id = "temporary-dummy-id"
-    azs_count = 3
-    msk_bootstrap_brokers = "bootstrap-brokers"
-    eks_worker_asg_arns = "dummy-arn1,dummy-arn2"
-    eks_worker_asg_names = "dummy-name1,dummy-name2"
-    eks_cluster_id = "dummy-cluster-id"
-    eks_cluster_access_role_arn = "dummy-arn"
-    eks_oidc_cluster_access_role_name = "dummy-ca-role-arn"
-    termination_handler_role_arn = "dummy-termination-handler-role-arn"
-    termination_handler_sqs_queue_id = "dummy-sqs-id"
-    nlb_dns_name = "dummy-lb-dns"
-    cluster_primary_sg = "dummy-sg"
-    primary_db_secret = "dummy-secret-id"
-    guide_images_bucket = "dummy-images-bucket"
-    guide_objects_bucket = "dummy-objects-bucket"
-    documents_bucket = "dummy-documents-bucket"
-    guide_pdfs_bucket = "dummy-pdfs-bucket"
-    memcached_cluster_address = "dummy-memcache"
-    dms_task_arn = "dummy-dms-arn"
-  }
-  mock_outputs_allowed_terraform_commands = ["validate","destroy"]
-}
-
-retryable_errors = [
-  "(?s).*frontegg-db-update is in failed state.*"
-]
-
-inputs = {
-  vpc_id = dependency.physical.outputs.vpc_id
-  azs_count = dependency.physical.outputs.azs_count
-
-  msk_bootstrap_brokers = dependency.physical.outputs.msk_bootstrap_brokers
-
-  eks_cluster_id = dependency.physical.outputs.eks_cluster_id
-  eks_cluster_access_role_arn = dependency.physical.outputs.eks_cluster_access_role_arn
-  eks_oidc_cluster_access_role_name = dependency.physical.outputs.eks_oidc_cluster_access_role_name
-  termination_handler_role_arn = dependency.physical.outputs.termination_handler_role_arn
-  termination_handler_sqs_queue_id = dependency.physical.outputs.termination_handler_sqs_queue_id
-  eks_worker_asg_arns = dependency.physical.outputs.eks_worker_asg_arns
-  eks_worker_asg_names = dependency.physical.outputs.eks_worker_asg_names
-  nlb_dns_name = dependency.physical.outputs.nlb_dns_name
-  cluster_primary_sg = dependency.physical.outputs.cluster_primary_sg
-
-  primary_db_secret = dependency.physical.outputs.primary_db_secret
-  s3_images_bucket = dependency.physical.outputs.guide_images_bucket
-  s3_objects_bucket = dependency.physical.outputs.guide_objects_bucket
-  s3_documents_bucket = dependency.physical.outputs.documents_bucket
-  s3_pdfs_bucket = dependency.physical.outputs.guide_pdfs_bucket
-  memcached_cluster_address = dependency.physical.outputs.memcached_cluster_address
-  dms_task_arn = dependency.physical.outputs.dms_task_arn
+include "common" {
+  path = find_in_parent_folders("common.hcl")
 }

--- a/live/standard/us-east-1/webhooks/logical/terragrunt.hcl
+++ b/live/standard/us-east-1/webhooks/logical/terragrunt.hcl
@@ -6,62 +6,10 @@ terraform {
 }
 
 # Include all settings from the root terragrunt.hcl file
-include {
+include "root" {
   path = find_in_parent_folders()
 }
 
-dependency "physical" {
-  config_path = "../physical"
-
-  mock_outputs = {
-    vpc_id = "temporary-dummy-id"
-    azs_count = 3
-    msk_bootstrap_brokers = "bootstrap-brokers"
-    eks_worker_asg_arns = "dummy-arn1,dummy-arn2"
-    eks_worker_asg_names = "dummy-name1,dummy-name2"
-    eks_cluster_id = "dummy-cluster-id"
-    eks_cluster_access_role_arn = "dummy-arn"
-    eks_oidc_cluster_access_role_name = "dummy-ca-role-arn"
-    termination_handler_role_arn = "dummy-termination-handler-role-arn"
-    termination_handler_sqs_queue_id = "dummy-sqs-id"
-    nlb_dns_name = "dummy-lb-dns"
-    cluster_primary_sg = "dummy-sg"
-    primary_db_secret = "dummy-secret-id"
-    guide_images_bucket = "dummy-images-bucket"
-    guide_objects_bucket = "dummy-objects-bucket"
-    documents_bucket = "dummy-documents-bucket"
-    guide_pdfs_bucket = "dummy-pdfs-bucket"
-    memcached_cluster_address = "dummy-memcache"
-    dms_task_arn = "dummy-dms-arn"
-  }
-  mock_outputs_allowed_terraform_commands = ["validate","destroy"]
-}
-
-retryable_errors = [
-  "(?s).*frontegg-db-update is in failed state.*"
-]
-
-inputs = {
-  vpc_id = dependency.physical.outputs.vpc_id
-  azs_count = dependency.physical.outputs.azs_count
-
-  msk_bootstrap_brokers = dependency.physical.outputs.msk_bootstrap_brokers
-
-  eks_cluster_id = dependency.physical.outputs.eks_cluster_id
-  eks_cluster_access_role_arn = dependency.physical.outputs.eks_cluster_access_role_arn
-  eks_oidc_cluster_access_role_name = dependency.physical.outputs.eks_oidc_cluster_access_role_name
-  termination_handler_role_arn = dependency.physical.outputs.termination_handler_role_arn
-  termination_handler_sqs_queue_id = dependency.physical.outputs.termination_handler_sqs_queue_id
-  eks_worker_asg_arns = dependency.physical.outputs.eks_worker_asg_arns
-  eks_worker_asg_names = dependency.physical.outputs.eks_worker_asg_names
-  nlb_dns_name = dependency.physical.outputs.nlb_dns_name
-  cluster_primary_sg = dependency.physical.outputs.cluster_primary_sg
-
-  primary_db_secret = dependency.physical.outputs.primary_db_secret
-  s3_images_bucket = dependency.physical.outputs.guide_images_bucket
-  s3_objects_bucket = dependency.physical.outputs.guide_objects_bucket
-  s3_documents_bucket = dependency.physical.outputs.documents_bucket
-  s3_pdfs_bucket = dependency.physical.outputs.guide_pdfs_bucket
-  memcached_cluster_address = dependency.physical.outputs.memcached_cluster_address
-  dms_task_arn = dependency.physical.outputs.dms_task_arn
+include "common" {
+  path = find_in_parent_folders("common.hcl")
 }

--- a/live/standard/us-east-2/bi/logical/terragrunt.hcl
+++ b/live/standard/us-east-2/bi/logical/terragrunt.hcl
@@ -6,62 +6,10 @@ terraform {
 }
 
 # Include all settings from the root terragrunt.hcl file
-include {
+include "root" {
   path = find_in_parent_folders()
 }
 
-dependency "physical" {
-  config_path = "../physical"
-
-  mock_outputs = {
-    vpc_id = "temporary-dummy-id"
-    azs_count = 3
-    msk_bootstrap_brokers = "bootstrap-brokers"
-    eks_worker_asg_arns = "dummy-arn1,dummy-arn2"
-    eks_worker_asg_names = "dummy-name1,dummy-name2"
-    eks_cluster_id = "dummy-cluster-id"
-    eks_cluster_access_role_arn = "dummy-arn"
-    eks_oidc_cluster_access_role_name = "dummy-ca-role-arn"
-    termination_handler_role_arn = "dummy-termination-handler-role-arn"
-    termination_handler_sqs_queue_id = "dummy-sqs-id"
-    nlb_dns_name = "dummy-lb-dns"
-    cluster_primary_sg = "dummy-sg"
-    primary_db_secret = "dummy-secret-id"
-    guide_images_bucket = "dummy-images-bucket"
-    guide_objects_bucket = "dummy-objects-bucket"
-    documents_bucket = "dummy-documents-bucket"
-    guide_pdfs_bucket = "dummy-pdfs-bucket"
-    memcached_cluster_address = "dummy-memcache"
-    dms_task_arn = "dummy-dms-arn"
-  }
-  mock_outputs_allowed_terraform_commands = ["validate","destroy"]
-}
-
-retryable_errors = [
-  "(?s).*frontegg-db-update is in failed state.*"
-]
-
-inputs = {
-  vpc_id = dependency.physical.outputs.vpc_id
-  azs_count = dependency.physical.outputs.azs_count
-
-  msk_bootstrap_brokers = dependency.physical.outputs.msk_bootstrap_brokers
-
-  eks_cluster_id = dependency.physical.outputs.eks_cluster_id
-  eks_cluster_access_role_arn = dependency.physical.outputs.eks_cluster_access_role_arn
-  eks_oidc_cluster_access_role_name = dependency.physical.outputs.eks_oidc_cluster_access_role_name
-  termination_handler_role_arn = dependency.physical.outputs.termination_handler_role_arn
-  termination_handler_sqs_queue_id = dependency.physical.outputs.termination_handler_sqs_queue_id
-  eks_worker_asg_arns = dependency.physical.outputs.eks_worker_asg_arns
-  eks_worker_asg_names = dependency.physical.outputs.eks_worker_asg_names
-  nlb_dns_name = dependency.physical.outputs.nlb_dns_name
-  cluster_primary_sg = dependency.physical.outputs.cluster_primary_sg
-
-  primary_db_secret = dependency.physical.outputs.primary_db_secret
-  s3_images_bucket = dependency.physical.outputs.guide_images_bucket
-  s3_objects_bucket = dependency.physical.outputs.guide_objects_bucket
-  s3_documents_bucket = dependency.physical.outputs.documents_bucket
-  s3_pdfs_bucket = dependency.physical.outputs.guide_pdfs_bucket
-  memcached_cluster_address = dependency.physical.outputs.memcached_cluster_address
-  dms_task_arn = dependency.physical.outputs.dms_task_arn
+include "common" {
+  path = find_in_parent_folders("common.hcl")
 }

--- a/live/standard/us-east-2/full/logical/terragrunt.hcl
+++ b/live/standard/us-east-2/full/logical/terragrunt.hcl
@@ -1,4 +1,4 @@
-skip = get_env("SKIP_FULL", false)
+skip = get_env("SKIP_LOGICAL", false)
 # Terragrunt will copy the Terraform configurations specified by the source parameter, along with any files in the
 # working directory, into a temporary folder, and execute your Terraform commands in that folder.
 terraform {
@@ -6,61 +6,10 @@ terraform {
 }
 
 # Include all settings from the root terragrunt.hcl file
-include {
+include "root" {
   path = find_in_parent_folders()
 }
 
-dependency "physical" {
-  config_path = "../physical"
-
-  mock_outputs = {
-    vpc_id = "temporary-dummy-id"
-    azs_count = 3
-    msk_bootstrap_brokers = "bootstrap-brokers"
-    eks_worker_asg_arns = "dummy-arn1,dummy-arn2"
-    eks_worker_asg_names = "dummy-name1,dummy-name2"
-    eks_cluster_id = "dummy-cluster-id"
-    eks_cluster_access_role_arn = "dummy-arn"
-    eks_oidc_cluster_access_role_name = "dummy-ca-role-arn"
-    termination_handler_role_arn = "dummy-termination-handler-role-arn"
-    termination_handler_sqs_queue_id = "dummy-sqs-id"
-    nlb_dns_name = "dummy-lb-dns"
-    cluster_primary_sg = "dummy-sg"
-    primary_db_secret = "dummy-secret-id"
-    guide_images_bucket = "dummy-images-bucket"
-    guide_objects_bucket = "dummy-objects-bucket"
-    documents_bucket = "dummy-documents-bucket"
-    guide_pdfs_bucket = "dummy-pdfs-bucket"
-    memcached_cluster_address = "dummy-memcache"
-    dms_task_arn = "dummy-dms-arn"
-  }
-}
-
-retryable_errors = [
-  "(?s).*frontegg-db-update is in failed state.*"
-]
-
-inputs = {
-  vpc_id = dependency.physical.outputs.vpc_id
-  azs_count = dependency.physical.outputs.azs_count
-
-  msk_bootstrap_brokers = dependency.physical.outputs.msk_bootstrap_brokers
-
-  eks_cluster_id = dependency.physical.outputs.eks_cluster_id
-  eks_cluster_access_role_arn = dependency.physical.outputs.eks_cluster_access_role_arn
-  eks_oidc_cluster_access_role_name = dependency.physical.outputs.eks_oidc_cluster_access_role_name
-  termination_handler_role_arn = dependency.physical.outputs.termination_handler_role_arn
-  termination_handler_sqs_queue_id = dependency.physical.outputs.termination_handler_sqs_queue_id
-  eks_worker_asg_arns = dependency.physical.outputs.eks_worker_asg_arns
-  eks_worker_asg_names = dependency.physical.outputs.eks_worker_asg_names
-  nlb_dns_name = dependency.physical.outputs.nlb_dns_name
-  cluster_primary_sg = dependency.physical.outputs.cluster_primary_sg
-
-  primary_db_secret = dependency.physical.outputs.primary_db_secret
-  s3_images_bucket = dependency.physical.outputs.guide_images_bucket
-  s3_objects_bucket = dependency.physical.outputs.guide_objects_bucket
-  s3_documents_bucket = dependency.physical.outputs.documents_bucket
-  s3_pdfs_bucket = dependency.physical.outputs.guide_pdfs_bucket
-  memcached_cluster_address = dependency.physical.outputs.memcached_cluster_address
-  dms_task_arn = dependency.physical.outputs.dms_task_arn
+include "common" {
+  path = find_in_parent_folders("common.hcl")
 }

--- a/live/standard/us-east-2/min/logical/terragrunt.hcl
+++ b/live/standard/us-east-2/min/logical/terragrunt.hcl
@@ -6,62 +6,10 @@ terraform {
 }
 
 # Include all settings from the root terragrunt.hcl file
-include {
+include "root" {
   path = find_in_parent_folders()
 }
 
-dependency "physical" {
-  config_path = "../physical"
-
-  mock_outputs = {
-    vpc_id = "temporary-dummy-id"
-    azs_count = 3
-    msk_bootstrap_brokers = "bootstrap-brokers"
-    eks_worker_asg_arns = "dummy-arn1,dummy-arn2"
-    eks_worker_asg_names = "dummy-name1,dummy-name2"
-    eks_cluster_id = "dummy-cluster-id"
-    eks_cluster_access_role_arn = "dummy-arn"
-    eks_oidc_cluster_access_role_name = "dummy-ca-role-arn"
-    termination_handler_role_arn = "dummy-termination-handler-role-arn"
-    termination_handler_sqs_queue_id = "dummy-sqs-id"
-    nlb_dns_name = "dummy-lb-dns"
-    cluster_primary_sg = "dummy-sg"
-    primary_db_secret = "dummy-secret-id"
-    guide_images_bucket = "dummy-images-bucket"
-    guide_objects_bucket = "dummy-objects-bucket"
-    documents_bucket = "dummy-documents-bucket"
-    guide_pdfs_bucket = "dummy-pdfs-bucket"
-    memcached_cluster_address = "dummy-memcache"
-    dms_task_arn = "dummy-dms-arn"
-  }
-  mock_outputs_allowed_terraform_commands = ["validate","destroy"]
-}
-
-retryable_errors = [
-  "(?s).*frontegg-db-update is in failed state.*"
-]
-
-inputs = {
-  vpc_id = dependency.physical.outputs.vpc_id
-  azs_count = dependency.physical.outputs.azs_count
-
-  msk_bootstrap_brokers = dependency.physical.outputs.msk_bootstrap_brokers
-
-  eks_cluster_id = dependency.physical.outputs.eks_cluster_id
-  eks_cluster_access_role_arn = dependency.physical.outputs.eks_cluster_access_role_arn
-  eks_oidc_cluster_access_role_name = dependency.physical.outputs.eks_oidc_cluster_access_role_name
-  termination_handler_role_arn = dependency.physical.outputs.termination_handler_role_arn
-  termination_handler_sqs_queue_id = dependency.physical.outputs.termination_handler_sqs_queue_id
-  eks_worker_asg_arns = dependency.physical.outputs.eks_worker_asg_arns
-  eks_worker_asg_names = dependency.physical.outputs.eks_worker_asg_names
-  nlb_dns_name = dependency.physical.outputs.nlb_dns_name
-  cluster_primary_sg = dependency.physical.outputs.cluster_primary_sg
-
-  primary_db_secret = dependency.physical.outputs.primary_db_secret
-  s3_images_bucket = dependency.physical.outputs.guide_images_bucket
-  s3_objects_bucket = dependency.physical.outputs.guide_objects_bucket
-  s3_documents_bucket = dependency.physical.outputs.documents_bucket
-  s3_pdfs_bucket = dependency.physical.outputs.guide_pdfs_bucket
-  memcached_cluster_address = dependency.physical.outputs.memcached_cluster_address
-  dms_task_arn = dependency.physical.outputs.dms_task_arn
+include "common" {
+  path = find_in_parent_folders("common.hcl")
 }

--- a/live/standard/us-east-2/webhooks/logical/terragrunt.hcl
+++ b/live/standard/us-east-2/webhooks/logical/terragrunt.hcl
@@ -6,62 +6,10 @@ terraform {
 }
 
 # Include all settings from the root terragrunt.hcl file
-include {
+include "root" {
   path = find_in_parent_folders()
 }
 
-dependency "physical" {
-  config_path = "../physical"
-
-  mock_outputs = {
-    vpc_id = "temporary-dummy-id"
-    azs_count = 3
-    msk_bootstrap_brokers = "bootstrap-brokers"
-    eks_worker_asg_arns = "dummy-arn1,dummy-arn2"
-    eks_worker_asg_names = "dummy-name1,dummy-name2"
-    eks_cluster_id = "dummy-cluster-id"
-    eks_cluster_access_role_arn = "dummy-arn"
-    eks_oidc_cluster_access_role_name = "dummy-ca-role-arn"
-    termination_handler_role_arn = "dummy-termination-handler-role-arn"
-    termination_handler_sqs_queue_id = "dummy-sqs-id"
-    nlb_dns_name = "dummy-lb-dns"
-    cluster_primary_sg = "dummy-sg"
-    primary_db_secret = "dummy-secret-id"
-    guide_images_bucket = "dummy-images-bucket"
-    guide_objects_bucket = "dummy-objects-bucket"
-    documents_bucket = "dummy-documents-bucket"
-    guide_pdfs_bucket = "dummy-pdfs-bucket"
-    memcached_cluster_address = "dummy-memcache"
-    dms_task_arn = "dummy-dms-arn"
-  }
-  mock_outputs_allowed_terraform_commands = ["validate","destroy"]
-}
-
-retryable_errors = [
-  "(?s).*frontegg-db-update is in failed state.*"
-]
-
-inputs = {
-  vpc_id = dependency.physical.outputs.vpc_id
-  azs_count = dependency.physical.outputs.azs_count
-
-  msk_bootstrap_brokers = dependency.physical.outputs.msk_bootstrap_brokers
-
-  eks_cluster_id = dependency.physical.outputs.eks_cluster_id
-  eks_cluster_access_role_arn = dependency.physical.outputs.eks_cluster_access_role_arn
-  eks_oidc_cluster_access_role_name = dependency.physical.outputs.eks_oidc_cluster_access_role_name
-  termination_handler_role_arn = dependency.physical.outputs.termination_handler_role_arn
-  termination_handler_sqs_queue_id = dependency.physical.outputs.termination_handler_sqs_queue_id
-  eks_worker_asg_arns = dependency.physical.outputs.eks_worker_asg_arns
-  eks_worker_asg_names = dependency.physical.outputs.eks_worker_asg_names
-  nlb_dns_name = dependency.physical.outputs.nlb_dns_name
-  cluster_primary_sg = dependency.physical.outputs.cluster_primary_sg
-
-  primary_db_secret = dependency.physical.outputs.primary_db_secret
-  s3_images_bucket = dependency.physical.outputs.guide_images_bucket
-  s3_objects_bucket = dependency.physical.outputs.guide_objects_bucket
-  s3_documents_bucket = dependency.physical.outputs.documents_bucket
-  s3_pdfs_bucket = dependency.physical.outputs.guide_pdfs_bucket
-  memcached_cluster_address = dependency.physical.outputs.memcached_cluster_address
-  dms_task_arn = dependency.physical.outputs.dms_task_arn
+include "common" {
+  path = find_in_parent_folders("common.hcl")
 }

--- a/live/standard/us-west-2/bi/logical/terragrunt.hcl
+++ b/live/standard/us-west-2/bi/logical/terragrunt.hcl
@@ -6,62 +6,10 @@ terraform {
 }
 
 # Include all settings from the root terragrunt.hcl file
-include {
+include "root" {
   path = find_in_parent_folders()
 }
 
-dependency "physical" {
-  config_path = "../physical"
-
-  mock_outputs = {
-    vpc_id = "temporary-dummy-id"
-    azs_count = 3
-    msk_bootstrap_brokers = "bootstrap-brokers"
-    eks_worker_asg_arns = "dummy-arn1,dummy-arn2"
-    eks_worker_asg_names = "dummy-name1,dummy-name2"
-    eks_cluster_id = "dummy-cluster-id"
-    eks_cluster_access_role_arn = "dummy-arn"
-    eks_oidc_cluster_access_role_name = "dummy-ca-role-arn"
-    termination_handler_role_arn = "dummy-termination-handler-role-arn"
-    termination_handler_sqs_queue_id = "dummy-sqs-id"
-    nlb_dns_name = "dummy-lb-dns"
-    cluster_primary_sg = "dummy-sg"
-    primary_db_secret = "dummy-secret-id"
-    guide_images_bucket = "dummy-images-bucket"
-    guide_objects_bucket = "dummy-objects-bucket"
-    documents_bucket = "dummy-documents-bucket"
-    guide_pdfs_bucket = "dummy-pdfs-bucket"
-    memcached_cluster_address = "dummy-memcache"
-    dms_task_arn = "dummy-dms-arn"
-  }
-  mock_outputs_allowed_terraform_commands = ["validate","destroy"]
-}
-
-retryable_errors = [
-  "(?s).*frontegg-db-update is in failed state.*"
-]
-
-inputs = {
-  vpc_id = dependency.physical.outputs.vpc_id
-  azs_count = dependency.physical.outputs.azs_count
-
-  msk_bootstrap_brokers = dependency.physical.outputs.msk_bootstrap_brokers
-
-  eks_cluster_id = dependency.physical.outputs.eks_cluster_id
-  eks_cluster_access_role_arn = dependency.physical.outputs.eks_cluster_access_role_arn
-  eks_oidc_cluster_access_role_name = dependency.physical.outputs.eks_oidc_cluster_access_role_name
-  termination_handler_role_arn = dependency.physical.outputs.termination_handler_role_arn
-  termination_handler_sqs_queue_id = dependency.physical.outputs.termination_handler_sqs_queue_id
-  eks_worker_asg_arns = dependency.physical.outputs.eks_worker_asg_arns
-  eks_worker_asg_names = dependency.physical.outputs.eks_worker_asg_names
-  nlb_dns_name = dependency.physical.outputs.nlb_dns_name
-  cluster_primary_sg = dependency.physical.outputs.cluster_primary_sg
-
-  primary_db_secret = dependency.physical.outputs.primary_db_secret
-  s3_images_bucket = dependency.physical.outputs.guide_images_bucket
-  s3_objects_bucket = dependency.physical.outputs.guide_objects_bucket
-  s3_documents_bucket = dependency.physical.outputs.documents_bucket
-  s3_pdfs_bucket = dependency.physical.outputs.guide_pdfs_bucket
-  memcached_cluster_address = dependency.physical.outputs.memcached_cluster_address
-  dms_task_arn = dependency.physical.outputs.dms_task_arn
+include "common" {
+  path = find_in_parent_folders("common.hcl")
 }

--- a/live/standard/us-west-2/full/logical/terragrunt.hcl
+++ b/live/standard/us-west-2/full/logical/terragrunt.hcl
@@ -1,4 +1,4 @@
-skip = get_env("SKIP_FULL", false)
+skip = get_env("SKIP_LOGICAL", false)
 # Terragrunt will copy the Terraform configurations specified by the source parameter, along with any files in the
 # working directory, into a temporary folder, and execute your Terraform commands in that folder.
 terraform {
@@ -6,61 +6,10 @@ terraform {
 }
 
 # Include all settings from the root terragrunt.hcl file
-include {
+include "root" {
   path = find_in_parent_folders()
 }
 
-dependency "physical" {
-  config_path = "../physical"
-
-  mock_outputs = {
-    vpc_id = "temporary-dummy-id"
-    azs_count = 3
-    msk_bootstrap_brokers = "bootstrap-brokers"
-    eks_worker_asg_arns = "dummy-arn1,dummy-arn2"
-    eks_worker_asg_names = "dummy-name1,dummy-name2"
-    eks_cluster_id = "dummy-cluster-id"
-    eks_cluster_access_role_arn = "dummy-arn"
-    eks_oidc_cluster_access_role_name = "dummy-ca-role-arn"
-    termination_handler_role_arn = "dummy-termination-handler-role-arn"
-    termination_handler_sqs_queue_id = "dummy-sqs-id"
-    nlb_dns_name = "dummy-lb-dns"
-    cluster_primary_sg = "dummy-sg"
-    primary_db_secret = "dummy-secret-id"
-    guide_images_bucket = "dummy-images-bucket"
-    guide_objects_bucket = "dummy-objects-bucket"
-    documents_bucket = "dummy-documents-bucket"
-    guide_pdfs_bucket = "dummy-pdfs-bucket"
-    memcached_cluster_address = "dummy-memcache"
-    dms_task_arn = "dummy-dms-arn"
-  }
-}
-
-retryable_errors = [
-  "(?s).*frontegg-db-update is in failed state.*"
-]
-
-inputs = {
-  vpc_id = dependency.physical.outputs.vpc_id
-  azs_count = dependency.physical.outputs.azs_count
-
-  msk_bootstrap_brokers = dependency.physical.outputs.msk_bootstrap_brokers
-
-  eks_cluster_id = dependency.physical.outputs.eks_cluster_id
-  eks_cluster_access_role_arn = dependency.physical.outputs.eks_cluster_access_role_arn
-  eks_oidc_cluster_access_role_name = dependency.physical.outputs.eks_oidc_cluster_access_role_name
-  termination_handler_role_arn = dependency.physical.outputs.termination_handler_role_arn
-  termination_handler_sqs_queue_id = dependency.physical.outputs.termination_handler_sqs_queue_id
-  eks_worker_asg_arns = dependency.physical.outputs.eks_worker_asg_arns
-  eks_worker_asg_names = dependency.physical.outputs.eks_worker_asg_names
-  nlb_dns_name = dependency.physical.outputs.nlb_dns_name
-  cluster_primary_sg = dependency.physical.outputs.cluster_primary_sg
-
-  primary_db_secret = dependency.physical.outputs.primary_db_secret
-  s3_images_bucket = dependency.physical.outputs.guide_images_bucket
-  s3_objects_bucket = dependency.physical.outputs.guide_objects_bucket
-  s3_documents_bucket = dependency.physical.outputs.documents_bucket
-  s3_pdfs_bucket = dependency.physical.outputs.guide_pdfs_bucket
-  memcached_cluster_address = dependency.physical.outputs.memcached_cluster_address
-  dms_task_arn = dependency.physical.outputs.dms_task_arn
+include "common" {
+  path = find_in_parent_folders("common.hcl")
 }

--- a/live/standard/us-west-2/min/logical/terragrunt.hcl
+++ b/live/standard/us-west-2/min/logical/terragrunt.hcl
@@ -6,62 +6,10 @@ terraform {
 }
 
 # Include all settings from the root terragrunt.hcl file
-include {
+include "root" {
   path = find_in_parent_folders()
 }
 
-dependency "physical" {
-  config_path = "../physical"
-
-  mock_outputs = {
-    vpc_id = "temporary-dummy-id"
-    azs_count = 3
-    msk_bootstrap_brokers = "bootstrap-brokers"
-    eks_worker_asg_arns = "dummy-arn1,dummy-arn2"
-    eks_worker_asg_names = "dummy-name1,dummy-name2"
-    eks_cluster_id = "dummy-cluster-id"
-    eks_cluster_access_role_arn = "dummy-arn"
-    eks_oidc_cluster_access_role_name = "dummy-ca-role-arn"
-    termination_handler_role_arn = "dummy-termination-handler-role-arn"
-    termination_handler_sqs_queue_id = "dummy-sqs-id"
-    nlb_dns_name = "dummy-lb-dns"
-    cluster_primary_sg = "dummy-sg"
-    primary_db_secret = "dummy-secret-id"
-    guide_images_bucket = "dummy-images-bucket"
-    guide_objects_bucket = "dummy-objects-bucket"
-    documents_bucket = "dummy-documents-bucket"
-    guide_pdfs_bucket = "dummy-pdfs-bucket"
-    memcached_cluster_address = "dummy-memcache"
-    dms_task_arn = "dummy-dms-arn"
-  }
-  mock_outputs_allowed_terraform_commands = ["validate","destroy"]
-}
-
-retryable_errors = [
-  "(?s).*frontegg-db-update is in failed state.*"
-]
-
-inputs = {
-  vpc_id = dependency.physical.outputs.vpc_id
-  azs_count = dependency.physical.outputs.azs_count
-
-  msk_bootstrap_brokers = dependency.physical.outputs.msk_bootstrap_brokers
-
-  eks_cluster_id = dependency.physical.outputs.eks_cluster_id
-  eks_cluster_access_role_arn = dependency.physical.outputs.eks_cluster_access_role_arn
-  eks_oidc_cluster_access_role_name = dependency.physical.outputs.eks_oidc_cluster_access_role_name
-  termination_handler_role_arn = dependency.physical.outputs.termination_handler_role_arn
-  termination_handler_sqs_queue_id = dependency.physical.outputs.termination_handler_sqs_queue_id
-  eks_worker_asg_arns = dependency.physical.outputs.eks_worker_asg_arns
-  eks_worker_asg_names = dependency.physical.outputs.eks_worker_asg_names
-  nlb_dns_name = dependency.physical.outputs.nlb_dns_name
-  cluster_primary_sg = dependency.physical.outputs.cluster_primary_sg
-
-  primary_db_secret = dependency.physical.outputs.primary_db_secret
-  s3_images_bucket = dependency.physical.outputs.guide_images_bucket
-  s3_objects_bucket = dependency.physical.outputs.guide_objects_bucket
-  s3_documents_bucket = dependency.physical.outputs.documents_bucket
-  s3_pdfs_bucket = dependency.physical.outputs.guide_pdfs_bucket
-  memcached_cluster_address = dependency.physical.outputs.memcached_cluster_address
-  dms_task_arn = dependency.physical.outputs.dms_task_arn
+include "common" {
+  path = find_in_parent_folders("common.hcl")
 }

--- a/live/standard/us-west-2/webhooks/logical/terragrunt.hcl
+++ b/live/standard/us-west-2/webhooks/logical/terragrunt.hcl
@@ -6,62 +6,10 @@ terraform {
 }
 
 # Include all settings from the root terragrunt.hcl file
-include {
+include "root" {
   path = find_in_parent_folders()
 }
 
-dependency "physical" {
-  config_path = "../physical"
-
-  mock_outputs = {
-    vpc_id = "temporary-dummy-id"
-    azs_count = 3
-    msk_bootstrap_brokers = "bootstrap-brokers"
-    eks_worker_asg_arns = "dummy-arn1,dummy-arn2"
-    eks_worker_asg_names = "dummy-name1,dummy-name2"
-    eks_cluster_id = "dummy-cluster-id"
-    eks_cluster_access_role_arn = "dummy-arn"
-    eks_oidc_cluster_access_role_name = "dummy-ca-role-arn"
-    termination_handler_role_arn = "dummy-termination-handler-role-arn"
-    termination_handler_sqs_queue_id = "dummy-sqs-id"
-    nlb_dns_name = "dummy-lb-dns"
-    cluster_primary_sg = "dummy-sg"
-    primary_db_secret = "dummy-secret-id"
-    guide_images_bucket = "dummy-images-bucket"
-    guide_objects_bucket = "dummy-objects-bucket"
-    documents_bucket = "dummy-documents-bucket"
-    guide_pdfs_bucket = "dummy-pdfs-bucket"
-    memcached_cluster_address = "dummy-memcache"
-    dms_task_arn = "dummy-dms-arn"
-  }
-  mock_outputs_allowed_terraform_commands = ["validate","destroy"]
-}
-
-retryable_errors = [
-  "(?s).*frontegg-db-update is in failed state.*"
-]
-
-inputs = {
-  vpc_id = dependency.physical.outputs.vpc_id
-  azs_count = dependency.physical.outputs.azs_count
-
-  msk_bootstrap_brokers = dependency.physical.outputs.msk_bootstrap_brokers
-
-  eks_cluster_id = dependency.physical.outputs.eks_cluster_id
-  eks_cluster_access_role_arn = dependency.physical.outputs.eks_cluster_access_role_arn
-  eks_oidc_cluster_access_role_name = dependency.physical.outputs.eks_oidc_cluster_access_role_name
-  termination_handler_role_arn = dependency.physical.outputs.termination_handler_role_arn
-  termination_handler_sqs_queue_id = dependency.physical.outputs.termination_handler_sqs_queue_id
-  eks_worker_asg_arns = dependency.physical.outputs.eks_worker_asg_arns
-  eks_worker_asg_names = dependency.physical.outputs.eks_worker_asg_names
-  nlb_dns_name = dependency.physical.outputs.nlb_dns_name
-  cluster_primary_sg = dependency.physical.outputs.cluster_primary_sg
-
-  primary_db_secret = dependency.physical.outputs.primary_db_secret
-  s3_images_bucket = dependency.physical.outputs.guide_images_bucket
-  s3_objects_bucket = dependency.physical.outputs.guide_objects_bucket
-  s3_documents_bucket = dependency.physical.outputs.documents_bucket
-  s3_pdfs_bucket = dependency.physical.outputs.guide_pdfs_bucket
-  memcached_cluster_address = dependency.physical.outputs.memcached_cluster_address
-  dms_task_arn = dependency.physical.outputs.dms_task_arn
+include "common" {
+  path = find_in_parent_folders("common.hcl")
 }


### PR DESCRIPTION
As I've made changes to the terragrunt config it's been made clear that maintaining an identical copy of the configuration in 30+ folders is a bad idea. Instead I coalesced all the common blocks and config into 1 file `common.hcl` in the terragrunt live root. We still have config duplication but I think what we have now is a good balance between keeping it DRY and still allowing for flexibility during development as that is what the live environment is meant for.

In addition to this refactor I've also moved the helmignore terragrunt workaround fix to the terragrunt config itself and out of the terraform in an effort to keep the configs for each layer of the infra separate. Terraform does not need to know about things specific only to terragrunt.

Note for CR: You should only need to validate one of the `logical/terragrunt.hcl` files as they are all copied and pasted to the others.

Signed-off-by: David Della Vecchia <ddv@dozuki.com>