### PR TITLE
Feature/ops 308b

### DIFF
--- a/live/clean.sh
+++ b/live/clean.sh
@@ -41,7 +41,7 @@ fi
 
 echo "Cleaning standard"
 pushd standard || exit
-#cleanPrefixes
+cleanPrefixes
 for region in *; do
  if [ -d "$region" ]; then
     echo "Cleaning $region"
@@ -52,11 +52,11 @@ done
 cloud-nuke aws --exclude-resource-type cloudwatch-loggroup --exclude-resource-type lambda --exclude-resource-type iam-role --force --config ../tests/cloud-nuke.yaml
 popd || exit
 
-# echo "Cleaning gov"
-# pushd gov || exit
-# cleanPrefixes
-# awsweeper --region us-gov-west-1 --profile gov --force ../tests/awsweeper.yaml
-# AWS_PROFILE=gov cloud-nuke aws --region us-gov-west-1 --exclude-resource-type cloudwatch-loggroup --exclude-resource-type lambda --exclude-resource-type macie-member --force --config ../tests/cloud-nuke.yaml
+echo "Cleaning gov"
+pushd gov || exit
+cleanPrefixes
+awsweeper --region us-gov-west-1 --profile gov --force ../tests/awsweeper.yaml
+AWS_PROFILE=gov cloud-nuke aws --region us-gov-west-1 --exclude-resource-type cloudwatch-loggroup --exclude-resource-type lambda --exclude-resource-type macie-member --force --config ../tests/cloud-nuke.yaml
 popd || exit
 
 

--- a/live/clean.sh
+++ b/live/clean.sh
@@ -41,7 +41,7 @@ fi
 
 echo "Cleaning standard"
 pushd standard || exit
-cleanPrefixes
+#cleanPrefixes
 for region in *; do
  if [ -d "$region" ]; then
     echo "Cleaning $region"
@@ -52,11 +52,11 @@ done
 cloud-nuke aws --exclude-resource-type cloudwatch-loggroup --exclude-resource-type lambda --exclude-resource-type iam-role --force --config ../tests/cloud-nuke.yaml
 popd || exit
 
-echo "Cleaning gov"
-pushd gov || exit
-cleanPrefixes
-awsweeper --region us-gov-west-1 --profile gov --force ../tests/awsweeper.yaml
-AWS_PROFILE=gov cloud-nuke aws --region us-gov-west-1 --exclude-resource-type cloudwatch-loggroup --exclude-resource-type lambda --exclude-resource-type macie-member --force --config ../tests/cloud-nuke.yaml
+# echo "Cleaning gov"
+# pushd gov || exit
+# cleanPrefixes
+# awsweeper --region us-gov-west-1 --profile gov --force ../tests/awsweeper.yaml
+# AWS_PROFILE=gov cloud-nuke aws --region us-gov-west-1 --exclude-resource-type cloudwatch-loggroup --exclude-resource-type lambda --exclude-resource-type macie-member --force --config ../tests/cloud-nuke.yaml
 popd || exit
 
 

--- a/terraform/physical/bastion.tf
+++ b/terraform/physical/bastion.tf
@@ -140,4 +140,10 @@ module "bastion" {
   tags_as_map = merge(local.tags, {
     Role = "Bastion"
   })
+
+  # load launch config with ssm
+  depends_on = [
+    aws_ssm_document.bastion_mysql_config,
+    aws_ssm_document.bastion_kubernetes_config
+  ]
 }

--- a/terraform/physical/bastion.tf
+++ b/terraform/physical/bastion.tf
@@ -111,7 +111,6 @@ resource "aws_ssm_association" "bastion_kubernetes_config" {
   }
 }
 
