### PR TITLE
Webhooks DB Update Fix

### DIFF
--- a/cloudprem/logical/README.md
+++ b/cloudprem/logical/README.md
@@ -40,9 +40,11 @@ No modules.
 | [kubernetes_config_map.unattended_config](https://registry.terraform.io/providers/hashicorp/kubernetes/2.4.1/docs/resources/config_map) | resource |
 | [kubernetes_horizontal_pod_autoscaler.app](https://registry.terraform.io/providers/hashicorp/kubernetes/2.4.1/docs/resources/horizontal_pod_autoscaler) | resource |
 | [kubernetes_horizontal_pod_autoscaler.queueworkerd](https://registry.terraform.io/providers/hashicorp/kubernetes/2.4.1/docs/resources/horizontal_pod_autoscaler) | resource |
-| [kubernetes_job.database_update](https://registry.terraform.io/providers/hashicorp/kubernetes/2.4.1/docs/resources/job) | resource |
 | [kubernetes_job.dms_start](https://registry.terraform.io/providers/hashicorp/kubernetes/2.4.1/docs/resources/job) | resource |
+| [kubernetes_job.frontegg_database_create](https://registry.terraform.io/providers/hashicorp/kubernetes/2.4.1/docs/resources/job) | resource |
 | [kubernetes_job.replicated_sequence_reset](https://registry.terraform.io/providers/hashicorp/kubernetes/2.4.1/docs/resources/job) | resource |
+| [kubernetes_job.sites_config_update](https://registry.terraform.io/providers/hashicorp/kubernetes/2.4.1/docs/resources/job) | resource |
+| [kubernetes_job.wait_for_app](https://registry.terraform.io/providers/hashicorp/kubernetes/2.4.1/docs/resources/job) | resource |
 | [random_password.dashboard_password](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/data-sources/caller_identity) | data source |
 | [aws_eks_cluster.main](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/data-sources/eks_cluster) | data source |

--- a/cloudprem/logical/kubernetes.tf
+++ b/cloudprem/logical/kubernetes.tf
@@ -1,6 +1,3 @@
-
-
-
 resource "kubernetes_config_map" "dozuki_resources" {
 
   metadata {

--- a/cloudprem/logical/main.tf
+++ b/cloudprem/logical/main.tf
@@ -44,9 +44,11 @@ locals {
 
   ca_cert_pem_file = local.is_us_gov ? "vendor/us-gov-west-1-bundle.pem" : "vendor/rds-ca-2019-root.pem"
 
-  db_master_host     = jsondecode(data.aws_secretsmanager_secret_version.db_master.secret_string)["host"]
-  db_master_username = jsondecode(data.aws_secretsmanager_secret_version.db_master.secret_string)["username"]
-  db_master_password = jsondecode(data.aws_secretsmanager_secret_version.db_master.secret_string)["password"]
+  db_credentials = jsondecode(data.aws_secretsmanager_secret_version.db_master.secret_string)
+
+  db_master_host     = local.db_credentials["host"]
+  db_master_username = local.db_credentials["username"]
+  db_master_password = local.db_credentials["password"]
 
   frontegg_clientid = try(data.kubernetes_secret.frontegg[0].data.clientid, "")
   frontegg_apikey   = try(data.kubernetes_secret.frontegg[0].data.apikey, "")

--- a/cloudprem/logical/static/frontegg-db.sql
+++ b/cloudprem/logical/static/frontegg-db.sql
@@ -1,1 +1,1 @@
-create database if not exists frontegg_events; create database if not exists frontegg_webhooks; update sites.site_config set value = 'true' where name = 'feature-webhooks';
+create database if not exists frontegg_events; create database if not exists frontegg_webhooks;

--- a/cloudprem/logical/static/sites-db.sql
+++ b/cloudprem/logical/static/sites-db.sql
@@ -1,0 +1,1 @@
+update sites.site_config set value = 'true' where name = 'feature-webhooks';

--- a/cloudprem/logical/webhooks.tf
+++ b/cloudprem/logical/webhooks.tf
@@ -9,7 +9,40 @@ data "kubernetes_secret" "frontegg" {
     namespace = "default"
   }
 }
-resource "kubernetes_job" "database_update" {
+resource "kubernetes_job" "wait_for_app" {
+  count = var.enable_webhooks ? 1 : 0
+
+  depends_on = [helm_release.replicated]
+
+  metadata {
+    name = "wait-for-app"
+  }
+  spec {
+    template {
+      metadata {}
+      spec {
+        container {
+          name  = "wait-for-app"
+          image = "bearengineer/awscli-kubectl:latest"
+          command = [
+            "/bin/sh",
+            "-c",
+            "kubectl -n ${coalesce([for i, v in data.kubernetes_all_namespaces.allns.namespaces : try(regexall("replicated\\-.*", v)[0], "")]...)} wait deploy/app-deployment --for condition=available --timeout=1200s"
+          ]
+        }
+        restart_policy = "Never"
+      }
+    }
+    backoff_limit = 1
+    completions   = 1
+  }
+  wait_for_completion = true
+
+  timeouts {
+    create = "20m"
+  }
+}
+resource "kubernetes_job" "frontegg_database_create" {
   count = var.enable_webhooks ? 1 : 0
 
   metadata {
@@ -33,8 +66,37 @@ resource "kubernetes_job" "database_update" {
         restart_policy = "Never"
       }
     }
-    backoff_limit = 5
-    completions   = 1
+    backoff_limit = 10
+  }
+  wait_for_completion = true
+}
+resource "kubernetes_job" "sites_config_update" {
+  count = var.enable_webhooks ? 1 : 0
+
+  depends_on = [kubernetes_job.wait_for_app]
+
+  metadata {
+    name = "sites-config-update"
+  }
+  spec {
+    template {
+      metadata {}
+      spec {
+        container {
+          name  = "sites-config-update"
+          image = "imega/mysql-client"
+          command = [
+            "mysql",
+            "--host=${local.db_master_host}",
+            "--user=${local.db_master_username}",
+            "--password=${local.db_master_password}",
+            "--execute=${file("static/sites-db.sql")}"
+          ]
+        }
+        restart_policy = "OnFailure"
+      }
+    }
+    backoff_limit = 50
   }
   wait_for_completion = true
 }
@@ -78,7 +140,7 @@ resource "helm_release" "frontegg" {
   depends_on = [
     helm_release.mongodb,
     helm_release.redis,
-    kubernetes_job.database_update
+    kubernetes_job.frontegg_database_create
   ]
 
   name  = "frontegg"

--- a/cloudprem/physical/eks.tf
+++ b/cloudprem/physical/eks.tf
@@ -233,7 +233,7 @@ module "eks_cluster" {
       tags = [
         {
           key                 = "aws-node-termination-handler/managed"
-          value               = ""
+          value               = true
           propagate_at_launch = true
         },
         {


### PR DESCRIPTION
Creating the frontegg database AND updating the sites db to enable webhooks in the same k8 job makes the entire process very fragile and susceptible to order of operations issues. This splits those and does them when more appropriate. The frontegg db is created as soon as we have a database connection whereas the sites db update waits for the app to be ready (and therefore the sites db actually existing) before trying to update it. 