### PR TITLE
Add SSL to Grafana frontend

### DIFF
--- a/cloudprem/common/acm/ca.tf
+++ b/cloudprem/common/acm/ca.tf
@@ -1,3 +1,4 @@
+
 resource "tls_private_key" "ca" {
   algorithm = "RSA"
 }
@@ -6,7 +7,7 @@ resource "tls_self_signed_cert" "ca" {
   private_key_pem = tls_private_key.ca.private_key_pem
 
   subject {
-    common_name  = "${local.identifier}.${data.aws_region.current.name}.vpn.ca"
+    common_name  = local.ssl_ca_cn
     organization = local.identifier
   }
   validity_period_hours = 87600
@@ -25,15 +26,15 @@ resource "aws_acm_certificate" "ca" {
 }
 
 # AWS SSM records
-resource "aws_ssm_parameter" "vpn_ca_key" {
-  name        = "${local.ssm_prefix}/acm/vpn/ca_key"
-  description = "VPN CA key"
+resource "aws_ssm_parameter" "ca_key" {
+  name        = "${local.ssm_prefix}/acm/${var.namespace}/ca_key"
+  description = "General CA key"
   type        = "SecureString"
   value       = tls_private_key.ca.private_key_pem
 }
-resource "aws_ssm_parameter" "vpn_ca_cert" {
-  name        = "${local.ssm_prefix}/acm/vpn/ca_cert"
-  description = "VPN CA cert"
+resource "aws_ssm_parameter" "ca_cert" {
+  name        = "${local.ssm_prefix}/acm/${var.namespace}/ca_cert"
+  description = "General CA cert"
   type        = "SecureString"
   value       = tls_self_signed_cert.ca.cert_pem
 }

--- a/cloudprem/common/acm/cert.tf
+++ b/cloudprem/common/acm/cert.tf
@@ -13,7 +13,7 @@ resource "tls_cert_request" "server" {
   key_algorithm   = "RSA"
   private_key_pem = tls_private_key.server.private_key_pem
   subject {
-    common_name  = "${local.identifier}.${data.aws_region.current.name}.vpn.server"
+    common_name  = local.ssl_cert_cn
     organization = local.identifier
   }
 }
@@ -30,15 +30,15 @@ resource "tls_locally_signed_cert" "server" {
   ]
 }
 
-resource "aws_ssm_parameter" "vpn_server_key" {
-  name        = "${local.ssm_prefix}/acm/vpn/server_key"
-  description = "VPN server key"
+resource "aws_ssm_parameter" "server_key" {
+  name        = "${local.ssm_prefix}/acm/${var.namespace}/server_key"
+  description = "General server key"
   type        = "SecureString"
   value       = tls_private_key.server.private_key_pem
 }
-resource "aws_ssm_parameter" "vpn_server_cert" {
-  name        = "${local.ssm_prefix}/acm/vpn/server_cert"
-  description = "VPN server cert"
+resource "aws_ssm_parameter" "server_cert" {
+  name        = "${local.ssm_prefix}/acm/${var.namespace}/server_cert"
+  description = "General server cert"
   type        = "SecureString"
   value       = tls_locally_signed_cert.server.cert_pem
 }

--- a/cloudprem/common/acm/main.tf
+++ b/cloudprem/common/acm/main.tf
@@ -1,0 +1,36 @@
+terraform {
+  required_version = ">= 1.1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "3.70.0"
+    }
+    tls = {
+      source  = "hashicorp/tls"
+      version = "3.1.0"
+    }
+  }
+}
+
+
+locals {
+  identifier = var.identifier == "" ? "dozuki-${var.environment}" : "${var.identifier}-dozuki-${var.environment}"
+
+  ssm_prefix = "/dozuki/${coalesce(var.identifier, "general")}/${var.environment}/${data.aws_region.current.name}"
+
+  ssl_ca_cn   = var.ca_common_name == "" ? "${local.identifier}.${data.aws_region.current.name}.general.ca" : var.ca_common_name
+  ssl_cert_cn = var.cert_common_name == "" ? "${local.identifier}.${data.aws_region.current.name}.general.server" : var.cert_common_name
+
+  # Tags for all resources. If you add a tag, it must never be blank.
+  tags = {
+    Terraform   = "true"
+    Project     = "Dozuki"
+    Identifier  = coalesce(var.identifier, "NA")
+    Environment = var.environment
+  }
+}
+
+data "aws_region" "current" {}
+data "aws_partition" "current" {}
+data "aws_caller_identity" "current" {}

--- a/cloudprem/common/acm/main.tf
+++ b/cloudprem/common/acm/main.tf
@@ -32,5 +32,3 @@ locals {
 }
 
 data "aws_region" "current" {}
-data "aws_partition" "current" {}
-data "aws_caller_identity" "current" {}

--- a/cloudprem/common/acm/outputs.tf
+++ b/cloudprem/common/acm/outputs.tf
@@ -1,0 +1,18 @@
+output "ssm_ca_key" {
+  value = aws_ssm_parameter.ca_key
+}
+output "ssm_ca_cert" {
+  value = aws_ssm_parameter.ca_cert
+}
+output "ssm_server_key" {
+  value = aws_ssm_parameter.server_key
+}
+output "ssm_server_cert" {
+  value = aws_ssm_parameter.server_cert
+}
+output "acm_server_arn" {
+  value = aws_acm_certificate.server.arn
+}
+output "acm_ca_arn" {
+  value = aws_acm_certificate.ca.arn
+}

--- a/cloudprem/common/acm/variables.tf
+++ b/cloudprem/common/acm/variables.tf
@@ -1,0 +1,34 @@
+variable "identifier" {
+  description = "A name identifier to use as prefix for all the resources."
+  type        = string
+
+  validation {
+    condition     = length(var.identifier) <= 10
+    error_message = "The length of the identifier must be less than 11 characters."
+  }
+}
+
+variable "environment" {
+  description = "Environment of the application"
+  type        = string
+
+  validation {
+    condition     = length(var.environment) <= 5
+    error_message = "The length of the Environment must be less than 6 characters."
+  }
+}
+variable "namespace" {
+  description = "For ACM and SSM parameter paths, this is part of the path to ensure uniqueness with multiple invocations"
+  default     = "general"
+  type        = string
+}
+variable "ca_common_name" {
+  description = "common name for SSL certificate authority"
+  type        = string
+  default     = ""
+}
+variable "cert_common_name" {
+  description = "common name for SSL certificate"
+  type        = string
+  default     = ""
+}

--- a/cloudprem/logical/README.md
+++ b/cloudprem/logical/README.md
@@ -3,11 +3,13 @@
 
 | Name | Version |
 |------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | 3.70.0 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | 2.3.0 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | 2.4.1 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | 2.2.3 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | 3.1.0 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | 3.1.0 |
 
 ## Providers
 
@@ -16,7 +18,7 @@
 | <a name="provider_aws"></a> [aws](#provider\_aws) | 3.70.0 |
 | <a name="provider_helm"></a> [helm](#provider\_helm) | 2.3.0 |
 | <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | 2.4.1 |
-| <a name="provider_random"></a> [random](#provider\_random) | n/a |
+| <a name="provider_random"></a> [random](#provider\_random) | 3.1.0 |
 
 ## Modules
 
@@ -50,8 +52,8 @@
 | [kubernetes_job.wait_for_app](https://registry.terraform.io/providers/hashicorp/kubernetes/2.4.1/docs/resources/job) | resource |
 | [kubernetes_secret.grafana_config](https://registry.terraform.io/providers/hashicorp/kubernetes/2.4.1/docs/resources/secret) | resource |
 | [kubernetes_secret.grafana_ssl](https://registry.terraform.io/providers/hashicorp/kubernetes/2.4.1/docs/resources/secret) | resource |
-| [random_password.dashboard_password](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
-| [random_password.grafana_admin](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
+| [random_password.dashboard_password](https://registry.terraform.io/providers/hashicorp/random/3.1.0/docs/resources/password) | resource |
+| [random_password.grafana_admin](https://registry.terraform.io/providers/hashicorp/random/3.1.0/docs/resources/password) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/data-sources/caller_identity) | data source |
 | [aws_eks_cluster.main](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/data-sources/eks_cluster) | data source |
 | [aws_eks_cluster_auth.main](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/data-sources/eks_cluster_auth) | data source |
@@ -61,8 +63,6 @@
 | [aws_secretsmanager_secret_version.db_bi](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/data-sources/secretsmanager_secret_version) | data source |
 | [aws_secretsmanager_secret_version.db_master](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/data-sources/secretsmanager_secret_version) | data source |
 | [aws_ssm_parameter.dozuki_license](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/data-sources/ssm_parameter) | data source |
-| [aws_subnets.private](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/data-sources/subnets) | data source |
-| [aws_vpc.main](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/data-sources/vpc) | data source |
 | [kubernetes_all_namespaces.allns](https://registry.terraform.io/providers/hashicorp/kubernetes/2.4.1/docs/data-sources/all_namespaces) | data source |
 | [kubernetes_secret.frontegg](https://registry.terraform.io/providers/hashicorp/kubernetes/2.4.1/docs/data-sources/secret) | data source |
 
@@ -73,22 +73,19 @@
 | <a name="input_aws_profile"></a> [aws\_profile](#input\_aws\_profile) | If running terraform from a workstation, which AWS CLI profile should we use for asset provisioning. | `string` | `""` | no |
 | <a name="input_azs_count"></a> [azs\_count](#input\_azs\_count) | The number of availability zones we should use for deployment. | `number` | `3` | no |
 | <a name="input_bi_database_credential_secret"></a> [bi\_database\_credential\_secret](#input\_bi\_database\_credential\_secret) | ARN to secret containing bi db credentials | `string` | `""` | no |
-| <a name="input_cluster_primary_sg"></a> [cluster\_primary\_sg](#input\_cluster\_primary\_sg) | Primary Security Group for the EKS cluster, used for ingress SG source | `any` | n/a | yes |
-| <a name="input_dms_task_arn"></a> [dms\_task\_arn](#input\_dms\_task\_arn) | If BI is enabled, the DMS replication task arn. | `any` | n/a | yes |
+| <a name="input_dms_task_arn"></a> [dms\_task\_arn](#input\_dms\_task\_arn) | If BI is enabled, the DMS replication task arn. | `string` | n/a | yes |
 | <a name="input_dozuki_license_parameter_name"></a> [dozuki\_license\_parameter\_name](#input\_dozuki\_license\_parameter\_name) | Parameter name for dozuki license in AWS Parameter store. | `string` | `""` | no |
-| <a name="input_eks_cluster_access_role_arn"></a> [eks\_cluster\_access\_role\_arn](#input\_eks\_cluster\_access\_role\_arn) | ARN for cluster access role for app provisioning | `string` | n/a | yes |
 | <a name="input_eks_cluster_id"></a> [eks\_cluster\_id](#input\_eks\_cluster\_id) | ID of EKS cluster for app provisioning | `string` | n/a | yes |
 | <a name="input_eks_oidc_cluster_access_role_name"></a> [eks\_oidc\_cluster\_access\_role\_name](#input\_eks\_oidc\_cluster\_access\_role\_name) | ARN for OIDC-compatible IAM Role for the EKS Cluster Autoscaler | `string` | n/a | yes |
-| <a name="input_eks_worker_asg_arns"></a> [eks\_worker\_asg\_arns](#input\_eks\_worker\_asg\_arns) | Autoscaling group ARNS for the EKS cluster | `list(string)` | n/a | yes |
 | <a name="input_eks_worker_asg_names"></a> [eks\_worker\_asg\_names](#input\_eks\_worker\_asg\_names) | Autoscaling group names for the EKS cluster | `list(string)` | n/a | yes |
 | <a name="input_enable_bi"></a> [enable\_bi](#input\_enable\_bi) | Whether to deploy resources for BI, a replica database, a DMS task, and a Kafka cluster | `string` | `false` | no |
 | <a name="input_enable_webhooks"></a> [enable\_webhooks](#input\_enable\_webhooks) | This option will spin up a managed Kafka & Redis cluster to support private webhooks. | `bool` | `false` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | Environment of the application | `string` | `"dev"` | no |
 | <a name="input_google_translate_api_token"></a> [google\_translate\_api\_token](#input\_google\_translate\_api\_token) | If using machine translation, enter your google translate API token here. | `string` | `""` | no |
 | <a name="input_identifier"></a> [identifier](#input\_identifier) | A name identifier to use as prefix for all the resources. | `string` | `""` | no |
-| <a name="input_memcached_cluster_address"></a> [memcached\_cluster\_address](#input\_memcached\_cluster\_address) | Address of the deployed memcached cluster | `any` | n/a | yes |
+| <a name="input_memcached_cluster_address"></a> [memcached\_cluster\_address](#input\_memcached\_cluster\_address) | Address of the deployed memcached cluster | `string` | n/a | yes |
 | <a name="input_msk_bootstrap_brokers"></a> [msk\_bootstrap\_brokers](#input\_msk\_bootstrap\_brokers) | Kafka bootstrap broker list | `any` | n/a | yes |
-| <a name="input_nlb_dns_name"></a> [nlb\_dns\_name](#input\_nlb\_dns\_name) | DNS address of the network load balancer and URL to the deployed application | `any` | n/a | yes |
+| <a name="input_nlb_dns_name"></a> [nlb\_dns\_name](#input\_nlb\_dns\_name) | DNS address of the network load balancer and URL to the deployed application | `string` | n/a | yes |
 | <a name="input_primary_db_secret"></a> [primary\_db\_secret](#input\_primary\_db\_secret) | ARN to secret containing primary db credentials | `string` | n/a | yes |
 | <a name="input_replicated_app_sequence_number"></a> [replicated\_app\_sequence\_number](#input\_replicated\_app\_sequence\_number) | For fresh installs you can target a specific Replicated sequence for first install. This will not be respected for existing installations. Use 0 for latest release. | `number` | `0` | no |
 | <a name="input_replicated_channel"></a> [replicated\_channel](#input\_replicated\_channel) | If specifying an app sequence for a fresh install, this is the channel that sequence was deployed to. You only need to set this if the sequence you configured was not released on the default channel associated with your customer license. | `string` | `""` | no |
@@ -97,9 +94,8 @@
 | <a name="input_s3_kms_key_id"></a> [s3\_kms\_key\_id](#input\_s3\_kms\_key\_id) | AWS KMS key identifier for S3 encryption. The identifier can be one of the following format: Key id, key ARN, alias name or alias ARN | `string` | `"alias/aws/s3"` | no |
 | <a name="input_s3_objects_bucket"></a> [s3\_objects\_bucket](#input\_s3\_objects\_bucket) | Name of the bucket to store guide objects. Use with 'create\_s3\_buckets' = false. | `string` | `""` | no |
 | <a name="input_s3_pdfs_bucket"></a> [s3\_pdfs\_bucket](#input\_s3\_pdfs\_bucket) | Name of the bucket to store guide pdfs. Use with 'create\_s3\_buckets' = false. | `string` | `""` | no |
-| <a name="input_termination_handler_role_arn"></a> [termination\_handler\_role\_arn](#input\_termination\_handler\_role\_arn) | IAM Role for EKS node termination handler | `any` | n/a | yes |
-| <a name="input_termination_handler_sqs_queue_id"></a> [termination\_handler\_sqs\_queue\_id](#input\_termination\_handler\_sqs\_queue\_id) | SQS Queue ID for the EKS node termination handler | `any` | n/a | yes |
-| <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | The VPC ID where we'll be deploying our resources. (If creating a new VPC leave this field and subnets blank). When using an existing VPC be sure to tag at least 2 subnets with type = public and another 2 with tag type = private | `string` | `""` | no |
+| <a name="input_termination_handler_role_arn"></a> [termination\_handler\_role\_arn](#input\_termination\_handler\_role\_arn) | IAM Role for EKS node termination handler | `string` | n/a | yes |
+| <a name="input_termination_handler_sqs_queue_id"></a> [termination\_handler\_sqs\_queue\_id](#input\_termination\_handler\_sqs\_queue\_id) | SQS Queue ID for the EKS node termination handler | `string` | n/a | yes |
 
 ## Outputs
 

--- a/cloudprem/logical/README.md
+++ b/cloudprem/logical/README.md
@@ -6,10 +6,10 @@
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | 3.70.0 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | 2.3.0 |
-| <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | 2.4.1 |
+| <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | 2.13.1 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | 2.2.3 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | 3.1.0 |
-| <a name="requirement_random"></a> [random](#requirement\_random) | 3.1.0 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | 3.4.3 |
 
 ## Providers
 
@@ -17,8 +17,8 @@
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | 3.70.0 |
 | <a name="provider_helm"></a> [helm](#provider\_helm) | 2.3.0 |
-| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | 2.4.1 |
-| <a name="provider_random"></a> [random](#provider\_random) | 3.1.0 |
+| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | 2.13.1 |
+| <a name="provider_random"></a> [random](#provider\_random) | 3.4.3 |
 
 ## Modules
 
@@ -41,19 +41,19 @@
 | [helm_release.mongodb](https://registry.terraform.io/providers/hashicorp/helm/2.3.0/docs/resources/release) | resource |
 | [helm_release.redis](https://registry.terraform.io/providers/hashicorp/helm/2.3.0/docs/resources/release) | resource |
 | [helm_release.replicated](https://registry.terraform.io/providers/hashicorp/helm/2.3.0/docs/resources/release) | resource |
-| [kubernetes_config_map.dozuki_resources](https://registry.terraform.io/providers/hashicorp/kubernetes/2.4.1/docs/resources/config_map) | resource |
-| [kubernetes_config_map.unattended_config](https://registry.terraform.io/providers/hashicorp/kubernetes/2.4.1/docs/resources/config_map) | resource |
-| [kubernetes_horizontal_pod_autoscaler.app](https://registry.terraform.io/providers/hashicorp/kubernetes/2.4.1/docs/resources/horizontal_pod_autoscaler) | resource |
-| [kubernetes_horizontal_pod_autoscaler.queueworkerd](https://registry.terraform.io/providers/hashicorp/kubernetes/2.4.1/docs/resources/horizontal_pod_autoscaler) | resource |
-| [kubernetes_job.dms_start](https://registry.terraform.io/providers/hashicorp/kubernetes/2.4.1/docs/resources/job) | resource |
-| [kubernetes_job.frontegg_database_create](https://registry.terraform.io/providers/hashicorp/kubernetes/2.4.1/docs/resources/job) | resource |
-| [kubernetes_job.replicated_sequence_reset](https://registry.terraform.io/providers/hashicorp/kubernetes/2.4.1/docs/resources/job) | resource |
-| [kubernetes_job.sites_config_update](https://registry.terraform.io/providers/hashicorp/kubernetes/2.4.1/docs/resources/job) | resource |
-| [kubernetes_job.wait_for_app](https://registry.terraform.io/providers/hashicorp/kubernetes/2.4.1/docs/resources/job) | resource |
-| [kubernetes_secret.grafana_config](https://registry.terraform.io/providers/hashicorp/kubernetes/2.4.1/docs/resources/secret) | resource |
-| [kubernetes_secret.grafana_ssl](https://registry.terraform.io/providers/hashicorp/kubernetes/2.4.1/docs/resources/secret) | resource |
-| [random_password.dashboard_password](https://registry.terraform.io/providers/hashicorp/random/3.1.0/docs/resources/password) | resource |
-| [random_password.grafana_admin](https://registry.terraform.io/providers/hashicorp/random/3.1.0/docs/resources/password) | resource |
+| [kubernetes_config_map.dozuki_resources](https://registry.terraform.io/providers/hashicorp/kubernetes/2.13.1/docs/resources/config_map) | resource |
+| [kubernetes_config_map.unattended_config](https://registry.terraform.io/providers/hashicorp/kubernetes/2.13.1/docs/resources/config_map) | resource |
+| [kubernetes_horizontal_pod_autoscaler.app](https://registry.terraform.io/providers/hashicorp/kubernetes/2.13.1/docs/resources/horizontal_pod_autoscaler) | resource |
+| [kubernetes_horizontal_pod_autoscaler.queueworkerd](https://registry.terraform.io/providers/hashicorp/kubernetes/2.13.1/docs/resources/horizontal_pod_autoscaler) | resource |
+| [kubernetes_job.dms_start](https://registry.terraform.io/providers/hashicorp/kubernetes/2.13.1/docs/resources/job) | resource |
+| [kubernetes_job.frontegg_database_create](https://registry.terraform.io/providers/hashicorp/kubernetes/2.13.1/docs/resources/job) | resource |
+| [kubernetes_job.replicated_sequence_reset](https://registry.terraform.io/providers/hashicorp/kubernetes/2.13.1/docs/resources/job) | resource |
+| [kubernetes_job.sites_config_update](https://registry.terraform.io/providers/hashicorp/kubernetes/2.13.1/docs/resources/job) | resource |
+| [kubernetes_job.wait_for_app](https://registry.terraform.io/providers/hashicorp/kubernetes/2.13.1/docs/resources/job) | resource |
+| [kubernetes_secret.grafana_config](https://registry.terraform.io/providers/hashicorp/kubernetes/2.13.1/docs/resources/secret) | resource |
+| [kubernetes_secret.grafana_ssl](https://registry.terraform.io/providers/hashicorp/kubernetes/2.13.1/docs/resources/secret) | resource |
+| [random_password.dashboard_password](https://registry.terraform.io/providers/hashicorp/random/3.4.3/docs/resources/password) | resource |
+| [random_password.grafana_admin](https://registry.terraform.io/providers/hashicorp/random/3.4.3/docs/resources/password) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/data-sources/caller_identity) | data source |
 | [aws_eks_cluster.main](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/data-sources/eks_cluster) | data source |
 | [aws_eks_cluster_auth.main](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/data-sources/eks_cluster_auth) | data source |
@@ -63,8 +63,8 @@
 | [aws_secretsmanager_secret_version.db_bi](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/data-sources/secretsmanager_secret_version) | data source |
 | [aws_secretsmanager_secret_version.db_master](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/data-sources/secretsmanager_secret_version) | data source |
 | [aws_ssm_parameter.dozuki_license](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/data-sources/ssm_parameter) | data source |
-| [kubernetes_all_namespaces.allns](https://registry.terraform.io/providers/hashicorp/kubernetes/2.4.1/docs/data-sources/all_namespaces) | data source |
-| [kubernetes_secret.frontegg](https://registry.terraform.io/providers/hashicorp/kubernetes/2.4.1/docs/data-sources/secret) | data source |
+| [kubernetes_all_namespaces.allns](https://registry.terraform.io/providers/hashicorp/kubernetes/2.13.1/docs/data-sources/all_namespaces) | data source |
+| [kubernetes_secret.frontegg](https://registry.terraform.io/providers/hashicorp/kubernetes/2.13.1/docs/data-sources/secret) | data source |
 
 ## Inputs
 

--- a/cloudprem/logical/README.md
+++ b/cloudprem/logical/README.md
@@ -20,7 +20,9 @@
 
 ## Modules
 
-No modules.
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_ssl_cert"></a> [ssl\_cert](#module\_ssl\_cert) | ../common/acm | n/a |
 
 ## Resources
 
@@ -46,6 +48,8 @@ No modules.
 | [kubernetes_job.replicated_sequence_reset](https://registry.terraform.io/providers/hashicorp/kubernetes/2.4.1/docs/resources/job) | resource |
 | [kubernetes_job.sites_config_update](https://registry.terraform.io/providers/hashicorp/kubernetes/2.4.1/docs/resources/job) | resource |
 | [kubernetes_job.wait_for_app](https://registry.terraform.io/providers/hashicorp/kubernetes/2.4.1/docs/resources/job) | resource |
+| [kubernetes_secret.grafana_config](https://registry.terraform.io/providers/hashicorp/kubernetes/2.4.1/docs/resources/secret) | resource |
+| [kubernetes_secret.grafana_ssl](https://registry.terraform.io/providers/hashicorp/kubernetes/2.4.1/docs/resources/secret) | resource |
 | [random_password.dashboard_password](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
 | [random_password.grafana_admin](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/data-sources/caller_identity) | data source |

--- a/cloudprem/logical/README.md
+++ b/cloudprem/logical/README.md
@@ -56,7 +56,6 @@
 | [random_password.grafana_admin](https://registry.terraform.io/providers/hashicorp/random/3.4.3/docs/resources/password) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/data-sources/caller_identity) | data source |
 | [aws_eks_cluster.main](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/data-sources/eks_cluster) | data source |
-| [aws_eks_cluster_auth.main](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/data-sources/eks_cluster_auth) | data source |
 | [aws_kms_key.s3](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/data-sources/kms_key) | data source |
 | [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/data-sources/partition) | data source |
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/data-sources/region) | data source |

--- a/cloudprem/logical/main.tf
+++ b/cloudprem/logical/main.tf
@@ -15,7 +15,11 @@ terraform {
 provider "kubernetes" {
   host                   = data.aws_eks_cluster.main.endpoint
   cluster_ca_certificate = base64decode(data.aws_eks_cluster.main.certificate_authority[0].data)
-  token                  = data.aws_eks_cluster_auth.main.token
+  exec {
+    api_version = "client.authentication.k8s.io/v1beta1"
+    args        = ["eks", "get-token", "--cluster-name", data.aws_eks_cluster.main.name, "--region", data.aws_region.current.name, "--profile", var.aws_profile]
+    command     = "aws"
+  }
 }
 
 provider "helm" {
@@ -23,7 +27,7 @@ provider "helm" {
     host                   = data.aws_eks_cluster.main.endpoint
     cluster_ca_certificate = base64decode(data.aws_eks_cluster.main.certificate_authority[0].data)
     exec {
-      api_version = "client.authentication.k8s.io/v1alpha1"
+      api_version = "client.authentication.k8s.io/v1beta1"
       args        = ["eks", "get-token", "--cluster-name", data.aws_eks_cluster.main.name, "--region", data.aws_region.current.name, "--profile", var.aws_profile]
       command     = "aws"
     }
@@ -59,10 +63,6 @@ locals {
 }
 
 data "aws_eks_cluster" "main" {
-  name = var.eks_cluster_id
-}
-
-data "aws_eks_cluster_auth" "main" {
   name = var.eks_cluster_id
 }
 

--- a/cloudprem/logical/main.tf
+++ b/cloudprem/logical/main.tf
@@ -59,7 +59,7 @@ locals {
   frontegg_username = try(data.kubernetes_secret.frontegg[0].data.username, "")
   frontegg_password = try(data.kubernetes_secret.frontegg[0].data.password, "") #tfsec:ignore:general-secrets-no-plaintext-exposure
 
-  grafana_url            = var.enable_bi ? format("http://%s:3000", var.nlb_dns_name) : null
+  grafana_url            = var.enable_bi ? format("https://%s:3000", var.nlb_dns_name) : null
   grafana_admin_username = var.enable_bi ? "dozuki" : null
   grafana_admin_password = var.enable_bi ? nonsensitive(random_password.grafana_admin[0].result) : null
 

--- a/cloudprem/logical/main.tf
+++ b/cloudprem/logical/main.tf
@@ -3,12 +3,12 @@ terraform {
 
   required_providers {
     aws        = "3.70.0"
-    kubernetes = "2.4.1"
+    kubernetes = "2.13.1"
     helm       = "2.3.0"
     null       = "3.1.0"
     # This provider needs to stay for awhile to maintain backwards compatibility with older infra versions (<=2.5.4)
     local  = "2.2.3"
-    random = "3.1.0"
+    random = "3.4.3"
   }
 }
 

--- a/cloudprem/logical/static/grafana_values.yml
+++ b/cloudprem/logical/static/grafana_values.yml
@@ -17,6 +17,27 @@ service:
   port: 80
   nodePort: 32020
 
+extraSecretMounts:
+  - name: ssl-files
+    mountPath: /etc/secrets
+    secretName: grafana-ssl
+    readOnly: true
+
+readinessProbe:
+  httpGet:
+    scheme: HTTPS
+    path: /api/health
+    port: 3000
+
+livenessProbe:
+  httpGet:
+    scheme: HTTPS
+    path: /api/health
+    port: 3000
+  initialDelaySeconds: 60
+  timeoutSeconds: 30
+  failureThreshold: 10
+
 persistence:
   type: pvc
   enabled: true
@@ -34,7 +55,7 @@ initChownData:
 
 # Administrator credentials when not using an existing secret (see below)
 adminUser: dozuki
-# adminPassword: s
+envFromSecret: "grafana-config"
 
 ## Configure grafana datasources
 ## ref: http://docs.grafana.org/administration/provisioning/#datasources
@@ -56,10 +77,6 @@ datasources:
 ##
 plugins:
   - grafana-piechart-panel
-
-grafana.ini:
-  users:
-    default_theme: light
 
 ## Configure grafana dashboard to import
 ## NOTE: To use dashboards you must also enable/configure dashboardProviders

--- a/cloudprem/logical/variables.tf
+++ b/cloudprem/logical/variables.tf
@@ -9,6 +9,7 @@ variable "identifier" {
   }
 }
 variable "dozuki_license_parameter_name" {
+  type        = string
   description = "Parameter name for dozuki license in AWS Parameter store."
   default     = ""
 }
@@ -22,13 +23,9 @@ variable "environment" {
     error_message = "The length of the Environment must be less than 6 characters."
   }
 }
-variable "vpc_id" {
-  description = "The VPC ID where we'll be deploying our resources. (If creating a new VPC leave this field and subnets blank). When using an existing VPC be sure to tag at least 2 subnets with type = public and another 2 with tag type = private"
-  type        = string
-  default     = ""
-}
 variable "azs_count" {
   default     = 3
+  type        = number
   description = "The number of availability zones we should use for deployment."
 
   validation {
@@ -40,17 +37,9 @@ variable "eks_cluster_id" {
   description = "ID of EKS cluster for app provisioning"
   type        = string
 }
-variable "eks_cluster_access_role_arn" {
-  description = "ARN for cluster access role for app provisioning"
-  type        = string
-}
 variable "eks_oidc_cluster_access_role_name" {
   description = "ARN for OIDC-compatible IAM Role for the EKS Cluster Autoscaler"
   type        = string
-}
-variable "eks_worker_asg_arns" {
-  description = "Autoscaling group ARNS for the EKS cluster"
-  type        = list(string)
 }
 variable "eks_worker_asg_names" {
   description = "Autoscaling group names for the EKS cluster"
@@ -58,12 +47,11 @@ variable "eks_worker_asg_names" {
 }
 variable "termination_handler_role_arn" {
   description = "IAM Role for EKS node termination handler"
+  type        = string
 }
 variable "termination_handler_sqs_queue_id" {
   description = "SQS Queue ID for the EKS node termination handler"
-}
-variable "cluster_primary_sg" {
-  description = "Primary Security Group for the EKS cluster, used for ingress SG source"
+  type        = string
 }
 variable "primary_db_secret" {
   description = "ARN to secret containing primary db credentials"
@@ -80,6 +68,7 @@ variable "enable_webhooks" {
   default     = false
 }
 variable "nlb_dns_name" {
+  type        = string
   description = "DNS address of the network load balancer and URL to the deployed application"
 }
 variable "replicated_app_sequence_number" {
@@ -93,6 +82,7 @@ variable "replicated_channel" {
   type        = string
 }
 variable "memcached_cluster_address" {
+  type        = string
   description = "Address of the deployed memcached cluster"
 }
 variable "s3_kms_key_id" {
@@ -120,6 +110,9 @@ variable "s3_pdfs_bucket" {
   type        = string
   default     = ""
 }
+# This needs to have no type due to terraform's weird handling of string lists. If you set a type it will convert it to
+# a format we can't feed into helm
+# tflint-ignore: terraform_typed_variables
 variable "msk_bootstrap_brokers" {
   description = "Kafka bootstrap broker list"
 }
@@ -135,6 +128,7 @@ variable "enable_bi" {
   default     = false
 }
 variable "dms_task_arn" {
+  type        = string
   description = "If BI is enabled, the DMS replication task arn."
 }
 variable "aws_profile" {

--- a/cloudprem/physical/README.md
+++ b/cloudprem/physical/README.md
@@ -7,7 +7,7 @@
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | 3.70.0 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | 2.13.1 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | 3.1.0 |
-| <a name="requirement_random"></a> [random](#requirement\_random) | 3.1.0 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | 3.4.3 |
 
 ## Providers
 
@@ -15,7 +15,7 @@
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | 3.70.0 |
 | <a name="provider_null"></a> [null](#provider\_null) | 3.1.0 |
-| <a name="provider_random"></a> [random](#provider\_random) | 3.1.0 |
+| <a name="provider_random"></a> [random](#provider\_random) | 3.4.3 |
 
 ## Modules
 
@@ -100,8 +100,8 @@
 | [aws_ssm_document.bastion_mysql_config](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/resources/ssm_document) | resource |
 | [null_resource.cluster_urls](https://registry.terraform.io/providers/hashicorp/null/3.1.0/docs/resources/resource) | resource |
 | [null_resource.replication_control](https://registry.terraform.io/providers/hashicorp/null/3.1.0/docs/resources/resource) | resource |
-| [random_password.primary_database](https://registry.terraform.io/providers/hashicorp/random/3.1.0/docs/resources/password) | resource |
-| [random_password.replica_database](https://registry.terraform.io/providers/hashicorp/random/3.1.0/docs/resources/password) | resource |
+| [random_password.primary_database](https://registry.terraform.io/providers/hashicorp/random/3.4.3/docs/resources/password) | resource |
+| [random_password.replica_database](https://registry.terraform.io/providers/hashicorp/random/3.4.3/docs/resources/password) | resource |
 | [aws_ami.amazon_linux_2](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/data-sources/ami) | data source |
 | [aws_availability_zones.available](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/data-sources/availability_zones) | data source |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/data-sources/caller_identity) | data source |

--- a/cloudprem/physical/README.md
+++ b/cloudprem/physical/README.md
@@ -106,7 +106,6 @@
 | [aws_availability_zones.available](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/data-sources/availability_zones) | data source |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/data-sources/caller_identity) | data source |
 | [aws_eks_cluster.main](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/data-sources/eks_cluster) | data source |
-| [aws_eks_cluster_auth.main](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/data-sources/eks_cluster_auth) | data source |
 | [aws_iam_policy_document.aws_node_termination_handler](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.aws_node_termination_handler_events](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.cluster_access](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/data-sources/iam_policy_document) | data source |

--- a/cloudprem/physical/README.md
+++ b/cloudprem/physical/README.md
@@ -3,7 +3,10 @@
 
 | Name | Version |
 |------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | 3.70.0 |
+| <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | 2.13.1 |
+| <a name="requirement_null"></a> [null](#requirement\_null) | 3.1.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | 3.1.0 |
 
 ## Providers
@@ -11,7 +14,7 @@
 | Name | Version |
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | 3.70.0 |
-| <a name="provider_null"></a> [null](#provider\_null) | n/a |
+| <a name="provider_null"></a> [null](#provider\_null) | 3.1.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | 3.1.0 |
 
 ## Modules
@@ -95,8 +98,8 @@
 | [aws_ssm_association.bastion_mysql_config](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/resources/ssm_association) | resource |
 | [aws_ssm_document.bastion_kubernetes_config](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/resources/ssm_document) | resource |
 | [aws_ssm_document.bastion_mysql_config](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/resources/ssm_document) | resource |
-| [null_resource.cluster_urls](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
-| [null_resource.replication_control](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
+| [null_resource.cluster_urls](https://registry.terraform.io/providers/hashicorp/null/3.1.0/docs/resources/resource) | resource |
+| [null_resource.replication_control](https://registry.terraform.io/providers/hashicorp/null/3.1.0/docs/resources/resource) | resource |
 | [random_password.primary_database](https://registry.terraform.io/providers/hashicorp/random/3.1.0/docs/resources/password) | resource |
 | [random_password.replica_database](https://registry.terraform.io/providers/hashicorp/random/3.1.0/docs/resources/password) | resource |
 | [aws_ami.amazon_linux_2](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/data-sources/ami) | data source |

--- a/cloudprem/physical/main.tf
+++ b/cloudprem/physical/main.tf
@@ -11,7 +11,11 @@ terraform {
 provider "kubernetes" {
   host                   = data.aws_eks_cluster.main.endpoint
   cluster_ca_certificate = base64decode(data.aws_eks_cluster.main.certificate_authority[0].data)
-  token                  = data.aws_eks_cluster_auth.main.token
+  exec {
+    api_version = "client.authentication.k8s.io/v1beta1"
+    args        = ["eks", "get-token", "--cluster-name", data.aws_eks_cluster.main.name, "--region", data.aws_region.current.name, "--profile", var.aws_profile]
+    command     = "aws"
+  }
 }
 
 locals {
@@ -56,9 +60,6 @@ locals {
   private_subnet_ids = local.create_vpc ? module.vpc[0].private_subnets : data.aws_subnet_ids.private[0].ids
 }
 data "aws_eks_cluster" "main" {
-  name = module.eks_cluster.cluster_id
-}
-data "aws_eks_cluster_auth" "main" {
   name = module.eks_cluster.cluster_id
 }
 

--- a/cloudprem/physical/main.tf
+++ b/cloudprem/physical/main.tf
@@ -1,12 +1,16 @@
 terraform {
+  required_version = ">= 1.1.0"
+
   required_providers {
-    aws    = "3.70.0"
-    random = "3.1.0"
+    aws        = "3.70.0"
+    random     = "3.1.0"
+    kubernetes = "2.13.1"
+    null       = "3.1.0"
   }
 }
 provider "kubernetes" {
   host                   = data.aws_eks_cluster.main.endpoint
-  cluster_ca_certificate = base64decode(data.aws_eks_cluster.main.certificate_authority.0.data)
+  cluster_ca_certificate = base64decode(data.aws_eks_cluster.main.certificate_authority[0].data)
   token                  = data.aws_eks_cluster_auth.main.token
 }
 

--- a/cloudprem/physical/main.tf
+++ b/cloudprem/physical/main.tf
@@ -3,7 +3,7 @@ terraform {
 
   required_providers {
     aws        = "3.70.0"
-    random     = "3.1.0"
+    random     = "3.4.3"
     kubernetes = "2.13.1"
     null       = "3.1.0"
   }

--- a/cloudprem/physical/modules/vpn/endpoint.tf
+++ b/cloudprem/physical/modules/vpn/endpoint.tf
@@ -1,6 +1,6 @@
 resource "aws_ec2_client_vpn_endpoint" "vpn-client" {
   description            = "${local.identifier}-vpn-client"
-  server_certificate_arn = aws_acm_certificate.server.arn
+  server_certificate_arn = module.ssl_cert.acm_server_arn
   client_cidr_block      = var.client_cidr_block
 
   split_tunnel = true

--- a/cloudprem/physical/modules/vpn/main.tf
+++ b/cloudprem/physical/modules/vpn/main.tf
@@ -17,12 +17,13 @@ terraform {
 locals {
   identifier = var.identifier == "" ? "dozuki-${var.environment}" : "${var.identifier}-dozuki-${var.environment}"
 
-  ssm_prefix = "/dozuki/${local.identifier}/${data.aws_region.current.name}"
+  ssm_prefix = "/dozuki/${coalesce(var.identifier, "general")}/${var.environment}/${data.aws_region.current.name}"
 
+  # Tags for all resources. If you add a tag, it must never be blank.
   tags = {
     Terraform   = "true"
     Project     = "Dozuki"
-    Identifier  = var.identifier
+    Identifier  = coalesce(var.identifier, "NA")
     Environment = var.environment
   }
 }

--- a/cloudprem/physical/modules/vpn/variables.tf
+++ b/cloudprem/physical/modules/vpn/variables.tf
@@ -21,19 +21,14 @@ variable "vpn-client-list" {
   description = "List of VPN Users"
   type        = list(string)
 }
-variable "session_timeout_hours" {
-  description = "Session timeout hours"
-  type        = number
-  default     = 8
-}
+#variable "session_timeout_hours" {
+#  description = "Session timeout hours"
+#  type        = number
+#  default     = 8
+#}
 variable "vpc_id" {
   description = "The VPC ID where we'll be deploying our resources. (If creating a new VPC leave this field and subnets blank). When using an existing VPC be sure to tag at least 2 subnets with type = public and another 2 with tag type = private"
   type        = string
-}
-variable "vpc_cidr" {
-  description = "The CIDR block for the VPC"
-  type        = string
-  default     = "172.16.0.0/16"
 }
 variable "azs_count" {
   description = "The number of availability zones we should use for deployment."


### PR DESCRIPTION
My MVP of Grafana did not include SSL access for the frontend, this PR adds that by using the self-signed cert functionality of the VPN module. I refactored said functionality into its own module, now stored in the `common` root directory, and is used by _both_ the VPN module _and_ the Grafana implementation. Additionally I refactored the way I set Grafana config directives: I no longer use the `grafana.ini` option in the helm chart, opting instead for environment variables set via a k8 secret.