-
 #tfsec:ignore:aws-autoscaling-enable-at-rest-encryption
 module "bastion" {
   source  = "terraform-aws-modules/autoscaling/aws"

--- a/terraform/physical/bastion.tf
+++ b/terraform/physical/bastion.tf
@@ -1,4 +1,4 @@
-data "aws_ami" "amazon_linux_2" {
+data "aws_ami" "amazon_linux_2023" {
   most_recent = true
   owners      = ["amazon"]
 
@@ -6,7 +6,7 @@ data "aws_ami" "amazon_linux_2" {
     name = "name"
 
     values = [
-      "amzn2-ami-hvm-*-x86_64-gp2",
+      "al2023-ami-2023.*-x86_64",
     ]
   }
 }
@@ -121,7 +121,7 @@ module "bastion" {
 
   iam_instance_profile = module.bastion_role.iam_instance_profile_arn
 
-  image_id                     = data.aws_ami.amazon_linux_2.id
+  image_id                     = data.aws_ami.amazon_linux_2023.id
   instance_type                = "t3.micro"
   security_groups              = [module.bastion_sg.security_group_id]
   associate_public_ip_address  = false

--- a/terraform/physical/bastion.tf
+++ b/terraform/physical/bastion.tf
@@ -140,10 +140,4 @@ module "bastion" {
   tags_as_map = merge(local.tags, {
     Role = "Bastion"
   })
-
-  # load launch config with ssm
-  depends_on = [
-    aws_ssm_document.bastion_mysql_config,
-    aws_ssm_document.bastion_kubernetes_config
-  ]
 }

--- a/terraform/physical/static/bastion_kubernetes_config.yaml
+++ b/terraform/physical/static/bastion_kubernetes_config.yaml
@@ -22,6 +22,18 @@ mainSteps:
       sourceInfo:
         url: "https://dl.k8s.io/release/v1.22.0/bin/linux/amd64/kubectl"
       destinationPath: "/usr/bin/kubectl"
+  - action: aws:runShellScript
+    name: installK9s
+    inputs:
+      runCommand:
+        - mkdir k9stemp
+        - cd k9stemp
+        - curl -LO https://github.com/derailed/k9s/releases/download/v0.27.3/k9s_Linux_amd64.tar.gz
+        - tar -xzf k9s_Linux_amd64.tar.gz
+        - sudo mv k9s /usr/local/bin/
+        - sudo chmod +x /usr/local/bin/k9s
+        - cd ..
+        - rm -rf k9stemp
   - action: aws:downloadContent
     name: downloadHelm
     inputs:

--- a/terraform/physical/static/bastion_kubernetes_config.yaml
+++ b/terraform/physical/static/bastion_kubernetes_config.yaml
@@ -15,12 +15,23 @@ parameters:
     type: "String"
     description: "AWS Region"
 mainSteps:
+  - action: aws:runShellScript
+    name: ReplaceAwsCLIv1Tov2
+    inputs:
+      runCommand:
+        - sudo yum remove awscli -y
+        - mkdir tempdir && cd tempdir
+        - curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+        - unzip awscliv2.zip
+        - sudo ./aws/install
+        - cd ..
+        - rm -rf tempdir
   - action: aws:downloadContent
     name: downloadKubectl
     inputs:
       sourceType: "HTTP"
       sourceInfo:
-        url: "https://dl.k8s.io/release/v1.22.0/bin/linux/amd64/kubectl"
+        url: "https://dl.k8s.io/release/v1.22.17/bin/linux/amd64/kubectl"
       destinationPath: "/usr/bin/kubectl"
   - action: aws:runShellScript
     name: installK9s
@@ -30,8 +41,7 @@ mainSteps:
         - cd k9stemp
         - curl -LO https://github.com/derailed/k9s/releases/download/v0.27.3/k9s_Linux_amd64.tar.gz
         - tar -xzf k9s_Linux_amd64.tar.gz
-        - sudo mv k9s /usr/local/bin/
-        - sudo chmod +x /usr/local/bin/k9s
+        - sudo cp k9s /usr/local/bin/; sudo cp k9s /usr/bin/
         - cd ..
         - rm -rf k9stemp
   - action: aws:downloadContent
@@ -69,5 +79,6 @@ mainSteps:
       runCommand:
         - chmod 755 /usr/bin/kubectl
         - chmod 755 /usr/bin/helm
+        - chmod 755 /usr/local/bin/k9s; chmod 755 /usr/bin/k9s
         - chown -R ssm-user:ssm-user /home/ssm-user/.kube
         - chmod -R 700 /home/ssm-user/.kube

--- a/terraform/physical/static/bastion_kubernetes_config.yaml
+++ b/terraform/physical/static/bastion_kubernetes_config.yaml
@@ -68,6 +68,6 @@ mainSteps:
       runCommand:
         - chmod 755 /usr/bin/kubectl
         - chmod 755 /usr/bin/helm
-        - chmod 755 /usr/local/bin/k9s; chmod 755 /usr/bin/k9s
+        - chmod 755 /usr/bin/k9s
         - chown -R ssm-user:ssm-user /home/ssm-user/.kube
         - chmod -R 700 /home/ssm-user/.kube

--- a/terraform/physical/static/bastion_kubernetes_config.yaml
+++ b/terraform/physical/static/bastion_kubernetes_config.yaml
@@ -30,7 +30,7 @@ mainSteps:
         - cd k9stemp
         - curl -LO https://github.com/derailed/k9s/releases/download/v0.27.3/k9s_Linux_amd64.tar.gz
         - tar -xzf k9s_Linux_amd64.tar.gz
-        - sudo cp k9s /usr/local/bin/; sudo cp k9s /usr/bin/
+        - cp k9s /usr/bin/
         - cd ..
         - rm -rf k9stemp
   - action: aws:downloadContent

--- a/terraform/physical/static/bastion_kubernetes_config.yaml
+++ b/terraform/physical/static/bastion_kubernetes_config.yaml
@@ -15,17 +15,6 @@ parameters:
     type: "String"
     description: "AWS Region"
 mainSteps:
-  - action: aws:runShellScript
-    name: ReplaceAwsCLIv1Tov2
-    inputs:
-      runCommand:
-        - sudo yum remove awscli -y
-        - mkdir tempdir && cd tempdir
-        - curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
-        - unzip awscliv2.zip
-        - sudo ./aws/install
-        - cd ..
-        - rm -rf tempdir
   - action: aws:downloadContent
     name: downloadKubectl
     inputs:

--- a/terraform/physical/static/bastion_mysql_config.yaml
+++ b/terraform/physical/static/bastion_mysql_config.yaml
@@ -19,7 +19,7 @@ mainSteps:
     name: installDeps
     inputs:
       runCommand:
-        - sudo yum install -y jq mariadb
+        - sudo yum install -y jq mariadb105
   - action: aws:runShellScript
     name: configMySQL
     inputs:


### PR DESCRIPTION
This is probably a better way of satisfying the dependency requirements of k9s for eks on the bastion than what I did in the other not merged PR https://github.com/Dozuki/CloudPrem-Infra/pull/66.

1.  upgrades OS from AL2 to AL2023
2. upgrades mariadb from 5.5 to 10.5 (so we can continue to use packages to install mariadb)
3. installs latest patches for same kubectl minor version
4. installs latest stable k9s

May need further testing to prove mariadb 10.5 does not require we update our scripts that will use it.

If we merge this, then we will update our bastions with the following command:

terragrunt run-all apply -replace=aws_ssm_association.bastion_kubernetes_config -replace=aws_ssm_document.bastion_mysql_config -replace=module.bastion.aws_launch_configuration.this[0]