### PR TITLE
Allow multiple ingress CIDRs for app and dashboard

### DIFF
--- a/cloudprem/physical/nlb.tf
+++ b/cloudprem/physical/nlb.tf
@@ -3,7 +3,7 @@ resource "aws_security_group_rule" "replicated_ui_access" {
   from_port         = 32001
   to_port           = 32001
   protocol          = "tcp"
-  cidr_blocks       = [var.replicated_ui_access_cidr] #tfsec:ignore:aws-vpc-no-public-ingress-sgr
+  cidr_blocks       = var.replicated_ui_access_cidrs #tfsec:ignore:aws-vpc-no-public-ingress-sgr
   security_group_id = module.eks_cluster.worker_security_group_id
   description       = "Access to the replicated UI"
 }

--- a/cloudprem/physical/nlb.tf
+++ b/cloudprem/physical/nlb.tf
@@ -13,7 +13,7 @@ resource "aws_security_group_rule" "app_access_https" {
   from_port         = 32005
   to_port           = 32005
   protocol          = "tcp"
-  cidr_blocks       = [var.app_access_cidr] #tfsec:ignore:aws-vpc-no-public-ingress-sgr
+  cidr_blocks       = var.app_access_cidrs #tfsec:ignore:aws-vpc-no-public-ingress-sgr
   security_group_id = module.eks_cluster.worker_security_group_id
   description       = "Access to application"
 }
@@ -23,7 +23,7 @@ resource "aws_security_group_rule" "app_access_http" {
   from_port         = 32010
   to_port           = 32010
   protocol          = "tcp"
-  cidr_blocks       = [var.app_access_cidr] #tfsec:ignore:aws-vpc-no-public-ingress-sgr
+  cidr_blocks       = var.app_access_cidrs #tfsec:ignore:aws-vpc-no-public-ingress-sgr
   security_group_id = module.eks_cluster.worker_security_group_id
   description       = "Access to application"
 }

--- a/cloudprem/physical/variables.tf
+++ b/cloudprem/physical/variables.tf
@@ -248,10 +248,10 @@ variable "replicated_ui_access_cidr" {
   default     = "0.0.0.0/0"
 }
 
-variable "app_access_cidr" {
-  description = "This CIDR will be allowed to connect to Dozuki. If running a public site, use the default value. Otherwise you probably want to lock this down to the VPC or your VPN CIDR."
-  type        = string
-  default     = "0.0.0.0/0"
+variable "app_access_cidrs" {
+  description = "These CIDRs will be allowed to connect to Dozuki. If running a public site, use the default value. Otherwise you probably want to lock this down to the VPC or your VPN CIDR."
+  type        = list(string)
+  default     = ["0.0.0.0/0"]
 }
 variable "enable_webhooks" {
   description = "This option will spin up a managed Kafka & Redis cluster to support private webhooks."

--- a/cloudprem/physical/variables.tf
+++ b/cloudprem/physical/variables.tf
@@ -242,10 +242,10 @@ variable "eks_desired_capacity" {
     error_message = "NodeAutoScalingGroupDesiredCapacity must be an integer >= 1\nNodeAutoScalingGroupDesiredCapacity must be >= NodeAutoScalingGroupMinSize\nNodeAutoScalingGroupDesiredCapacity must be <= NodeAutoScalingGroupMaxSize."
   }
 }
-variable "replicated_ui_access_cidr" {
+variable "replicated_ui_access_cidrs" {
   description = "This CIDR will be allowed to connect to the app dashboard. This is where you upgrade to new versions as well as view cluster status and start/stop the cluster. You probably want to lock this down to your company network CIDR, especially if you chose 'true' for public access."
-  type        = string
-  default     = "0.0.0.0/0"
+  type        = list(string)
+  default     = ["0.0.0.0/0"]
 }
 
 variable "app_access_cidrs" {

--- a/cloudprem/physical/variables.tf
+++ b/cloudprem/physical/variables.tf
@@ -243,7 +243,7 @@ variable "eks_desired_capacity" {
   }
 }
 variable "replicated_ui_access_cidrs" {
-  description = "This CIDR will be allowed to connect to the app dashboard. This is where you upgrade to new versions as well as view cluster status and start/stop the cluster. You probably want to lock this down to your company network CIDR, especially if you chose 'true' for public access."
+  description = "These CIDRs will be allowed to connect to the app dashboard. This is where you upgrade to new versions as well as view cluster status and start/stop the cluster. You probably want to lock this down to your company network CIDR, especially if you chose 'true' for public access."
   type        = list(string)
   default     = ["0.0.0.0/0"]
 }

--- a/live/tests/common/config.go
+++ b/live/tests/common/config.go
@@ -38,8 +38,8 @@ type Environment struct {
 	EKSClusterMinSize          string `yaml:"eks_min_size" physical:"true"`
 	EKSClusterMaxSize          string `yaml:"eks_max_size" physical:"true"`
 	EKSClusterDesiredCapacity  string `yaml:"eks_desired_capacity" physical:"true"`
-	AppAccessCIDR              string `yaml:"app_access_cidr" physical:"true"`
-	ReplicatedAccessCIDR       string `yaml:"replicated_ui_access_cidr" physical:"true"`
+	AppAccessCIDRs             string `yaml:"app_access_cidrs" physical:"true"`
+	ReplicatedAccessCIDRs      string `yaml:"replicated_ui_access_cidrs" physical:"true"`
 	LicenseParameter           string `yaml:"dozuki_license_parameter_name" logical:"true"`
 	BootstrapAppSequenceNumber int    `yaml:"replicated_app_sequence_number" logical:"true"`
 	GoogleTranslateAPIToken    string `yaml:"google_translate_api_token" logical:"true"`


### PR DESCRIPTION
Due to an oversight we were only allowing a single CIDR to access the dashboard and the app, now we allow a list of CIDRs for each.