### PR TITLE
Fix S3 naming scheme to ensure uniqueness

### DIFF
--- a/cloudprem/physical/main.tf
+++ b/cloudprem/physical/main.tf
@@ -19,7 +19,7 @@ provider "kubernetes" {
 }
 
 locals {
-  identifier = var.identifier == "" ? "dozuki-${var.environment}" : "${var.identifier}-dozuki-${var.environment}"
+  identifier = var.identifier == "" ? "dozuki-${var.environment}" : "${var.identifier}-${var.environment}"
 
   # EKS
   cluster_access_role_name = "${local.identifier}-${data.aws_region.current.name}-cluster-access"

--- a/cloudprem/physical/s3.tf
+++ b/cloudprem/physical/s3.tf
@@ -35,7 +35,7 @@ resource "aws_s3_bucket_public_access_block" "logging_bucket_acl_block" {
 resource "aws_s3_bucket" "logging_bucket" {
   count = var.create_s3_buckets ? 1 : 0
 
-  bucket        = "dozuki-bucket-access-logs-${local.identifier}-${data.aws_region.current.name}"
+  bucket_prefix = "${local.identifier}-log-${data.aws_region.current.name}"
   acl           = "private"
   force_destroy = !var.protect_resources
 
@@ -75,7 +75,7 @@ resource "aws_s3_bucket_public_access_block" "guide_images_acl_block" {
 resource "aws_s3_bucket" "guide_images" {
   count = var.create_s3_buckets ? 1 : 0
 
-  bucket        = "dozuki-guide-images-${local.identifier}-${data.aws_region.current.name}"
+  bucket_prefix = "${local.identifier}-image-${data.aws_region.current.name}"
   acl           = "private"
   force_destroy = !var.protect_resources
 
@@ -120,7 +120,7 @@ resource "aws_s3_bucket_public_access_block" "guide_objects_acl_block" {
 resource "aws_s3_bucket" "guide_objects" {
   count = var.create_s3_buckets ? 1 : 0
 
-  bucket        = "dozuki-guide-objects-${local.identifier}-${data.aws_region.current.name}"
+  bucket_prefix = "${local.identifier}-obj-${data.aws_region.current.name}"
   acl           = "private"
   force_destroy = !var.protect_resources
 
@@ -165,7 +165,7 @@ resource "aws_s3_bucket_public_access_block" "guide_pdfs_acl_block" {
 resource "aws_s3_bucket" "guide_pdfs" {
   count = var.create_s3_buckets ? 1 : 0
 
-  bucket        = "dozuki-guide-pdfs-${local.identifier}-${data.aws_region.current.name}"
+  bucket_prefix = "${local.identifier}-pdf-${data.aws_region.current.name}"
   acl           = "private"
   force_destroy = !var.protect_resources
 
@@ -210,7 +210,7 @@ resource "aws_s3_bucket_public_access_block" "guide_documents_acl_block" {
 resource "aws_s3_bucket" "guide_documents" {
   count = var.create_s3_buckets ? 1 : 0
 
-  bucket        = "dozuki-guide-documents-${local.identifier}-${data.aws_region.current.name}"
+  bucket_prefix = "${local.identifier}-doc-${data.aws_region.current.name}"
   acl           = "private"
   force_destroy = !var.protect_resources
 

--- a/cloudprem/physical/variables.tf
+++ b/cloudprem/physical/variables.tf
@@ -6,8 +6,8 @@ variable "identifier" {
   default     = ""
 
   validation {
-    condition     = length(var.identifier) <= 10
-    error_message = "The length of the identifier must be less than 11 characters."
+    condition     = length(var.identifier) <= 10 && can(regex("[[:lower:]]", substr(var.identifier, 0, 1)))
+    error_message = "The length of the identifier must be less than 10 characters and must begin with a lower-case letter."
   }
 }
 

--- a/cloudprem/physical/variables.tf
+++ b/cloudprem/physical/variables.tf
@@ -7,7 +7,7 @@ variable "identifier" {
 
   validation {
     condition     = length(var.identifier) <= 10 && can(regex("[[:lower:]]", substr(var.identifier, 0, 1)))
-    error_message = "The length of the identifier must be less than 10 characters and must begin with a lower-case letter."
+    error_message = "The length of the identifier must be less than or equal to 10 characters and must begin with a lower-case letter."
   }
 }
 


### PR DESCRIPTION
By using the terraform AWS provider s3 resource value `bucket` for naming the s3 buckets we take on the responsibility of ensuring each bucket we create has a unique name across the entire globally shared s3 namespace. This was problematic for obvious reasons so we instead use terraform's built-in `bucket_prefix` value which allows us to prepend the bucket name with a semantic tag while adding a sufficiently unique suffix to ensure no naming collisions take place. Doing so required shortening our naming scheme to stay within the 37 character limit enforced by the terraform AWS provider for the `bucket_prefix` value. 

After allotting 10 characters for an optional identifier, 5 characters for an environment name, up to 14 characters for the AWS region name, and potentially 1 section delimiter; that leaves us with just 7 characters to safely work with, 5 if you want additional section delimiters for clarity. This required shortening the names of each bucket considerably; however it should still be clear what each bucket is for.

Additionally we also needed to shorten the default locally generated identifier (the value we use as the "name" for most resources which is constructed based on the users configuration). We used to inject "dozuki" into this but those are 6 characters we can use elsewhere so I removed that. This has a nasty consequence though for any existing stacks that use the `var.identifier` field, either through the `env.hcl` file or via an overridden value configured via CloudFormation. If such a stack is upgraded to this version, it will trigger a full re-create of the environment which is effectively a no-op. So if any environments exist that currently use identifier, they will need to be manually migrated to a new stack using this version. In the future we will resist modifying this variable unless absolutely necessary to prevent this again.