### PR TITLE
Restore feature parity and improve reliability of KOTS deploys

### DIFF
--- a/cloudprem/logical/charts/kubed/OWNERS
+++ b/cloudprem/logical/charts/kubed/OWNERS
@@ -1,5 +1,0 @@
-approvers:
-- tamalsaha
-reviewers:
-- tamalsaha
-

--- a/live/gov/us-gov-west-1/bi/env.hcl
+++ b/live/gov/us-gov-west-1/bi/env.hcl
@@ -6,7 +6,7 @@ locals {
   enable_bi = true
   rds_multi_az = false
   highly_available_nat_gateway = false
-  dozuki_license_parameter_name = "/dozuki/workstation/kots"
+  dozuki_customer_id_parameter_name = "/dozuki/workstation/kots/default/customer_id"
   protect_resources = false
   bi_public_access = false
   bi_access_cidrs = ["0.0.0.0/0"]

--- a/live/gov/us-gov-west-1/full/env.hcl
+++ b/live/gov/us-gov-west-1/full/env.hcl
@@ -6,6 +6,10 @@ locals {
   enable_bi = true
   rds_multi_az = true
   highly_available_nat_gateway = false
-  dozuki_license_parameter_name = "/dozuki/workstation/webhooks/kots"
+  dozuki_customer_id_parameter_name = "/dozuki/workstation/kots/webhooks/customer_id"
   protect_resources = false
+  bi_public_access = true
+  bi_access_cidrs = ["0.0.0.0/0"]
+  grafana_access_cidrs = ["0.0.0.0/0"]
+  bi_vpn_access = false
 }

--- a/live/gov/us-gov-west-1/hooks/env.hcl
+++ b/live/gov/us-gov-west-1/hooks/env.hcl
@@ -6,6 +6,6 @@ locals {
   enable_bi = false
   rds_multi_az = false
   highly_available_nat_gateway = false
-  dozuki_license_parameter_name = "/dozuki/workstation/webhooks/kots"
+  dozuki_customer_id_parameter_name = "/dozuki/workstation/kots/webhooks/customer_id"
   protect_resources = false
 }

--- a/live/gov/us-gov-west-1/min/env.hcl
+++ b/live/gov/us-gov-west-1/min/env.hcl
@@ -6,6 +6,6 @@ locals {
   enable_bi = false
   rds_multi_az = false
   highly_available_nat_gateway = false
-  dozuki_license_parameter_name = "/dozuki/workstation/kots"
+  dozuki_customer_id_parameter_name = "/dozuki/workstation/kots/default/customer_id"
   protect_resources = false
 }

--- a/live/standard/eu-central-1/bi/env.hcl
+++ b/live/standard/eu-central-1/bi/env.hcl
@@ -6,7 +6,7 @@ locals {
   enable_bi = true
   rds_multi_az = false
   highly_available_nat_gateway = false
-  dozuki_license_parameter_name = "/dozuki/workstation/kots"
+  dozuki_customer_id_parameter_name = "/dozuki/workstation/kots/default/customer_id"
   protect_resources = false
   bi_public_access = false
   bi_access_cidrs = ["0.0.0.0/0"]

--- a/live/standard/eu-central-1/full/env.hcl
+++ b/live/standard/eu-central-1/full/env.hcl
@@ -6,6 +6,6 @@ locals {
   enable_bi = true
   rds_multi_az = true
   highly_available_nat_gateway = false
-  dozuki_license_parameter_name = "/dozuki/workstation/webhooks/kots"
+  dozuki_customer_id_parameter_name = "/dozuki/workstation/kots/webhooks/customer_id"
   protect_resources = false
 }

--- a/live/standard/eu-central-1/hooks/env.hcl
+++ b/live/standard/eu-central-1/hooks/env.hcl
@@ -6,6 +6,6 @@ locals {
   enable_bi = false
   rds_multi_az = false
   highly_available_nat_gateway = false
-  dozuki_license_parameter_name = "/dozuki/workstation/webhooks/kots"
+  dozuki_customer_id_parameter_name = "/dozuki/workstation/kots/webhooks/customer_id"
   protect_resources = false
 }

--- a/live/standard/eu-central-1/min/env.hcl
+++ b/live/standard/eu-central-1/min/env.hcl
@@ -6,6 +6,6 @@ locals {
   enable_bi = false
   rds_multi_az = false
   highly_available_nat_gateway = false
-  dozuki_license_parameter_name = "/dozuki/workstation/kots"
+  dozuki_customer_id_parameter_name = "/dozuki/workstation/kots/default/customer_id"
   protect_resources = false
 }

--- a/live/standard/eu-west-1/bi/env.hcl
+++ b/live/standard/eu-west-1/bi/env.hcl
@@ -6,7 +6,7 @@ locals {
   enable_bi = true
   rds_multi_az = false
   highly_available_nat_gateway = false
-  dozuki_license_parameter_name = "/dozuki/workstation/kots"
+  dozuki_customer_id_parameter_name = "/dozuki/workstation/kots/default/customer_id"
   protect_resources = false
   bi_public_access = false
   bi_access_cidrs = ["0.0.0.0/0"]

--- a/live/standard/eu-west-1/full/env.hcl
+++ b/live/standard/eu-west-1/full/env.hcl
@@ -6,6 +6,6 @@ locals {
   enable_bi = true
   rds_multi_az = true
   highly_available_nat_gateway = false
-  dozuki_license_parameter_name = "/dozuki/workstation/webhooks/kots"
+  dozuki_customer_id_parameter_name = "/dozuki/workstation/kots/webhooks/customer_id"
   protect_resources = false
 }

--- a/live/standard/eu-west-1/hooks/env.hcl
+++ b/live/standard/eu-west-1/hooks/env.hcl
@@ -6,6 +6,6 @@ locals {
   enable_bi = false
   rds_multi_az = false
   highly_available_nat_gateway = false
-  dozuki_license_parameter_name = "/dozuki/workstation/webhooks/kots"
+  dozuki_customer_id_parameter_name = "/dozuki/workstation/kots/webhooks/customer_id"
   protect_resources = false
 }

--- a/live/standard/eu-west-1/min/env.hcl
+++ b/live/standard/eu-west-1/min/env.hcl
@@ -6,6 +6,6 @@ locals {
   enable_bi = false
   rds_multi_az = false
   highly_available_nat_gateway = false
-  dozuki_license_parameter_name = "/dozuki/workstation/kots"
+  dozuki_customer_id_parameter_name = "/dozuki/workstation/kots/default/customer_id"
   protect_resources = false
 }

--- a/live/standard/eu-west-2/bi/env.hcl
+++ b/live/standard/eu-west-2/bi/env.hcl
@@ -6,7 +6,7 @@ locals {
   enable_bi = true
   rds_multi_az = false
   highly_available_nat_gateway = false
-  dozuki_license_parameter_name = "/dozuki/workstation/kots"
+  dozuki_customer_id_parameter_name = "/dozuki/workstation/kots/default/customer_id"
   protect_resources = false
   bi_public_access = false
   bi_access_cidrs = ["0.0.0.0/0"]

--- a/live/standard/eu-west-2/full/env.hcl
+++ b/live/standard/eu-west-2/full/env.hcl
@@ -6,6 +6,6 @@ locals {
   enable_bi = true
   rds_multi_az = true
   highly_available_nat_gateway = false
-  dozuki_license_parameter_name = "/dozuki/workstation/webhooks/kots"
+  dozuki_customer_id_parameter_name = "/dozuki/workstation/kots/webhooks/customer_id"
   protect_resources = false
 }

--- a/live/standard/eu-west-2/hooks/env.hcl
+++ b/live/standard/eu-west-2/hooks/env.hcl
@@ -6,6 +6,6 @@ locals {
   enable_bi = false
   rds_multi_az = false
   highly_available_nat_gateway = false
-  dozuki_license_parameter_name = "/dozuki/workstation/webhooks/kots"
+  dozuki_customer_id_parameter_name = "/dozuki/workstation/kots/webhooks/customer_id"
   protect_resources = false
 }

--- a/live/standard/eu-west-2/min/env.hcl
+++ b/live/standard/eu-west-2/min/env.hcl
@@ -6,6 +6,6 @@ locals {
   enable_bi = false
   rds_multi_az = false
   highly_available_nat_gateway = false
-  dozuki_license_parameter_name = "/dozuki/workstation/kots"
+  dozuki_customer_id_parameter_name = "/dozuki/workstation/kots/default/customer_id"
   protect_resources = false
 }

--- a/live/standard/eu-west-3/bi/env.hcl
+++ b/live/standard/eu-west-3/bi/env.hcl
@@ -6,7 +6,7 @@ locals {
   enable_bi = true
   rds_multi_az = false
   highly_available_nat_gateway = false
-  dozuki_license_parameter_name = "/dozuki/workstation/kots"
+  dozuki_customer_id_parameter_name = "/dozuki/workstation/kots/default/customer_id"
   protect_resources = false
   bi_public_access = false
   bi_access_cidrs = ["0.0.0.0/0"]

--- a/live/standard/eu-west-3/full/env.hcl
+++ b/live/standard/eu-west-3/full/env.hcl
@@ -6,6 +6,6 @@ locals {
   enable_bi = true
   rds_multi_az = true
   highly_available_nat_gateway = false
-  dozuki_license_parameter_name = "/dozuki/workstation/webhooks/kots"
+  dozuki_customer_id_parameter_name = "/dozuki/workstation/kots/webhooks/customer_id"
   protect_resources = false
 }

--- a/live/standard/eu-west-3/hooks/env.hcl
+++ b/live/standard/eu-west-3/hooks/env.hcl
@@ -6,6 +6,6 @@ locals {
   enable_bi = false
   rds_multi_az = false
   highly_available_nat_gateway = false
-  dozuki_license_parameter_name = "/dozuki/workstation/webhooks/kots"
+  dozuki_customer_id_parameter_name = "/dozuki/workstation/kots/webhooks/customer_id"
   protect_resources = false
 }

--- a/live/standard/eu-west-3/min/env.hcl
+++ b/live/standard/eu-west-3/min/env.hcl
@@ -6,6 +6,6 @@ locals {
   enable_bi = false
   rds_multi_az = false
   highly_available_nat_gateway = false
-  dozuki_license_parameter_name = "/dozuki/workstation/kots"
+  dozuki_customer_id_parameter_name = "/dozuki/workstation/kots/default/customer_id"
   protect_resources = false
 }

--- a/live/standard/us-east-1/bi/env.hcl
+++ b/live/standard/us-east-1/bi/env.hcl
@@ -6,7 +6,7 @@ locals {
   enable_bi = true
   rds_multi_az = false
   highly_available_nat_gateway = false
-  dozuki_license_parameter_name = "/dozuki/workstation/kots"
+  dozuki_customer_id_parameter_name = "/dozuki/workstation/kots/default/customer_id"
   protect_resources = false
   bi_public_access = false
   bi_access_cidrs = ["0.0.0.0/0"]

--- a/live/standard/us-east-1/full/env.hcl
+++ b/live/standard/us-east-1/full/env.hcl
@@ -6,6 +6,10 @@ locals {
   enable_bi = true
   rds_multi_az = true
   highly_available_nat_gateway = false
-  dozuki_license_parameter_name = "/dozuki/workstation/webhooks/kots"
+  dozuki_customer_id_parameter_name = "/dozuki/workstation/kots/webhooks/customer_id"
   protect_resources = false
+  bi_public_access = true
+  bi_access_cidrs = ["0.0.0.0/0"]
+  grafana_access_cidrs = ["0.0.0.0/0"]
+  bi_vpn_access = false
 }

--- a/live/standard/us-east-1/hooks/env.hcl
+++ b/live/standard/us-east-1/hooks/env.hcl
@@ -6,6 +6,6 @@ locals {
   enable_bi = false
   rds_multi_az = false
   highly_available_nat_gateway = false
-  dozuki_license_parameter_name = "/dozuki/workstation/webhooks/kots"
+  dozuki_customer_id_parameter_name = "/dozuki/workstation/kots/webhooks/customer_id"
   protect_resources = false
 }

--- a/live/standard/us-east-1/min/env.hcl
+++ b/live/standard/us-east-1/min/env.hcl
@@ -6,6 +6,6 @@ locals {
   enable_bi = false
   rds_multi_az = false
   highly_available_nat_gateway = false
-  dozuki_license_parameter_name = "/dozuki/workstation/kots"
+  dozuki_customer_id_parameter_name = "/dozuki/workstation/kots/default/customer_id"
   protect_resources = false
 }

--- a/live/standard/us-east-2/bi/env.hcl
+++ b/live/standard/us-east-2/bi/env.hcl
@@ -6,7 +6,7 @@ locals {
   enable_bi = true
   rds_multi_az = false
   highly_available_nat_gateway = false
-  dozuki_license_parameter_name = "/dozuki/workstation/kots"
+  dozuki_customer_id_parameter_name = "/dozuki/workstation/kots/default/customer_id"
   protect_resources = false
   bi_public_access = false
   bi_access_cidrs = ["0.0.0.0/0"]

--- a/live/standard/us-east-2/full/env.hcl
+++ b/live/standard/us-east-2/full/env.hcl
@@ -6,6 +6,6 @@ locals {
   enable_bi = true
   rds_multi_az = true
   highly_available_nat_gateway = false
-  dozuki_license_parameter_name = "/dozuki/workstation/webhooks/kots"
+  dozuki_customer_id_parameter_name = "/dozuki/workstation/kots/webhooks/customer_id"
   protect_resources = false
 }

--- a/live/standard/us-east-2/hooks/env.hcl
+++ b/live/standard/us-east-2/hooks/env.hcl
@@ -6,6 +6,6 @@ locals {
   enable_bi = false
   rds_multi_az = false
   highly_available_nat_gateway = false
-  dozuki_license_parameter_name = "/dozuki/workstation/webhooks/kots"
+  dozuki_customer_id_parameter_name = "/dozuki/workstation/kots/webhooks/customer_id"
   protect_resources = false
 }

--- a/live/standard/us-east-2/min/env.hcl
+++ b/live/standard/us-east-2/min/env.hcl
@@ -6,6 +6,6 @@ locals {
   enable_bi = false
   rds_multi_az = false
   highly_available_nat_gateway = false
-  dozuki_license_parameter_name = "/dozuki/workstation/kots"
+  dozuki_customer_id_parameter_name = "/dozuki/workstation/kots/default/customer_id"
   protect_resources = false
 }

--- a/live/standard/us-west-2/bi/env.hcl
+++ b/live/standard/us-west-2/bi/env.hcl
@@ -6,7 +6,7 @@ locals {
   enable_bi = true
   rds_multi_az = false
   highly_available_nat_gateway = false
-  dozuki_license_parameter_name = "/dozuki/workstation/kots"
+  dozuki_customer_id_parameter_name = "/dozuki/workstation/kots/default/customer_id"
   protect_resources = false
   bi_public_access = false
   bi_access_cidrs = ["0.0.0.0/0"]

--- a/live/standard/us-west-2/full/env.hcl
+++ b/live/standard/us-west-2/full/env.hcl
@@ -6,6 +6,6 @@ locals {
   enable_bi = true
   rds_multi_az = true
   highly_available_nat_gateway = false
-  dozuki_license_parameter_name = "/dozuki/workstation/webhooks/kots"
+  dozuki_customer_id_parameter_name = "/dozuki/workstation/kots/webhooks/customer_id"
   protect_resources = false
 }

--- a/live/standard/us-west-2/hooks/env.hcl
+++ b/live/standard/us-west-2/hooks/env.hcl
@@ -6,6 +6,6 @@ locals {
   enable_bi = false
   rds_multi_az = false
   highly_available_nat_gateway = false
-  dozuki_license_parameter_name = "/dozuki/workstation/webhooks/kots"
+  dozuki_customer_id_parameter_name = "/dozuki/workstation/kots/webhooks/customer_id"
   protect_resources = false
 }

--- a/live/standard/us-west-2/min/env.hcl
+++ b/live/standard/us-west-2/min/env.hcl
@@ -6,6 +6,6 @@ locals {
   enable_bi = false
   rds_multi_az = false
   highly_available_nat_gateway = false
-  dozuki_license_parameter_name = "/dozuki/workstation/kots"
+  dozuki_customer_id_parameter_name = "/dozuki/workstation/kots/default/customer_id"
   protect_resources = false
 }

--- a/terraform/logical/README.md
+++ b/terraform/logical/README.md
@@ -19,6 +19,7 @@
 | <a name="provider_helm"></a> [helm](#provider\_helm) | 2.3.0 |
 | <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | 2.13.1 |
 | <a name="provider_local"></a> [local](#provider\_local) | 2.2.3 |
+| <a name="provider_null"></a> [null](#provider\_null) | 3.1.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | 3.4.3 |
 
 ## Modules
@@ -54,7 +55,7 @@
 | [kubernetes_secret.grafana_ssl](https://registry.terraform.io/providers/hashicorp/kubernetes/2.13.1/docs/resources/secret) | resource |
 | [kubernetes_secret.site_tls](https://registry.terraform.io/providers/hashicorp/kubernetes/2.13.1/docs/resources/secret) | resource |
 | [local_file.replicated_install](https://registry.terraform.io/providers/hashicorp/local/2.2.3/docs/resources/file) | resource |
-| [local_file.replicated_license](https://registry.terraform.io/providers/hashicorp/local/2.2.3/docs/resources/file) | resource |
+| [null_resource.pull_replicated_license](https://registry.terraform.io/providers/hashicorp/null/3.1.0/docs/resources/resource) | resource |
 | [random_password.dashboard_password](https://registry.terraform.io/providers/hashicorp/random/3.4.3/docs/resources/password) | resource |
 | [random_password.grafana_admin](https://registry.terraform.io/providers/hashicorp/random/3.4.3/docs/resources/password) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/data-sources/caller_identity) | data source |
@@ -64,7 +65,7 @@
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/data-sources/region) | data source |
 | [aws_secretsmanager_secret_version.db_bi](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/data-sources/secretsmanager_secret_version) | data source |
 | [aws_secretsmanager_secret_version.db_master](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/data-sources/secretsmanager_secret_version) | data source |
-| [aws_ssm_parameter.dozuki_license](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/data-sources/ssm_parameter) | data source |
+| [aws_ssm_parameter.dozuki_customer_id](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/data-sources/ssm_parameter) | data source |
 | [kubernetes_secret.frontegg](https://registry.terraform.io/providers/hashicorp/kubernetes/2.13.1/docs/data-sources/secret) | data source |
 
 ## Inputs
@@ -75,7 +76,7 @@
 | <a name="input_azs_count"></a> [azs\_count](#input\_azs\_count) | The number of availability zones we should use for deployment. | `number` | `3` | no |
 | <a name="input_bi_database_credential_secret"></a> [bi\_database\_credential\_secret](#input\_bi\_database\_credential\_secret) | ARN to secret containing bi db credentials | `string` | `""` | no |
 | <a name="input_dms_task_arn"></a> [dms\_task\_arn](#input\_dms\_task\_arn) | If BI is enabled, the DMS replication task arn. | `string` | n/a | yes |
-| <a name="input_dozuki_license_parameter_name"></a> [dozuki\_license\_parameter\_name](#input\_dozuki\_license\_parameter\_name) | Parameter name for dozuki license in AWS Parameter store. | `string` | `""` | no |
+| <a name="input_dozuki_customer_id_parameter_name"></a> [dozuki\_customer\_id\_parameter\_name](#input\_dozuki\_customer\_id\_parameter\_name) | Parameter name for dozuki customer id in AWS Parameter store. | `string` | `""` | no |
 | <a name="input_eks_cluster_access_role_arn"></a> [eks\_cluster\_access\_role\_arn](#input\_eks\_cluster\_access\_role\_arn) | ARN for the IAM Role for API-based EKS cluster access. | `string` | n/a | yes |
 | <a name="input_eks_cluster_id"></a> [eks\_cluster\_id](#input\_eks\_cluster\_id) | ID of EKS cluster for app provisioning | `string` | n/a | yes |
 | <a name="input_eks_oidc_cluster_access_role_name"></a> [eks\_oidc\_cluster\_access\_role\_name](#input\_eks\_oidc\_cluster\_access\_role\_name) | ARN for OIDC-compatible IAM Role for the EKS Cluster Autoscaler | `string` | n/a | yes |

--- a/terraform/logical/README.md
+++ b/terraform/logical/README.md
@@ -42,7 +42,6 @@
 | [helm_release.metrics_server](https://registry.terraform.io/providers/hashicorp/helm/2.3.0/docs/resources/release) | resource |
 | [helm_release.mongodb](https://registry.terraform.io/providers/hashicorp/helm/2.3.0/docs/resources/release) | resource |
 | [helm_release.redis](https://registry.terraform.io/providers/hashicorp/helm/2.3.0/docs/resources/release) | resource |
-| [kubernetes_annotations.www_tls](https://registry.terraform.io/providers/hashicorp/kubernetes/2.13.1/docs/resources/annotations) | resource |
 | [kubernetes_config_map.dozuki_resources](https://registry.terraform.io/providers/hashicorp/kubernetes/2.13.1/docs/resources/config_map) | resource |
 | [kubernetes_horizontal_pod_autoscaler.app](https://registry.terraform.io/providers/hashicorp/kubernetes/2.13.1/docs/resources/horizontal_pod_autoscaler) | resource |
 | [kubernetes_horizontal_pod_autoscaler.queueworkerd](https://registry.terraform.io/providers/hashicorp/kubernetes/2.13.1/docs/resources/horizontal_pod_autoscaler) | resource |

--- a/terraform/logical/README.md
+++ b/terraform/logical/README.md
@@ -55,6 +55,7 @@
 | [kubernetes_secret.grafana_config](https://registry.terraform.io/providers/hashicorp/kubernetes/2.13.1/docs/resources/secret) | resource |
 | [kubernetes_secret.grafana_ssl](https://registry.terraform.io/providers/hashicorp/kubernetes/2.13.1/docs/resources/secret) | resource |
 | [kubernetes_secret.site_tls](https://registry.terraform.io/providers/hashicorp/kubernetes/2.13.1/docs/resources/secret) | resource |
+| [local_file.replicated_bootstrap_config](https://registry.terraform.io/providers/hashicorp/local/2.2.3/docs/resources/file) | resource |
 | [local_file.replicated_install](https://registry.terraform.io/providers/hashicorp/local/2.2.3/docs/resources/file) | resource |
 | [null_resource.pull_replicated_license](https://registry.terraform.io/providers/hashicorp/null/3.1.0/docs/resources/resource) | resource |
 | [random_password.dashboard_password](https://registry.terraform.io/providers/hashicorp/random/3.4.3/docs/resources/password) | resource |

--- a/terraform/logical/README.md
+++ b/terraform/logical/README.md
@@ -51,6 +51,8 @@
 | [kubernetes_job.sites_config_update](https://registry.terraform.io/providers/hashicorp/kubernetes/2.13.1/docs/resources/job) | resource |
 | [kubernetes_job.wait_for_app](https://registry.terraform.io/providers/hashicorp/kubernetes/2.13.1/docs/resources/job) | resource |
 | [kubernetes_namespace.kots_app](https://registry.terraform.io/providers/hashicorp/kubernetes/2.13.1/docs/resources/namespace) | resource |
+| [kubernetes_role.dozuki_list_role](https://registry.terraform.io/providers/hashicorp/kubernetes/2.13.1/docs/resources/role) | resource |
+| [kubernetes_role_binding.dozuki_list_role_binding](https://registry.terraform.io/providers/hashicorp/kubernetes/2.13.1/docs/resources/role_binding) | resource |
 | [kubernetes_secret.grafana_config](https://registry.terraform.io/providers/hashicorp/kubernetes/2.13.1/docs/resources/secret) | resource |
 | [kubernetes_secret.grafana_ssl](https://registry.terraform.io/providers/hashicorp/kubernetes/2.13.1/docs/resources/secret) | resource |
 | [kubernetes_secret.site_tls](https://registry.terraform.io/providers/hashicorp/kubernetes/2.13.1/docs/resources/secret) | resource |

--- a/terraform/logical/bi.tf
+++ b/terraform/logical/bi.tf
@@ -1,7 +1,7 @@
 resource "kubernetes_job" "dms_start" {
   count = var.enable_bi ? 1 : 0
 
-  depends_on = [local_file.replicated_install]
+  depends_on = [local_file.replicated_install, kubernetes_role_binding.dozuki_list_role_binding]
 
   metadata {
     name = "dms-start"

--- a/terraform/logical/bi.tf
+++ b/terraform/logical/bi.tf
@@ -5,7 +5,7 @@ resource "kubernetes_job" "dms_start" {
 
   metadata {
     name      = "dms-start"
-    namespace = local.k8s_namespace
+    namespace = kubernetes_namespace.kots_app.metadata[0].name
   }
   spec {
     template {
@@ -45,12 +45,11 @@ module "grafana_ssl_cert" {
 }
 
 resource "kubernetes_secret" "grafana_ssl" {
-  count      = var.enable_bi ? !var.grafana_use_replicated_ssl ? 1 : 0 : 0
-  depends_on = [kubernetes_namespace.kots_app]
+  count = var.enable_bi ? !var.grafana_use_replicated_ssl ? 1 : 0 : 0
 
   metadata {
     name      = "grafana-ssl"
-    namespace = local.k8s_namespace
+    namespace = kubernetes_namespace.kots_app.metadata[0].name
   }
 
   data = {
@@ -60,11 +59,10 @@ resource "kubernetes_secret" "grafana_ssl" {
 }
 
 resource "kubernetes_secret" "grafana_config" {
-  depends_on = [kubernetes_namespace.kots_app]
 
   metadata {
     name      = "grafana-config"
-    namespace = local.k8s_namespace
+    namespace = kubernetes_namespace.kots_app.metadata[0].name
   }
 
   data = {
@@ -90,7 +88,7 @@ resource "helm_release" "grafana" {
   name  = "grafana"
   chart = "${path.module}/charts/grafana"
 
-  namespace = local.k8s_namespace
+  namespace = kubernetes_namespace.kots_app.metadata[0].name
 
   reuse_values = true
 

--- a/terraform/logical/kubernetes.tf
+++ b/terraform/logical/kubernetes.tf
@@ -8,7 +8,7 @@ resource "kubernetes_role" "dozuki_list_role" {
 
   metadata {
     name      = "dozuki_list_role"
-    namespace = local.k8s_namespace
+    namespace = kubernetes_namespace.kots_app.metadata[0].name
   }
 
   rule {
@@ -22,7 +22,7 @@ resource "kubernetes_role_binding" "dozuki_list_role_binding" {
 
   metadata {
     name      = "dozuki_list_role_binding"
-    namespace = local.k8s_namespace
+    namespace = kubernetes_namespace.kots_app.metadata[0].name
   }
   role_ref {
     api_group = "rbac.authorization.k8s.io"
@@ -32,7 +32,7 @@ resource "kubernetes_role_binding" "dozuki_list_role_binding" {
   subject {
     kind      = "ServiceAccount"
     name      = "default"
-    namespace = local.k8s_namespace
+    namespace = kubernetes_namespace.kots_app.metadata[0].name
   }
 }
 
@@ -40,7 +40,7 @@ resource "kubernetes_config_map" "dozuki_resources" {
 
   metadata {
     name      = "dozuki-resources-configmap"
-    namespace = local.k8s_namespace
+    namespace = kubernetes_namespace.kots_app.metadata[0].name
   }
 
   data = {
@@ -142,7 +142,7 @@ resource "kubernetes_config_map" "dozuki_resources" {
       {
         "clientId": "${local.frontegg_clientid}",
         "apiToken": "${local.frontegg_apikey}",
-        "apiBaseUrl": "http://frontegg-api-gateway.${local.k8s_namespace}.svc.cluster.local",
+        "apiBaseUrl": "http://frontegg-api-gateway.${kubernetes_namespace.kots_app.metadata[0].name}.svc.cluster.local",
         "authUrl": "https://api.frontegg.com/auth/vendor"
       }
     EOF
@@ -196,7 +196,7 @@ resource "helm_release" "container_insights" {
   name  = "container-insights"
   chart = "${path.module}/charts/container_insights"
 
-  namespace = local.k8s_namespace
+  namespace = kubernetes_namespace.kots_app.metadata[0].name
 
   set {
     name  = "cluster_name"

--- a/terraform/logical/kubernetes.tf
+++ b/terraform/logical/kubernetes.tf
@@ -1,3 +1,9 @@
+resource "kubernetes_namespace" "kots_app" {
+  metadata {
+    name = local.k8s_namespace_name
+  }
+}
+
 resource "kubernetes_role" "dozuki_list_role" {
 
   metadata {

--- a/terraform/logical/kubernetes.tf
+++ b/terraform/logical/kubernetes.tf
@@ -1,3 +1,35 @@
+resource "kubernetes_role" "dozuki_list_role" {
+
+  metadata {
+    name      = "dozuki_list_role"
+    namespace = local.k8s_namespace
+  }
+
+  rule {
+    api_groups = ["apps"]
+    resources  = ["deployments"]
+    verbs      = ["get", "list", "watch"]
+  }
+}
+
+resource "kubernetes_role_binding" "dozuki_list_role_binding" {
+
+  metadata {
+    name      = "dozuki_list_role_binding"
+    namespace = local.k8s_namespace
+  }
+  role_ref {
+    api_group = "rbac.authorization.k8s.io"
+    kind      = "Role"
+    name      = kubernetes_role.dozuki_list_role.metadata[0].name
+  }
+  subject {
+    kind      = "ServiceAccount"
+    name      = "default"
+    namespace = local.k8s_namespace
+  }
+}
+
 resource "kubernetes_config_map" "dozuki_resources" {
 
   metadata {

--- a/terraform/logical/kubernetes.tf
+++ b/terraform/logical/kubernetes.tf
@@ -136,7 +136,7 @@ resource "kubernetes_config_map" "dozuki_resources" {
       {
         "clientId": "${local.frontegg_clientid}",
         "apiToken": "${local.frontegg_apikey}",
-        "apiBaseUrl": "http://frontegg-api-gateway.default.svc.cluster.local",
+        "apiBaseUrl": "http://frontegg-api-gateway.${local.k8s_namespace}.svc.cluster.local",
         "authUrl": "https://api.frontegg.com/auth/vendor"
       }
     EOF
@@ -190,7 +190,7 @@ resource "helm_release" "container_insights" {
   name  = "container-insights"
   chart = "${path.module}/charts/container_insights"
 
-  namespace = "default"
+  namespace = local.k8s_namespace
 
   set {
     name  = "cluster_name"

--- a/terraform/logical/main.tf
+++ b/terraform/logical/main.tf
@@ -41,7 +41,7 @@ locals {
 
   ca_cert_pem_file = local.is_us_gov ? "vendor/us-gov-west-1-bundle.pem" : "vendor/rds-ca-2019-root.pem"
 
-  aws_profile = var.aws_profile ? "AWS_PROFILE=${var.aws_profile}" : ""
+  aws_profile_prefix = var.aws_profile != "" ? "AWS_PROFILE=${var.aws_profile}" : ""
 
   # Database
   db_credentials = jsondecode(data.aws_secretsmanager_secret_version.db_master.secret_string)

--- a/terraform/logical/main.tf
+++ b/terraform/logical/main.tf
@@ -68,9 +68,9 @@ locals {
   grafana_ssl_secret_name = var.grafana_use_replicated_ssl ? "www-tls" : kubernetes_secret.grafana_ssl[0].metadata[0].name
 
   # Replicated
-  app_slug        = "dozukikots"
-  k8s_namespace   = "dozuki"
-  app_and_channel = "${local.app_slug}${var.replicated_channel != "" ? "/" : ""}${var.replicated_channel}"
+  app_slug           = "dozukikots"
+  k8s_namespace_name = "dozuki"
+  app_and_channel    = "${local.app_slug}${var.replicated_channel != "" ? "/" : ""}${var.replicated_channel}"
 
 }
 

--- a/terraform/logical/main.tf
+++ b/terraform/logical/main.tf
@@ -35,7 +35,7 @@ provider "helm" {
 }
 
 locals {
-  dozuki_license_parameter_name = var.dozuki_license_parameter_name == "" ? (var.identifier == "" ? "/dozuki/${var.environment}/license" : "/${var.identifier}/dozuki/${var.environment}/license") : var.dozuki_license_parameter_name
+  dozuki_customer_id_parameter_name = var.dozuki_customer_id_parameter_name == "" ? (var.identifier == "" ? "/dozuki/${var.environment}/customer_id" : "/${var.identifier}/dozuki/${var.environment}/customer_id") : var.dozuki_customer_id_parameter_name
 
   is_us_gov = data.aws_partition.current.partition == "aws-us-gov"
 

--- a/terraform/logical/main.tf
+++ b/terraform/logical/main.tf
@@ -41,6 +41,8 @@ locals {
 
   ca_cert_pem_file = local.is_us_gov ? "vendor/us-gov-west-1-bundle.pem" : "vendor/rds-ca-2019-root.pem"
 
+  aws_profile = var.aws_profile ? "AWS_PROFILE=${var.aws_profile}" : ""
+
   # Database
   db_credentials = jsondecode(data.aws_secretsmanager_secret_version.db_master.secret_string)
 

--- a/terraform/logical/outputs.tf
+++ b/terraform/logical/outputs.tf
@@ -1,6 +1,6 @@
 output "dashboard_url" {
   description = "URL to your Dozuki Dashboard."
-  value       = format("https://%s:8800", var.nlb_dns_name)
+  value       = format("http://%s:8800", var.nlb_dns_name)
 }
 
 output "dashboard_password" {

--- a/terraform/logical/replicated.tf
+++ b/terraform/logical/replicated.tf
@@ -70,7 +70,7 @@ resource "local_file" "replicated_install" {
 #!/bin/bash
 set -euo pipefail
 
-${local.aws_profile} aws --region ${data.aws_region.current.name} eks update-kubeconfig --name ${var.eks_cluster_id} --role-arn ${var.eks_cluster_access_role_arn}
+${local.aws_profile_prefix} aws --region ${data.aws_region.current.name} eks update-kubeconfig --name ${var.eks_cluster_id} --role-arn ${var.eks_cluster_access_role_arn}
 
 kubectl config set-context --current --namespace=${local.k8s_namespace}
 

--- a/terraform/logical/replicated.tf
+++ b/terraform/logical/replicated.tf
@@ -55,7 +55,7 @@ resource "local_file" "replicated_install" {
 #!/bin/sh
 set -euo pipefail
 
-aws --region ${data.aws_region.current.name} eks update-kubeconfig --name ${var.eks_cluster_id} --role-arn ${var.eks_cluster_access_role_arn}
+aws --region ${data.aws_region.current.name} eks update-kubeconfig --name ${var.eks_cluster_id} --role-arn ${var.eks_cluster_access_role_arn} --profile ${var.aws_profile}
 
 kubectl config set-context --current --namespace=${local.k8s_namespace}
 

--- a/terraform/logical/replicated.tf
+++ b/terraform/logical/replicated.tf
@@ -29,14 +29,14 @@ module "ssl_cert" {
   identifier  = var.identifier
 
   cert_common_name = var.nlb_dns_name
-  namespace        = local.k8s_namespace
+  namespace        = kubernetes_namespace.kots_app.metadata[0].name
 }
 
 resource "kubernetes_secret" "site_tls" {
 
   metadata {
     name      = "www-tls"
-    namespace = local.k8s_namespace
+    namespace = kubernetes_namespace.kots_app.metadata[0].name
   }
 
   data = {
@@ -71,14 +71,14 @@ set -euo pipefail
 
 ${local.aws_profile_prefix} aws --region ${data.aws_region.current.name} eks update-kubeconfig --name ${var.eks_cluster_id} --role-arn ${var.eks_cluster_access_role_arn}
 
-kubectl config set-context --current --namespace=${local.k8s_namespace}
+kubectl config set-context --current --namespace=${kubernetes_namespace.kots_app.metadata[0].name}
 
 [[ -x $(which kubectl-kots) ]] || curl https://kots.io/install | bash
 
 set -v
 
 kubectl kots install ${local.app_and_channel} \
-  --namespace ${local.k8s_namespace} \
+  --namespace ${kubernetes_namespace.kots_app.metadata[0].name} \
   --license-file ./dozuki.yaml \
   --shared-password '${random_password.dashboard_password.result}' \
   --config-values ${local_file.replicated_bootstrap_config.filename} \

--- a/terraform/logical/replicated.tf
+++ b/terraform/logical/replicated.tf
@@ -70,7 +70,7 @@ resource "local_file" "replicated_install" {
 #!/bin/bash
 set -euo pipefail
 
-aws --region ${data.aws_region.current.name} eks update-kubeconfig --name ${var.eks_cluster_id} --role-arn ${var.eks_cluster_access_role_arn} --profile ${var.aws_profile}
+AWS_PROFILE=${var.aws_profile} aws --region ${data.aws_region.current.name} eks update-kubeconfig --name ${var.eks_cluster_id} --role-arn ${var.eks_cluster_access_role_arn}
 
 kubectl config set-context --current --namespace=${local.k8s_namespace}
 

--- a/terraform/logical/replicated.tf
+++ b/terraform/logical/replicated.tf
@@ -67,7 +67,7 @@ resource "local_file" "replicated_install" {
 
   filename = "./kots_install.sh"
   content  = <<EOT
-#!/bin/sh
+#!/bin/bash
 set -euo pipefail
 
 aws --region ${data.aws_region.current.name} eks update-kubeconfig --name ${var.eks_cluster_id} --role-arn ${var.eks_cluster_access_role_arn} --profile ${var.aws_profile}

--- a/terraform/logical/replicated.tf
+++ b/terraform/logical/replicated.tf
@@ -22,12 +22,6 @@ resource "null_resource" "pull_replicated_license" {
   }
 }
 
-resource "kubernetes_namespace" "kots_app" {
-  metadata {
-    name = local.k8s_namespace
-  }
-}
-
 module "ssl_cert" {
 
   source      = "../common/acm"

--- a/terraform/logical/replicated.tf
+++ b/terraform/logical/replicated.tf
@@ -12,8 +12,13 @@ resource "random_password" "dashboard_password" {
 }
 
 resource "null_resource" "pull_replicated_license" {
+
+  triggers = {
+    customer_parameter_name = data.aws_ssm_parameter.dozuki_customer_id.value
+  }
+
   provisioner "local-exec" {
-    command = "curl -o dozuki.yaml -H 'Authorization: ${data.aws_ssm_parameter.dozuki_customer_id.value}' https://replicated.app/customer/license/download/dozukikots"
+    command = "curl -o dozuki.yaml -H 'Authorization: ${self.triggers.customer_parameter_name}' https://replicated.app/customer/license/download/dozukikots"
   }
 }
 

--- a/terraform/logical/replicated.tf
+++ b/terraform/logical/replicated.tf
@@ -70,7 +70,7 @@ resource "local_file" "replicated_install" {
 #!/bin/bash
 set -euo pipefail
 
-AWS_PROFILE=${var.aws_profile} aws --region ${data.aws_region.current.name} eks update-kubeconfig --name ${var.eks_cluster_id} --role-arn ${var.eks_cluster_access_role_arn}
+${local.aws_profile} aws --region ${data.aws_region.current.name} eks update-kubeconfig --name ${var.eks_cluster_id} --role-arn ${var.eks_cluster_access_role_arn}
 
 kubectl config set-context --current --namespace=${local.k8s_namespace}
 

--- a/terraform/logical/scaling.tf
+++ b/terraform/logical/scaling.tf
@@ -30,9 +30,10 @@ resource "helm_release" "metrics_server" {
 
 resource "kubernetes_horizontal_pod_autoscaler" "app" {
   depends_on = [local_file.replicated_install]
+
   metadata {
     name      = "app-hpa"
-    namespace = local.k8s_namespace
+    namespace = kubernetes_namespace.kots_app.metadata[0].name
   }
 
   spec {
@@ -71,9 +72,10 @@ resource "kubernetes_horizontal_pod_autoscaler" "app" {
 
 resource "kubernetes_horizontal_pod_autoscaler" "queueworkerd" {
   depends_on = [local_file.replicated_install]
+
   metadata {
     name      = "queueworkerd-hpa"
-    namespace = local.k8s_namespace
+    namespace = kubernetes_namespace.kots_app.metadata[0].name
   }
 
   spec {

--- a/terraform/logical/variables.tf
+++ b/terraform/logical/variables.tf
@@ -47,9 +47,9 @@ variable "azs_count" {
 
 # --- BEGIN App Configuration --- #
 
-variable "dozuki_license_parameter_name" {
+variable "dozuki_customer_id_parameter_name" {
   type        = string
-  description = "Parameter name for dozuki license in AWS Parameter store."
+  description = "Parameter name for dozuki customer id in AWS Parameter store."
   default     = ""
 }
 
@@ -64,12 +64,6 @@ variable "enable_bi" {
   type        = string
   default     = false
 }
-
-#variable "replicated_app_sequence_number" {
-#  description = "For fresh installs you can target a specific Replicated sequence for first install. This will not be respected for existing installations. Use 0 for latest release."
-#  default     = 0
-#  type        = number
-#}
 
 variable "replicated_channel" {
   description = "If specifying an app sequence for a fresh install, this is the channel that sequence was deployed to. You only need to set this if the sequence you configured was not released on the default channel associated with your customer license."

--- a/terraform/logical/webhooks.tf
+++ b/terraform/logical/webhooks.tf
@@ -6,7 +6,7 @@ data "kubernetes_secret" "frontegg" {
 
   metadata {
     name      = "frontegg-credentials"
-    namespace = local.k8s_namespace
+    namespace = kubernetes_namespace.kots_app.metadata[0].name
   }
 }
 resource "kubernetes_job" "wait_for_app" {
@@ -16,7 +16,7 @@ resource "kubernetes_job" "wait_for_app" {
 
   metadata {
     name      = "wait-for-app"
-    namespace = local.k8s_namespace
+    namespace = kubernetes_namespace.kots_app.metadata[0].name
   }
   spec {
     template {
@@ -48,7 +48,7 @@ resource "kubernetes_job" "frontegg_database_create" {
 
   metadata {
     name      = "frontegg-db-update"
-    namespace = local.k8s_namespace
+    namespace = kubernetes_namespace.kots_app.metadata[0].name
   }
   spec {
     template {
@@ -79,7 +79,7 @@ resource "kubernetes_job" "sites_config_update" {
 
   metadata {
     name      = "sites-config-update"
-    namespace = local.k8s_namespace
+    namespace = kubernetes_namespace.kots_app.metadata[0].name
   }
   spec {
     template {
@@ -109,7 +109,7 @@ resource "helm_release" "mongodb" {
 
   name      = "frontegg-documents"
   chart     = "charts/mongodb"
-  namespace = local.k8s_namespace
+  namespace = kubernetes_namespace.kots_app.metadata[0].name
 
   set {
     name  = "auth.enabled"
@@ -122,7 +122,7 @@ resource "helm_release" "redis" {
 
   name      = "frontegg-kvstore"
   chart     = "charts/redis"
-  namespace = local.k8s_namespace
+  namespace = kubernetes_namespace.kots_app.metadata[0].name
 
   set {
     name  = "auth.enabled"
@@ -151,7 +151,7 @@ resource "helm_release" "frontegg" {
   name  = "frontegg"
   chart = "charts/connectivity"
 
-  namespace = local.k8s_namespace
+  namespace = kubernetes_namespace.kots_app.metadata[0].name
 
   reuse_values = true
 

--- a/terraform/logical/webhooks.tf
+++ b/terraform/logical/webhooks.tf
@@ -12,7 +12,7 @@ data "kubernetes_secret" "frontegg" {
 resource "kubernetes_job" "wait_for_app" {
   count = var.enable_webhooks ? 1 : 0
 
-  depends_on = [local_file.replicated_install]
+  depends_on = [local_file.replicated_install, kubernetes_role_binding.dozuki_list_role_binding]
 
   metadata {
     name = "wait-for-app"


### PR DESCRIPTION
# Overview
This PR will restore most of the features lost with the KOTS upgrade:

1. Working Grafana, Frontegg & Webhooks
3. Dynamically setting the Hostname to the NLB
4. Replicated dashboard access
5. License install during bootstrap

## Grafana & Frontegg

Because of the way KOTS deploys we can no longer make use of cross-namespace communication in kubernetes (we never should've had to but that's another argument). We now put all relevant resources into the created `dozuki` namespace. 

## NLB Hostname

The old replicated scheduler allowed for a bootstrap config file. If it existed in the right place the control plane would pick it up automatically and apply the settings. Within the file was the ability to set the dashboard hostname which would be inherited by the app. Thankfully kots does things a little more predictably and a little more inline with K8s standards. We now have to create a yaml manifest with config values declared and pass that to the kots installer. We can set any config values we want this way but right now we are only using it for the hostname.

## Dashboard Access

By default KOTS does not allow direct access to the admin dashboard. You must execute a `kubectl` command to open a local proxy. This obviously will not work for us due to some customers needing access so I had to create my own K8s service to route traffic to the admin dashboard manually. Unfortunately since the KOTS dashboard does not support TLS the connection is currently insecure. In an upcoming PR we will implement an SSL termination ingress controller to handle this.

## License Install

This is the big one. Our old replicated licenses were fairly small. Usually just 1 string of around 200 characters of base64 encoded json. And within the json blob was a key fingerprint and a customer ID. This was fed to the replicated control plane and then it called out to replicated servers directly to query for license details. This had the added benefit of protecting our secure license fields that we don't want exposed to customers. Unfortunately KOTS licenses are not only fully k8s CRDs, but they include, in plaintext, all of our secure fields making it impossible to share the license data directly with the customers. 

So we have 2 problems:

1. Physical license size. Our KOTS licenses are now over 9kb in size and the maximum amount of text that can be entered into an AWS parameter is 4kb. 
2. Plaintext license fields. Our webhook connection information is exposed in the license file, not even base64 encoded. Theoretically anyone with these credentials could add or remove webhooks to all our clients.

The solution to both problems is the same: we don't give the license to the customer. Thankfully replicated has an API endpoint we can hit with a curl request to pull down the license manifest with only a customer ID needed as an authorization field. This isn't the most secure thing in the world but for now I feel It's good enough until we move to other deployment strategies in the future. The customer ID is a UUID so it should be fairly safe as long as it remains hidden.


# Leftovers
There are 2 main features that are left to be implemented in a future PR:

1. SSL termination for the admin dashboard
2. Custom SSL cert support for the app itself. 
