### PR TITLE
Release 2.0.1 legacy module backport fixes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,10 +22,9 @@ jobs:
           tag_name: ${{ github.ref }}
           release_name: Release ${{ github.ref }}
           body: |
-            Major Module Refactor & Scaling
-            - Split Terraform code into 4 separate modules: Network, Compute, Storage, and App
-            - Using Terragrunt to manage configuration, dependencies, and state
-            - Added support for Cluster & Pod autoscaling in Kubernetes
-            - Fixed replicated app sequence targeting to unpin release after initial install
+            Legacy Module BI Backports & Hotfixes
+            - Backport Public BI feature
+            - Backport RDS group_concat_max_len parameter fix
+            - Add terraform provider version constraints to prevent deprecation
           draft: false
           prerelease: false


### PR DESCRIPTION
We're making this release because some customers are on our legacy module configuration that is not upgradeable to our current incarnation without a full migration and they need these upgrades.

In the future we will need to figure out a viable upgrade strategy for them.

Signed-off-by: David Della Vecchia <ddv@dozuki.com>