### PR TITLE
Update Kubernetes to 1.22

### DIFF
--- a/terraform/physical/eks.tf
+++ b/terraform/physical/eks.tf
@@ -194,7 +194,7 @@ module "eks_cluster" {
 
   # EKS cofigurations
   cluster_name    = local.identifier
-  cluster_version = "1.21"
+  cluster_version = "1.22"
   enable_irsa     = true
   # Need public access even when deploying from AWS due to the occasional inability to access private endpoints.
   cluster_endpoint_public_access                 = true

--- a/terraform/physical/modules/acm/ca.tf
+++ b/terraform/physical/modules/acm/ca.tf
@@ -6,8 +6,9 @@ resource "tls_self_signed_cert" "ca" {
   key_algorithm   = "RSA"
   private_key_pem = tls_private_key.ca.private_key_pem
 
+  dns_names = [local.ssl_ca_cn]
+
   subject {
-    common_name  = local.ssl_ca_cn
     organization = local.identifier
   }
   validity_period_hours = 87600

--- a/terraform/physical/modules/acm/cert.tf
+++ b/terraform/physical/modules/acm/cert.tf
@@ -12,8 +12,9 @@ resource "tls_private_key" "server" {
 resource "tls_cert_request" "server" {
   key_algorithm   = "RSA"
   private_key_pem = tls_private_key.server.private_key_pem
+  dns_names       = [local.ssl_cert_cn]
+
   subject {
-    common_name  = local.ssl_cert_cn
     organization = local.identifier
   }
 }

--- a/terraform/physical/static/bastion_kubernetes_config.yaml
+++ b/terraform/physical/static/bastion_kubernetes_config.yaml
@@ -20,7 +20,7 @@ mainSteps:
     inputs:
       sourceType: "HTTP"
       sourceInfo:
-        url: "https://dl.k8s.io/release/v1.21.0/bin/linux/amd64/kubectl"
+        url: "https://dl.k8s.io/release/v1.22.0/bin/linux/amd64/kubectl"
       destinationPath: "/usr/bin/kubectl"
   - action: aws:downloadContent
     name: downloadHelm


### PR DESCRIPTION
Due to AWS deprecating 1.21 we need to upgrade to 1.22. I swept through and updated everything that needed to be updated. It did require quite a few changes to our ingress controller but that was all done within replicated. This is a pretty straight forward change and has been validated as working.