### PR TITLE
Fix upgrading from older versions (<=2.5.4)

### DIFF
--- a/cloudprem/logical/README.md
+++ b/cloudprem/logical/README.md
@@ -6,6 +6,7 @@
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | 3.70.0 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | 2.3.0 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | 2.4.1 |
+| <a name="requirement_local"></a> [local](#requirement\_local) | 2.2.3 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | 3.1.0 |
 
 ## Providers

--- a/cloudprem/logical/main.tf
+++ b/cloudprem/logical/main.tf
@@ -32,10 +32,11 @@ locals {
 
   dozuki_license_parameter_name = var.dozuki_license_parameter_name == "" ? (var.identifier == "" ? "/dozuki/${var.environment}/license" : "/${var.identifier}/dozuki/${var.environment}/license") : var.dozuki_license_parameter_name
 
+  # Tags for all resources. If you add a tag, it must never be blank.
   tags = {
     Terraform   = "true"
     Project     = "Dozuki"
-    Identifier  = var.identifier
+    Identifier  = coalesce(var.identifier, "NA")
     Environment = var.environment
   }
 

--- a/cloudprem/logical/main.tf
+++ b/cloudprem/logical/main.tf
@@ -4,6 +4,8 @@ terraform {
     kubernetes = "2.4.1"
     helm       = "2.3.0"
     null       = "3.1.0"
+    # This provider needs to stay for awhile to maintain backwards compatibility with older infra versions (<=2.5.4)
+    local = "2.2.3"
   }
 }
 

--- a/cloudprem/physical/bastion.tf
+++ b/cloudprem/physical/bastion.tf
@@ -77,13 +77,13 @@ resource "aws_ssm_association" "bastion_mysql_config" {
     key    = "tag:Role"
     values = ["Bastion"]
   }
-  targets {
-    key    = "tag:Identifier"
-    values = [var.identifier]
-  }
-  targets {
-    key    = "tag:Environment"
-    values = [var.environment]
+
+  dynamic "targets" {
+    for_each = local.tags
+    content {
+      key    = "tag:${targets.key}"
+      values = [targets.value]
+    }
   }
 }
 
@@ -101,13 +101,13 @@ resource "aws_ssm_association" "bastion_kubernetes_config" {
     key    = "tag:Role"
     values = ["Bastion"]
   }
-  targets {
-    key    = "tag:Identifier"
-    values = [var.identifier]
-  }
-  targets {
-    key    = "tag:Environment"
-    values = [var.environment]
+
+  dynamic "targets" {
+    for_each = local.tags
+    content {
+      key    = "tag:${targets.key}"
+      values = [targets.value]
+    }
   }
 }
 

--- a/cloudprem/physical/main.tf
+++ b/cloudprem/physical/main.tf
@@ -18,10 +18,11 @@ locals {
   create_eks_kms           = var.eks_kms_key_id == "" ? true : false
   eks_kms_key              = local.create_eks_kms ? aws_kms_key.eks[0].arn : data.aws_kms_key.eks[0].arn
 
+  # Tags for all resources. If you add a tag, it must never be blank.
   tags = {
     Terraform   = "true"
     Project     = "Dozuki"
-    Identifier  = var.identifier == "" ? "-" : var.identifier
+    Identifier  = coalesce(var.identifier, "NA")
     Environment = var.environment
   }
 

--- a/cloudprem/physical/rds.tf
+++ b/cloudprem/physical/rds.tf
@@ -4,8 +4,9 @@ module "primary_database_sg" {
 
   name            = "${local.identifier}-database"
   use_name_prefix = false
-  description     = "Security group for ${local.identifier}s primary database. Allows access from worker nodes, bastion, and bi database on port 3306"
-  vpc_id          = local.vpc_id
+  # Do not modify the description. Doing so triggers a full recreate (which fails) due to an AWS bug.
+  description = "Security group for ${local.identifier}. Allows access from within the VPC on port 3306"
+  vpc_id      = local.vpc_id
 
   ingress_with_source_security_group_id = [
     {

--- a/cloudprem/physical/rds.tf
+++ b/cloudprem/physical/rds.tf
@@ -1,3 +1,15 @@
+moved {
+  from = module.database_sg
+  to   = module.primary_database_sg
+}
+moved {
+  from = aws_secretsmanager_secret.replica_database[0]
+  to   = aws_secretsmanager_secret.replica_database_credentials[0]
+}
+moved {
+  from = aws_secretsmanager_secret_version.replica_database[0]
+  to   = aws_secretsmanager_secret_version.replica_database_credentials[0]
+}
 module "primary_database_sg" {
   source  = "terraform-aws-modules/security-group/aws"
   version = "4.7.0"

--- a/cloudprem/physical/s3.tf
+++ b/cloudprem/physical/s3.tf
@@ -54,6 +54,13 @@ resource "aws_s3_bucket" "logging_bucket" {
     }
 
   }
+
+  lifecycle {
+    ignore_changes = [
+      bucket,
+      bucket_prefix
+    ]
+  }
 }
 resource "aws_s3_bucket_public_access_block" "guide_images_acl_block" {
   count = var.create_s3_buckets ? 1 : 0
@@ -91,6 +98,13 @@ resource "aws_s3_bucket" "guide_images" {
       }
     }
 
+  }
+
+  lifecycle {
+    ignore_changes = [
+      bucket,
+      bucket_prefix
+    ]
   }
 }
 resource "aws_s3_bucket_public_access_block" "guide_objects_acl_block" {
@@ -130,6 +144,13 @@ resource "aws_s3_bucket" "guide_objects" {
     }
 
   }
+
+  lifecycle {
+    ignore_changes = [
+      bucket,
+      bucket_prefix
+    ]
+  }
 }
 resource "aws_s3_bucket_public_access_block" "guide_pdfs_acl_block" {
   count = var.create_s3_buckets ? 1 : 0
@@ -167,6 +188,13 @@ resource "aws_s3_bucket" "guide_pdfs" {
       }
     }
 
+  }
+
+  lifecycle {
+    ignore_changes = [
+      bucket,
+      bucket_prefix
+    ]
   }
 }
 resource "aws_s3_bucket_public_access_block" "guide_documents_acl_block" {
@@ -215,4 +243,10 @@ resource "aws_s3_bucket" "guide_documents" {
     max_age_seconds = 3000
   }
 
+  lifecycle {
+    ignore_changes = [
+      bucket,
+      bucket_prefix
+    ]
+  }
 }


### PR DESCRIPTION
We had some changes to the terraform that was breaking backwards compatibility and causing terraform to try to delete and re-create resources erroneously. This fixes that by using `moved` blocks to tell terraform which resources we renamed as well as lifecycle rules to ignore changes where appropriate.