### PR TITLE
Intelligent S3 bucket migration support

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Setup Terraform
       uses: hashicorp/setup-terraform@v1
       with:
-        terraform_version: 1.1.8
+        terraform_version: 1.2.0
 
     - name: Terraform ${{ matrix.module }} Module Init
       run: terraform init

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Setup Terraform
       uses: hashicorp/setup-terraform@v1
       with:
-        terraform_version: 1.2.0
+        terraform_version: 1.3.9
 
     - name: Terraform ${{ matrix.module }} Module Init
       run: terraform init

--- a/live/common.hcl
+++ b/live/common.hcl
@@ -109,6 +109,8 @@ dependency "physical" {
     guide_objects_bucket = "dummy-objects-bucket"
     documents_bucket = "dummy-documents-bucket"
     guide_pdfs_bucket = "dummy-pdfs-bucket"
+    s3_kms_key_id = "dummy-kms-arn"
+    s3_replicate_buckets = "false"
     memcached_cluster_address = "dummy-memcache"
     dms_task_arn = "dummy-dms-arn"
     bi_database_credential_secret = "dummy-secret"
@@ -142,6 +144,8 @@ inputs = {
   s3_objects_bucket = dependency.physical.outputs.guide_objects_bucket
   s3_documents_bucket = dependency.physical.outputs.documents_bucket
   s3_pdfs_bucket = dependency.physical.outputs.guide_pdfs_bucket
+  s3_kms_key_id = dependency.physical.outputs.s3_kms_key_id
+  s3_replicate_buckets = dependency.physical.outputs.s3_replicate_buckets
   memcached_cluster_address = dependency.physical.outputs.memcached_cluster_address
   dms_task_arn = dependency.physical.outputs.dms_task_arn
   grafana_ssl_server_cert_parameter = dependency.physical.outputs.grafana_ssl_cert_parameter

--- a/terraform/bootstrap/main.tf
+++ b/terraform/bootstrap/main.tf
@@ -1,8 +1,8 @@
 terraform {
-  required_version = ">= 1.1.0"
+  required_version = ">= 1.3.9"
 
   required_providers {
-    aws = "3.70.0"
+    aws = "4.57.0"
   }
 }
 

--- a/terraform/logical/README.md
+++ b/terraform/logical/README.md
@@ -3,7 +3,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.9 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | 4.57.0 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | 2.9.0 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | 2.18.1 |

--- a/terraform/logical/README.md
+++ b/terraform/logical/README.md
@@ -100,9 +100,10 @@ No modules.
 | <a name="input_replicated_channel"></a> [replicated\_channel](#input\_replicated\_channel) | If specifying an app sequence for a fresh install, this is the channel that sequence was deployed to. You only need to set this if the sequence you configured was not released on the default channel associated with your customer license. | `string` | `""` | no |
 | <a name="input_s3_documents_bucket"></a> [s3\_documents\_bucket](#input\_s3\_documents\_bucket) | Name of the bucket to store documents. Use with 'create\_s3\_buckets' = false. | `string` | `""` | no |
 | <a name="input_s3_images_bucket"></a> [s3\_images\_bucket](#input\_s3\_images\_bucket) | Name of the bucket to store guide images. Use with 'create\_s3\_buckets' = false. | `string` | `""` | no |
-| <a name="input_s3_kms_key_id"></a> [s3\_kms\_key\_id](#input\_s3\_kms\_key\_id) | AWS KMS key identifier for S3 encryption. The identifier can be one of the following format: Key id, key ARN, alias name or alias ARN | `string` | `"alias/aws/s3"` | no |
+| <a name="input_s3_kms_key_id"></a> [s3\_kms\_key\_id](#input\_s3\_kms\_key\_id) | AWS KMS key identifier for S3 encryption. The identifier can be one of the following format: Key id, key ARN, alias name or alias ARN | `string` | `""` | no |
 | <a name="input_s3_objects_bucket"></a> [s3\_objects\_bucket](#input\_s3\_objects\_bucket) | Name of the bucket to store guide objects. Use with 'create\_s3\_buckets' = false. | `string` | `""` | no |
 | <a name="input_s3_pdfs_bucket"></a> [s3\_pdfs\_bucket](#input\_s3\_pdfs\_bucket) | Name of the bucket to store guide pdfs. Use with 'create\_s3\_buckets' = false. | `string` | `""` | no |
+| <a name="input_s3_replicate_buckets"></a> [s3\_replicate\_buckets](#input\_s3\_replicate\_buckets) | Whether or not we are replicating objects from existing S3 buckets. | `bool` | `false` | no |
 | <a name="input_termination_handler_role_arn"></a> [termination\_handler\_role\_arn](#input\_termination\_handler\_role\_arn) | IAM Role for EKS node termination handler | `string` | n/a | yes |
 | <a name="input_termination_handler_sqs_queue_id"></a> [termination\_handler\_sqs\_queue\_id](#input\_termination\_handler\_sqs\_queue\_id) | SQS Queue ID for the EKS node termination handler | `string` | n/a | yes |
 
@@ -116,4 +117,5 @@ No modules.
 | <a name="output_grafana_admin_password"></a> [grafana\_admin\_password](#output\_grafana\_admin\_password) | Password for Grafana admin user |
 | <a name="output_grafana_admin_username"></a> [grafana\_admin\_username](#output\_grafana\_admin\_username) | n/a |
 | <a name="output_grafana_url"></a> [grafana\_url](#output\_grafana\_url) | n/a |
+| <a name="output_replicate_instructions"></a> [replicate\_instructions](#output\_replicate\_instructions) | n/a |
 <!-- END_TF_DOCS -->

--- a/terraform/logical/README.md
+++ b/terraform/logical/README.md
@@ -3,7 +3,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | 4.57.0 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | 2.9.0 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | 2.18.1 |

--- a/terraform/logical/README.md
+++ b/terraform/logical/README.md
@@ -4,22 +4,22 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | 3.70.0 |
-| <a name="requirement_helm"></a> [helm](#requirement\_helm) | 2.3.0 |
-| <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | 2.13.1 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | 4.57.0 |
+| <a name="requirement_helm"></a> [helm](#requirement\_helm) | 2.9.0 |
+| <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | 2.18.1 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | 2.2.3 |
-| <a name="requirement_null"></a> [null](#requirement\_null) | 3.1.0 |
+| <a name="requirement_null"></a> [null](#requirement\_null) | 3.2.1 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | 3.4.3 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.70.0 |
-| <a name="provider_helm"></a> [helm](#provider\_helm) | 2.3.0 |
-| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | 2.13.1 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.57.0 |
+| <a name="provider_helm"></a> [helm](#provider\_helm) | 2.9.0 |
+| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | 2.18.1 |
 | <a name="provider_local"></a> [local](#provider\_local) | 2.2.3 |
-| <a name="provider_null"></a> [null](#provider\_null) | 3.1.0 |
+| <a name="provider_null"></a> [null](#provider\_null) | 3.2.1 |
 | <a name="provider_random"></a> [random](#provider\_random) | 3.4.3 |
 
 ## Modules
@@ -30,45 +30,45 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [aws_autoscaling_lifecycle_hook.aws_node_termination_handler](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/resources/autoscaling_lifecycle_hook) | resource |
-| [helm_release.aws_node_termination_handler](https://registry.terraform.io/providers/hashicorp/helm/2.3.0/docs/resources/release) | resource |
-| [helm_release.cluster_autoscaler](https://registry.terraform.io/providers/hashicorp/helm/2.3.0/docs/resources/release) | resource |
-| [helm_release.container_insights](https://registry.terraform.io/providers/hashicorp/helm/2.3.0/docs/resources/release) | resource |
-| [helm_release.frontegg](https://registry.terraform.io/providers/hashicorp/helm/2.3.0/docs/resources/release) | resource |
-| [helm_release.grafana](https://registry.terraform.io/providers/hashicorp/helm/2.3.0/docs/resources/release) | resource |
-| [helm_release.metrics_server](https://registry.terraform.io/providers/hashicorp/helm/2.3.0/docs/resources/release) | resource |
-| [helm_release.mongodb](https://registry.terraform.io/providers/hashicorp/helm/2.3.0/docs/resources/release) | resource |
-| [helm_release.redis](https://registry.terraform.io/providers/hashicorp/helm/2.3.0/docs/resources/release) | resource |
-| [kubernetes_config_map.dozuki_resources](https://registry.terraform.io/providers/hashicorp/kubernetes/2.13.1/docs/resources/config_map) | resource |
-| [kubernetes_horizontal_pod_autoscaler.app](https://registry.terraform.io/providers/hashicorp/kubernetes/2.13.1/docs/resources/horizontal_pod_autoscaler) | resource |
-| [kubernetes_horizontal_pod_autoscaler.queueworkerd](https://registry.terraform.io/providers/hashicorp/kubernetes/2.13.1/docs/resources/horizontal_pod_autoscaler) | resource |
-| [kubernetes_job.dms_start](https://registry.terraform.io/providers/hashicorp/kubernetes/2.13.1/docs/resources/job) | resource |
-| [kubernetes_job.frontegg_database_create](https://registry.terraform.io/providers/hashicorp/kubernetes/2.13.1/docs/resources/job) | resource |
-| [kubernetes_job.sites_config_update](https://registry.terraform.io/providers/hashicorp/kubernetes/2.13.1/docs/resources/job) | resource |
-| [kubernetes_job.wait_for_app](https://registry.terraform.io/providers/hashicorp/kubernetes/2.13.1/docs/resources/job) | resource |
-| [kubernetes_namespace.kots_app](https://registry.terraform.io/providers/hashicorp/kubernetes/2.13.1/docs/resources/namespace) | resource |
-| [kubernetes_role.dozuki_list_role](https://registry.terraform.io/providers/hashicorp/kubernetes/2.13.1/docs/resources/role) | resource |
-| [kubernetes_role_binding.dozuki_list_role_binding](https://registry.terraform.io/providers/hashicorp/kubernetes/2.13.1/docs/resources/role_binding) | resource |
-| [kubernetes_secret.grafana_config](https://registry.terraform.io/providers/hashicorp/kubernetes/2.13.1/docs/resources/secret) | resource |
-| [kubernetes_secret.grafana_ssl](https://registry.terraform.io/providers/hashicorp/kubernetes/2.13.1/docs/resources/secret) | resource |
+| [aws_autoscaling_lifecycle_hook.aws_node_termination_handler](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/resources/autoscaling_lifecycle_hook) | resource |
+| [helm_release.aws_node_termination_handler](https://registry.terraform.io/providers/hashicorp/helm/2.9.0/docs/resources/release) | resource |
+| [helm_release.cluster_autoscaler](https://registry.terraform.io/providers/hashicorp/helm/2.9.0/docs/resources/release) | resource |
+| [helm_release.container_insights](https://registry.terraform.io/providers/hashicorp/helm/2.9.0/docs/resources/release) | resource |
+| [helm_release.frontegg](https://registry.terraform.io/providers/hashicorp/helm/2.9.0/docs/resources/release) | resource |
+| [helm_release.grafana](https://registry.terraform.io/providers/hashicorp/helm/2.9.0/docs/resources/release) | resource |
+| [helm_release.metrics_server](https://registry.terraform.io/providers/hashicorp/helm/2.9.0/docs/resources/release) | resource |
+| [helm_release.mongodb](https://registry.terraform.io/providers/hashicorp/helm/2.9.0/docs/resources/release) | resource |
+| [helm_release.redis](https://registry.terraform.io/providers/hashicorp/helm/2.9.0/docs/resources/release) | resource |
+| [kubernetes_config_map.dozuki_resources](https://registry.terraform.io/providers/hashicorp/kubernetes/2.18.1/docs/resources/config_map) | resource |
+| [kubernetes_horizontal_pod_autoscaler.app](https://registry.terraform.io/providers/hashicorp/kubernetes/2.18.1/docs/resources/horizontal_pod_autoscaler) | resource |
+| [kubernetes_horizontal_pod_autoscaler.queueworkerd](https://registry.terraform.io/providers/hashicorp/kubernetes/2.18.1/docs/resources/horizontal_pod_autoscaler) | resource |
+| [kubernetes_job.dms_start](https://registry.terraform.io/providers/hashicorp/kubernetes/2.18.1/docs/resources/job) | resource |
+| [kubernetes_job.frontegg_database_create](https://registry.terraform.io/providers/hashicorp/kubernetes/2.18.1/docs/resources/job) | resource |
+| [kubernetes_job.sites_config_update](https://registry.terraform.io/providers/hashicorp/kubernetes/2.18.1/docs/resources/job) | resource |
+| [kubernetes_job.wait_for_app](https://registry.terraform.io/providers/hashicorp/kubernetes/2.18.1/docs/resources/job) | resource |
+| [kubernetes_namespace.kots_app](https://registry.terraform.io/providers/hashicorp/kubernetes/2.18.1/docs/resources/namespace) | resource |
+| [kubernetes_role.dozuki_list_role](https://registry.terraform.io/providers/hashicorp/kubernetes/2.18.1/docs/resources/role) | resource |
+| [kubernetes_role_binding.dozuki_list_role_binding](https://registry.terraform.io/providers/hashicorp/kubernetes/2.18.1/docs/resources/role_binding) | resource |
+| [kubernetes_secret.grafana_config](https://registry.terraform.io/providers/hashicorp/kubernetes/2.18.1/docs/resources/secret) | resource |
+| [kubernetes_secret.grafana_ssl](https://registry.terraform.io/providers/hashicorp/kubernetes/2.18.1/docs/resources/secret) | resource |
 | [local_file.replicated_bootstrap_config](https://registry.terraform.io/providers/hashicorp/local/2.2.3/docs/resources/file) | resource |
 | [local_file.replicated_install](https://registry.terraform.io/providers/hashicorp/local/2.2.3/docs/resources/file) | resource |
-| [null_resource.pull_replicated_license](https://registry.terraform.io/providers/hashicorp/null/3.1.0/docs/resources/resource) | resource |
+| [null_resource.pull_replicated_license](https://registry.terraform.io/providers/hashicorp/null/3.2.1/docs/resources/resource) | resource |
 | [random_password.dashboard_password](https://registry.terraform.io/providers/hashicorp/random/3.4.3/docs/resources/password) | resource |
 | [random_password.grafana_admin](https://registry.terraform.io/providers/hashicorp/random/3.4.3/docs/resources/password) | resource |
-| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/data-sources/caller_identity) | data source |
-| [aws_eks_cluster.main](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/data-sources/eks_cluster) | data source |
-| [aws_kms_key.s3](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/data-sources/kms_key) | data source |
-| [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/data-sources/partition) | data source |
-| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/data-sources/region) | data source |
-| [aws_secretsmanager_secret_version.db_bi](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/data-sources/secretsmanager_secret_version) | data source |
-| [aws_secretsmanager_secret_version.db_master](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/data-sources/secretsmanager_secret_version) | data source |
-| [aws_ssm_parameter.dozuki_customer_id](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/data-sources/ssm_parameter) | data source |
-| [aws_ssm_parameter.grafana_ssl_cert](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/data-sources/ssm_parameter) | data source |
-| [aws_ssm_parameter.grafana_ssl_key](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/data-sources/ssm_parameter) | data source |
-| [aws_ssm_parameter.nlb_ssl_cert](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/data-sources/ssm_parameter) | data source |
-| [aws_ssm_parameter.nlb_ssl_key](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/data-sources/ssm_parameter) | data source |
-| [kubernetes_secret.frontegg](https://registry.terraform.io/providers/hashicorp/kubernetes/2.13.1/docs/data-sources/secret) | data source |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/data-sources/caller_identity) | data source |
+| [aws_eks_cluster.main](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/data-sources/eks_cluster) | data source |
+| [aws_kms_key.s3](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/data-sources/kms_key) | data source |
+| [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/data-sources/partition) | data source |
+| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/data-sources/region) | data source |
+| [aws_secretsmanager_secret_version.db_bi](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/data-sources/secretsmanager_secret_version) | data source |
+| [aws_secretsmanager_secret_version.db_master](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/data-sources/secretsmanager_secret_version) | data source |
+| [aws_ssm_parameter.dozuki_customer_id](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/data-sources/ssm_parameter) | data source |
+| [aws_ssm_parameter.grafana_ssl_cert](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/data-sources/ssm_parameter) | data source |
+| [aws_ssm_parameter.grafana_ssl_key](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/data-sources/ssm_parameter) | data source |
+| [aws_ssm_parameter.nlb_ssl_cert](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/data-sources/ssm_parameter) | data source |
+| [aws_ssm_parameter.nlb_ssl_key](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/data-sources/ssm_parameter) | data source |
+| [kubernetes_secret.frontegg](https://registry.terraform.io/providers/hashicorp/kubernetes/2.18.1/docs/data-sources/secret) | data source |
 
 ## Inputs
 

--- a/terraform/logical/main.tf
+++ b/terraform/logical/main.tf
@@ -2,10 +2,10 @@ terraform {
   required_version = ">= 1.1.0"
 
   required_providers {
-    aws        = "3.70.0"
-    kubernetes = "2.13.1"
-    helm       = "2.3.0"
-    null       = "3.1.0"
+    aws        = "4.57.0"
+    kubernetes = "2.18.1"
+    helm       = "2.9.0"
+    null       = "3.2.1"
     # This provider needs to stay for awhile to maintain backwards compatibility with older infra versions (<=2.5.4)
     local  = "2.2.3"
     random = "3.4.3"

--- a/terraform/logical/main.tf
+++ b/terraform/logical/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.1.0"
+  required_version = ">= 1.2.0"
 
   required_providers {
     aws        = "4.57.0"

--- a/terraform/logical/main.tf
+++ b/terraform/logical/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.2.0"
+  required_version = ">= 1.3.9"
 
   required_providers {
     aws        = "4.57.0"

--- a/terraform/logical/outputs.tf
+++ b/terraform/logical/outputs.tf
@@ -25,3 +25,7 @@ output "grafana_admin_password" {
   description = "Password for Grafana admin user"
   value       = local.grafana_admin_password
 }
+
+output "replicate_instructions" {
+  value = var.s3_replicate_buckets ? "NOTE: Be sure to verify the Replicate Batch Operations complete successfully before deleting the donor buckets!" : null
+}

--- a/terraform/logical/variables.tf
+++ b/terraform/logical/variables.tf
@@ -141,7 +141,7 @@ variable "memcached_cluster_address" {
 variable "s3_kms_key_id" {
   description = "AWS KMS key identifier for S3 encryption. The identifier can be one of the following format: Key id, key ARN, alias name or alias ARN"
   type        = string
-  default     = "alias/aws/s3"
+  default     = ""
 }
 
 variable "s3_objects_bucket" {
@@ -166,6 +166,12 @@ variable "s3_pdfs_bucket" {
   description = "Name of the bucket to store guide pdfs. Use with 'create_s3_buckets' = false."
   type        = string
   default     = ""
+}
+
+variable "s3_replicate_buckets" {
+  description = "Whether or not we are replicating objects from existing S3 buckets."
+  type        = bool
+  default     = false
 }
 
 # This needs to have no type due to terraform's weird handling of string lists. If you set a type it will convert it to

--- a/terraform/physical/README.md
+++ b/terraform/physical/README.md
@@ -4,128 +4,123 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | 3.70.0 |
-| <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | 2.13.1 |
-| <a name="requirement_null"></a> [null](#requirement\_null) | 3.1.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | 4.57.0 |
+| <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | 2.18.1 |
+| <a name="requirement_null"></a> [null](#requirement\_null) | 3.2.1 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | 3.4.3 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.70.0 |
-| <a name="provider_null"></a> [null](#provider\_null) | 3.1.0 |
-| <a name="provider_random"></a> [random](#provider\_random) | 3.4.3 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.57.0 |
+| <a name="provider_null"></a> [null](#provider\_null) | 3.2.1 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_aws_node_termination_handler_role"></a> [aws\_node\_termination\_handler\_role](#module\_aws\_node\_termination\_handler\_role) | terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc | 4.7.0 |
-| <a name="module_aws_node_termination_handler_sqs"></a> [aws\_node\_termination\_handler\_sqs](#module\_aws\_node\_termination\_handler\_sqs) | terraform-aws-modules/sqs/aws | ~> 3.1.0 |
-| <a name="module_bastion"></a> [bastion](#module\_bastion) | terraform-aws-modules/autoscaling/aws | 3.8.0 |
-| <a name="module_bastion_role"></a> [bastion\_role](#module\_bastion\_role) | terraform-aws-modules/iam/aws//modules/iam-assumable-role | 4.7.0 |
-| <a name="module_bastion_sg"></a> [bastion\_sg](#module\_bastion\_sg) | terraform-aws-modules/security-group/aws | 4.7.0 |
-| <a name="module_bi_database_sg"></a> [bi\_database\_sg](#module\_bi\_database\_sg) | terraform-aws-modules/security-group/aws | 4.7.0 |
-| <a name="module_cluster_access_role"></a> [cluster\_access\_role](#module\_cluster\_access\_role) | terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc | 4.7.0 |
-| <a name="module_cluster_access_role_assumable"></a> [cluster\_access\_role\_assumable](#module\_cluster\_access\_role\_assumable) | terraform-aws-modules/iam/aws//modules/iam-assumable-role | 4.7.0 |
-| <a name="module_cpu_alarm"></a> [cpu\_alarm](#module\_cpu\_alarm) | terraform-aws-modules/cloudwatch/aws//modules/metric-alarm | 2.1.0 |
+| <a name="module_aws_node_termination_handler_role"></a> [aws\_node\_termination\_handler\_role](#module\_aws\_node\_termination\_handler\_role) | terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc | 5.11.2 |
+| <a name="module_aws_node_termination_handler_sqs"></a> [aws\_node\_termination\_handler\_sqs](#module\_aws\_node\_termination\_handler\_sqs) | terraform-aws-modules/sqs/aws | ~> 4.0.1 |
+| <a name="module_bastion"></a> [bastion](#module\_bastion) | terraform-aws-modules/autoscaling/aws | 6.7.1 |
+| <a name="module_bastion_sg"></a> [bastion\_sg](#module\_bastion\_sg) | terraform-aws-modules/security-group/aws | 4.17.1 |
+| <a name="module_bi_database_sg"></a> [bi\_database\_sg](#module\_bi\_database\_sg) | terraform-aws-modules/security-group/aws | 4.17.1 |
+| <a name="module_cluster_access_role"></a> [cluster\_access\_role](#module\_cluster\_access\_role) | terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc | 5.11.2 |
+| <a name="module_cluster_access_role_assumable"></a> [cluster\_access\_role\_assumable](#module\_cluster\_access\_role\_assumable) | terraform-aws-modules/iam/aws//modules/iam-assumable-role | 5.11.2 |
+| <a name="module_cpu_alarm"></a> [cpu\_alarm](#module\_cpu\_alarm) | terraform-aws-modules/cloudwatch/aws//modules/metric-alarm | 4.2.1 |
 | <a name="module_eks_cluster"></a> [eks\_cluster](#module\_eks\_cluster) | terraform-aws-modules/eks/aws | 17.24.0 |
 | <a name="module_grafana_ssl_cert"></a> [grafana\_ssl\_cert](#module\_grafana\_ssl\_cert) | ./modules/acm | n/a |
-| <a name="module_memory_alarm"></a> [memory\_alarm](#module\_memory\_alarm) | terraform-aws-modules/cloudwatch/aws//modules/metric-alarm | 2.1.0 |
-| <a name="module_nlb"></a> [nlb](#module\_nlb) | terraform-aws-modules/alb/aws | 6.6.1 |
+| <a name="module_memory_alarm"></a> [memory\_alarm](#module\_memory\_alarm) | terraform-aws-modules/cloudwatch/aws//modules/metric-alarm | 4.2.1 |
+| <a name="module_nlb"></a> [nlb](#module\_nlb) | terraform-aws-modules/alb/aws | 8.4.0 |
 | <a name="module_nlb_ssl_cert"></a> [nlb\_ssl\_cert](#module\_nlb\_ssl\_cert) | ./modules/acm | n/a |
-| <a name="module_nodes_alarm"></a> [nodes\_alarm](#module\_nodes\_alarm) | terraform-aws-modules/cloudwatch/aws//modules/metric-alarm | 2.1.0 |
-| <a name="module_primary_database"></a> [primary\_database](#module\_primary\_database) | terraform-aws-modules/rds/aws | 3.4.1 |
-| <a name="module_primary_database_sg"></a> [primary\_database\_sg](#module\_primary\_database\_sg) | terraform-aws-modules/security-group/aws | 4.7.0 |
-| <a name="module_replica_database"></a> [replica\_database](#module\_replica\_database) | terraform-aws-modules/rds/aws | 3.4.1 |
-| <a name="module_sns"></a> [sns](#module\_sns) | terraform-aws-modules/sns/aws | 2.1.0 |
-| <a name="module_status_alarm"></a> [status\_alarm](#module\_status\_alarm) | terraform-aws-modules/cloudwatch/aws//modules/metric-alarm | 2.1.0 |
-| <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | 3.14.1 |
+| <a name="module_nodes_alarm"></a> [nodes\_alarm](#module\_nodes\_alarm) | terraform-aws-modules/cloudwatch/aws//modules/metric-alarm | 4.2.1 |
+| <a name="module_primary_database"></a> [primary\_database](#module\_primary\_database) | terraform-aws-modules/rds/aws | 5.6.0 |
+| <a name="module_primary_database_sg"></a> [primary\_database\_sg](#module\_primary\_database\_sg) | terraform-aws-modules/security-group/aws | 4.17.1 |
+| <a name="module_replica_database"></a> [replica\_database](#module\_replica\_database) | terraform-aws-modules/rds/aws | 5.6.0 |
+| <a name="module_sns"></a> [sns](#module\_sns) | terraform-aws-modules/sns/aws | 5.1.0 |
+| <a name="module_status_alarm"></a> [status\_alarm](#module\_status\_alarm) | terraform-aws-modules/cloudwatch/aws//modules/metric-alarm | 4.2.1 |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | 3.19.0 |
 | <a name="module_vpn"></a> [vpn](#module\_vpn) | ./modules/vpn | n/a |
 
 ## Resources
 
 | Name | Type |
 |------|------|
-| [aws_cloudwatch_event_rule.aws_node_termination_handler_asg](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/resources/cloudwatch_event_rule) | resource |
-| [aws_cloudwatch_event_rule.aws_node_termination_handler_spot](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/resources/cloudwatch_event_rule) | resource |
-| [aws_cloudwatch_event_target.aws_node_termination_handler_asg](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/resources/cloudwatch_event_target) | resource |
-| [aws_cloudwatch_event_target.aws_node_termination_handler_spot](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/resources/cloudwatch_event_target) | resource |
-| [aws_db_parameter_group.bi](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/resources/db_parameter_group) | resource |
-| [aws_db_parameter_group.default](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/resources/db_parameter_group) | resource |
-| [aws_dms_certificate.this](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/resources/dms_certificate) | resource |
-| [aws_dms_endpoint.source](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/resources/dms_endpoint) | resource |
-| [aws_dms_endpoint.target](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/resources/dms_endpoint) | resource |
-| [aws_dms_replication_instance.this](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/resources/dms_replication_instance) | resource |
-| [aws_dms_replication_subnet_group.this](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/resources/dms_replication_subnet_group) | resource |
-| [aws_dms_replication_task.this](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/resources/dms_replication_task) | resource |
-| [aws_elasticache_cluster.this](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/resources/elasticache_cluster) | resource |
-| [aws_elasticache_parameter_group.this](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/resources/elasticache_parameter_group) | resource |
-| [aws_elasticache_subnet_group.this](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/resources/elasticache_subnet_group) | resource |
-| [aws_iam_policy.aws_node_termination_handler](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/resources/iam_policy) | resource |
-| [aws_iam_policy.cluster_access](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/resources/iam_policy) | resource |
-| [aws_iam_policy.cluster_autoscaler_policy](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/resources/iam_policy) | resource |
-| [aws_iam_policy.eks_worker](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/resources/iam_policy) | resource |
-| [aws_kms_key.bi](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/resources/kms_key) | resource |
-| [aws_kms_key.eks](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/resources/kms_key) | resource |
-| [aws_msk_cluster.this](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/resources/msk_cluster) | resource |
-| [aws_msk_configuration.this](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/resources/msk_configuration) | resource |
-| [aws_s3_bucket.guide_documents](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/resources/s3_bucket) | resource |
-| [aws_s3_bucket.guide_images](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/resources/s3_bucket) | resource |
-| [aws_s3_bucket.guide_objects](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/resources/s3_bucket) | resource |
-| [aws_s3_bucket.guide_pdfs](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/resources/s3_bucket) | resource |
-| [aws_s3_bucket.logging_bucket](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/resources/s3_bucket) | resource |
-| [aws_s3_bucket_public_access_block.guide_documents_acl_block](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/resources/s3_bucket_public_access_block) | resource |
-| [aws_s3_bucket_public_access_block.guide_images_acl_block](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/resources/s3_bucket_public_access_block) | resource |
-| [aws_s3_bucket_public_access_block.guide_objects_acl_block](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/resources/s3_bucket_public_access_block) | resource |
-| [aws_s3_bucket_public_access_block.guide_pdfs_acl_block](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/resources/s3_bucket_public_access_block) | resource |
-| [aws_s3_bucket_public_access_block.logging_bucket_acl_block](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/resources/s3_bucket_public_access_block) | resource |
-| [aws_secretsmanager_secret.primary_database_credentials](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/resources/secretsmanager_secret) | resource |
-| [aws_secretsmanager_secret.replica_database_credentials](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/resources/secretsmanager_secret) | resource |
-| [aws_secretsmanager_secret_version.primary_database_credentials](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/resources/secretsmanager_secret_version) | resource |
-| [aws_secretsmanager_secret_version.replica_database_credentials](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/resources/secretsmanager_secret_version) | resource |
-| [aws_security_group.elasticache](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/resources/security_group) | resource |
-| [aws_security_group.kafka](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/resources/security_group) | resource |
-| [aws_security_group_rule.app_access_http](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.app_access_https](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.egress](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.grafana_access_http](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.ingress_cidr_blocks](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.kafka_egress](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.kafka_ingress_cidr_blocks](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.kafka_ingress_security_groups](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.replicated_ui_access](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/resources/security_group_rule) | resource |
-| [aws_ssm_association.bastion_kubernetes_config](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/resources/ssm_association) | resource |
-| [aws_ssm_association.bastion_mysql_config](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/resources/ssm_association) | resource |
-| [aws_ssm_document.bastion_kubernetes_config](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/resources/ssm_document) | resource |
-| [aws_ssm_document.bastion_mysql_config](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/resources/ssm_document) | resource |
-| [null_resource.cluster_urls](https://registry.terraform.io/providers/hashicorp/null/3.1.0/docs/resources/resource) | resource |
-| [null_resource.replication_control](https://registry.terraform.io/providers/hashicorp/null/3.1.0/docs/resources/resource) | resource |
-| [random_password.primary_database](https://registry.terraform.io/providers/hashicorp/random/3.4.3/docs/resources/password) | resource |
-| [random_password.replica_database](https://registry.terraform.io/providers/hashicorp/random/3.4.3/docs/resources/password) | resource |
-| [aws_ami.amazon_linux_2](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/data-sources/ami) | data source |
-| [aws_availability_zones.available](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/data-sources/availability_zones) | data source |
-| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/data-sources/caller_identity) | data source |
-| [aws_eks_cluster.main](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/data-sources/eks_cluster) | data source |
-| [aws_iam_policy_document.aws_node_termination_handler](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/data-sources/iam_policy_document) | data source |
-| [aws_iam_policy_document.aws_node_termination_handler_events](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/data-sources/iam_policy_document) | data source |
-| [aws_iam_policy_document.cluster_access](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/data-sources/iam_policy_document) | data source |
-| [aws_iam_policy_document.cluster_autoscaler_pd](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/data-sources/iam_policy_document) | data source |
-| [aws_iam_policy_document.eks_worker](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/data-sources/iam_policy_document) | data source |
-| [aws_kms_key.eks](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/data-sources/kms_key) | data source |
-| [aws_kms_key.rds](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/data-sources/kms_key) | data source |
-| [aws_kms_key.s3](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/data-sources/kms_key) | data source |
-| [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/data-sources/partition) | data source |
-| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/data-sources/region) | data source |
-| [aws_s3_bucket.documents](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/data-sources/s3_bucket) | data source |
-| [aws_s3_bucket.guide_images](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/data-sources/s3_bucket) | data source |
-| [aws_s3_bucket.guide_objects](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/data-sources/s3_bucket) | data source |
-| [aws_s3_bucket.guide_pdfs](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/data-sources/s3_bucket) | data source |
-| [aws_s3_bucket.logging](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/data-sources/s3_bucket) | data source |
-| [aws_subnet_ids.private](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/data-sources/subnet_ids) | data source |
-| [aws_subnet_ids.public](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/data-sources/subnet_ids) | data source |
-| [aws_vpc.this](https://registry.terraform.io/providers/hashicorp/aws/3.70.0/docs/data-sources/vpc) | data source |
+| [aws_cloudwatch_event_rule.aws_node_termination_handler_asg](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/resources/cloudwatch_event_rule) | resource |
+| [aws_cloudwatch_event_rule.aws_node_termination_handler_spot](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/resources/cloudwatch_event_rule) | resource |
+| [aws_cloudwatch_event_target.aws_node_termination_handler_asg](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/resources/cloudwatch_event_target) | resource |
+| [aws_cloudwatch_event_target.aws_node_termination_handler_spot](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/resources/cloudwatch_event_target) | resource |
+| [aws_db_parameter_group.bi](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/resources/db_parameter_group) | resource |
+| [aws_db_parameter_group.default](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/resources/db_parameter_group) | resource |
+| [aws_dms_certificate.this](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/resources/dms_certificate) | resource |
+| [aws_dms_endpoint.source](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/resources/dms_endpoint) | resource |
+| [aws_dms_endpoint.target](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/resources/dms_endpoint) | resource |
+| [aws_dms_replication_instance.this](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/resources/dms_replication_instance) | resource |
+| [aws_dms_replication_subnet_group.this](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/resources/dms_replication_subnet_group) | resource |
+| [aws_dms_replication_task.this](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/resources/dms_replication_task) | resource |
+| [aws_elasticache_cluster.this](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/resources/elasticache_cluster) | resource |
+| [aws_elasticache_parameter_group.this](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/resources/elasticache_parameter_group) | resource |
+| [aws_elasticache_subnet_group.this](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/resources/elasticache_subnet_group) | resource |
+| [aws_iam_policy.aws_node_termination_handler](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/resources/iam_policy) | resource |
+| [aws_iam_policy.cluster_access](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/resources/iam_policy) | resource |
+| [aws_iam_policy.cluster_autoscaler_policy](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/resources/iam_policy) | resource |
+| [aws_iam_policy.eks_worker](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/resources/iam_policy) | resource |
+| [aws_kms_key.bi](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/resources/kms_key) | resource |
+| [aws_kms_key.eks](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/resources/kms_key) | resource |
+| [aws_msk_cluster.this](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/resources/msk_cluster) | resource |
+| [aws_msk_configuration.this](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/resources/msk_configuration) | resource |
+| [aws_s3_bucket.guide_documents](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/resources/s3_bucket) | resource |
+| [aws_s3_bucket.guide_images](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/resources/s3_bucket) | resource |
+| [aws_s3_bucket.guide_objects](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/resources/s3_bucket) | resource |
+| [aws_s3_bucket.guide_pdfs](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/resources/s3_bucket) | resource |
+| [aws_s3_bucket.logging_bucket](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/resources/s3_bucket) | resource |
+| [aws_s3_bucket_public_access_block.guide_documents_acl_block](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/resources/s3_bucket_public_access_block) | resource |
+| [aws_s3_bucket_public_access_block.guide_images_acl_block](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/resources/s3_bucket_public_access_block) | resource |
+| [aws_s3_bucket_public_access_block.guide_objects_acl_block](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/resources/s3_bucket_public_access_block) | resource |
+| [aws_s3_bucket_public_access_block.guide_pdfs_acl_block](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/resources/s3_bucket_public_access_block) | resource |
+| [aws_s3_bucket_public_access_block.logging_bucket_acl_block](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/resources/s3_bucket_public_access_block) | resource |
+| [aws_secretsmanager_secret.primary_database_credentials](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/resources/secretsmanager_secret) | resource |
+| [aws_secretsmanager_secret.replica_database_credentials](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/resources/secretsmanager_secret) | resource |
+| [aws_secretsmanager_secret_version.primary_database_credentials](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/resources/secretsmanager_secret_version) | resource |
+| [aws_secretsmanager_secret_version.replica_database_credentials](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/resources/secretsmanager_secret_version) | resource |
+| [aws_security_group.elasticache](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/resources/security_group) | resource |
+| [aws_security_group.kafka](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/resources/security_group) | resource |
+| [aws_security_group_rule.app_access_http](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.app_access_https](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.egress](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.grafana_access_http](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.ingress_cidr_blocks](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.kafka_egress](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.kafka_ingress_cidr_blocks](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.kafka_ingress_security_groups](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.replicated_ui_access](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/resources/security_group_rule) | resource |
+| [aws_ssm_association.bastion_kubernetes_config](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/resources/ssm_association) | resource |
+| [aws_ssm_association.bastion_mysql_config](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/resources/ssm_association) | resource |
+| [aws_ssm_document.bastion_kubernetes_config](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/resources/ssm_document) | resource |
+| [aws_ssm_document.bastion_mysql_config](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/resources/ssm_document) | resource |
+| [null_resource.cluster_urls](https://registry.terraform.io/providers/hashicorp/null/3.2.1/docs/resources/resource) | resource |
+| [null_resource.replication_control](https://registry.terraform.io/providers/hashicorp/null/3.2.1/docs/resources/resource) | resource |
+| [aws_ami.amazon_linux_2](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/data-sources/ami) | data source |
+| [aws_availability_zones.available](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/data-sources/availability_zones) | data source |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/data-sources/caller_identity) | data source |
+| [aws_eks_cluster.main](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/data-sources/eks_cluster) | data source |
+| [aws_iam_policy_document.aws_node_termination_handler](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.cluster_access](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.cluster_autoscaler_pd](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.eks_worker](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/data-sources/iam_policy_document) | data source |
+| [aws_kms_key.eks](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/data-sources/kms_key) | data source |
+| [aws_kms_key.rds](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/data-sources/kms_key) | data source |
+| [aws_kms_key.s3](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/data-sources/kms_key) | data source |
+| [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/data-sources/partition) | data source |
+| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/data-sources/region) | data source |
+| [aws_s3_bucket.documents](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/data-sources/s3_bucket) | data source |
+| [aws_s3_bucket.guide_images](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/data-sources/s3_bucket) | data source |
+| [aws_s3_bucket.guide_objects](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/data-sources/s3_bucket) | data source |
+| [aws_s3_bucket.guide_pdfs](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/data-sources/s3_bucket) | data source |
+| [aws_s3_bucket.logging](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/data-sources/s3_bucket) | data source |
+| [aws_subnet_ids.private](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/data-sources/subnet_ids) | data source |
+| [aws_subnet_ids.public](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/data-sources/subnet_ids) | data source |
+| [aws_vpc.this](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/data-sources/vpc) | data source |
 
 ## Inputs
 

--- a/terraform/physical/README.md
+++ b/terraform/physical/README.md
@@ -110,7 +110,7 @@
 | [null_resource.cluster_urls](https://registry.terraform.io/providers/hashicorp/null/3.2.1/docs/resources/resource) | resource |
 | [null_resource.replication_control](https://registry.terraform.io/providers/hashicorp/null/3.2.1/docs/resources/resource) | resource |
 | [null_resource.s3_replication_job_init](https://registry.terraform.io/providers/hashicorp/null/3.2.1/docs/resources/resource) | resource |
-| [aws_ami.amazon_linux_2](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/data-sources/ami) | data source |
+| [aws_ami.amazon_linux_2023](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/data-sources/ami) | data source |
 | [aws_availability_zones.available](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/data-sources/availability_zones) | data source |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/data-sources/caller_identity) | data source |
 | [aws_eks_cluster.main](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/data-sources/eks_cluster) | data source |

--- a/terraform/physical/README.md
+++ b/terraform/physical/README.md
@@ -3,7 +3,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.9 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | 4.57.0 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | 2.18.1 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | 3.2.1 |

--- a/terraform/physical/README.md
+++ b/terraform/physical/README.md
@@ -69,10 +69,10 @@
 | [aws_iam_policy.s3_replication](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/resources/iam_policy) | resource |
 | [aws_iam_role.s3_replication](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy_attachment.s3_replication](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/resources/iam_role_policy_attachment) | resource |
-| [aws_kms_alias.s3_kms_key](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/resources/kms_alias) | resource |
+| [aws_kms_alias.s3](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/resources/kms_alias) | resource |
 | [aws_kms_key.bi](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/resources/kms_key) | resource |
 | [aws_kms_key.eks](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/resources/kms_key) | resource |
-| [aws_kms_key.s3_kms_key](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/resources/kms_key) | resource |
+| [aws_kms_key.s3](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/resources/kms_key) | resource |
 | [aws_msk_cluster.this](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/resources/msk_cluster) | resource |
 | [aws_msk_configuration.this](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/resources/msk_configuration) | resource |
 | [aws_s3_bucket.guide_buckets](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/resources/s3_bucket) | resource |
@@ -125,8 +125,8 @@
 | [aws_iam_policy_document.s3_replication_assume_role](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/data-sources/iam_policy_document) | data source |
 | [aws_kms_key.eks](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/data-sources/kms_key) | data source |
 | [aws_kms_key.rds](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/data-sources/kms_key) | data source |
-| [aws_kms_key.s3](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/data-sources/kms_key) | data source |
-| [aws_kms_key.s3-default](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/data-sources/kms_key) | data source |
+| [aws_kms_key.s3_default](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/data-sources/kms_key) | data source |
+| [aws_kms_key.s3_migration](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/data-sources/kms_key) | data source |
 | [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/data-sources/partition) | data source |
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/data-sources/region) | data source |
 | [aws_s3_bucket.guide_buckets](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/data-sources/s3_bucket) | data source |

--- a/terraform/physical/README.md
+++ b/terraform/physical/README.md
@@ -22,7 +22,7 @@
 |------|--------|---------|
 | <a name="module_aws_node_termination_handler_role"></a> [aws\_node\_termination\_handler\_role](#module\_aws\_node\_termination\_handler\_role) | terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc | 5.11.2 |
 | <a name="module_aws_node_termination_handler_sqs"></a> [aws\_node\_termination\_handler\_sqs](#module\_aws\_node\_termination\_handler\_sqs) | terraform-aws-modules/sqs/aws | ~> 4.0.1 |
-| <a name="module_bastion"></a> [bastion](#module\_bastion) | terraform-aws-modules/autoscaling/aws | 6.7.1 |
+| <a name="module_bastion"></a> [bastion](#module\_bastion) | terraform-aws-modules/autoscaling/aws | 6.9.0 |
 | <a name="module_bastion_sg"></a> [bastion\_sg](#module\_bastion\_sg) | terraform-aws-modules/security-group/aws | 4.17.1 |
 | <a name="module_bi_database_sg"></a> [bi\_database\_sg](#module\_bi\_database\_sg) | terraform-aws-modules/security-group/aws | 4.17.1 |
 | <a name="module_cluster_access_role"></a> [cluster\_access\_role](#module\_cluster\_access\_role) | terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc | 5.11.2 |

--- a/terraform/physical/README.md
+++ b/terraform/physical/README.md
@@ -85,6 +85,7 @@
 | [aws_s3_bucket_public_access_block.logging_bucket_acl_block](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/resources/s3_bucket_public_access_block) | resource |
 | [aws_s3_bucket_replication_configuration.replication](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/resources/s3_bucket_replication_configuration) | resource |
 | [aws_s3_bucket_server_side_encryption_configuration.guide_buckets_encryption](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/resources/s3_bucket_server_side_encryption_configuration) | resource |
+| [aws_s3_bucket_server_side_encryption_configuration.logging_bucket_encryption](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/resources/s3_bucket_server_side_encryption_configuration) | resource |
 | [aws_s3_bucket_versioning.guide_buckets_versioning](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/resources/s3_bucket_versioning) | resource |
 | [aws_s3_bucket_versioning.logging_bucket_versioning_block](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/resources/s3_bucket_versioning) | resource |
 | [aws_secretsmanager_secret.primary_database_credentials](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/resources/secretsmanager_secret) | resource |

--- a/terraform/physical/README.md
+++ b/terraform/physical/README.md
@@ -65,6 +65,7 @@
 | [aws_iam_policy.cluster_access](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.cluster_autoscaler_policy](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.eks_worker](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/resources/iam_policy) | resource |
+| [aws_iam_policy.eks_worker_kms](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.s3_replication](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/resources/iam_policy) | resource |
 | [aws_iam_role.s3_replication](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy_attachment.s3_replication](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/resources/iam_role_policy_attachment) | resource |
@@ -118,12 +119,14 @@
 | [aws_iam_policy_document.cluster_access](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.cluster_autoscaler_pd](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.eks_worker](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.eks_worker_kms](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.logging_policy](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.s3_replication](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.s3_replication_assume_role](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/data-sources/iam_policy_document) | data source |
 | [aws_kms_key.eks](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/data-sources/kms_key) | data source |
 | [aws_kms_key.rds](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/data-sources/kms_key) | data source |
 | [aws_kms_key.s3](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/data-sources/kms_key) | data source |
+| [aws_kms_key.s3-default](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/data-sources/kms_key) | data source |
 | [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/data-sources/partition) | data source |
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/data-sources/region) | data source |
 | [aws_s3_bucket.guide_buckets](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/data-sources/s3_bucket) | data source |

--- a/terraform/physical/README.md
+++ b/terraform/physical/README.md
@@ -110,7 +110,6 @@
 | [aws_iam_policy_document.eks_worker](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/data-sources/iam_policy_document) | data source |
 | [aws_kms_key.eks](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/data-sources/kms_key) | data source |
 | [aws_kms_key.rds](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/data-sources/kms_key) | data source |
-| [aws_kms_key.s3](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/data-sources/kms_key) | data source |
 | [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/data-sources/partition) | data source |
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/data-sources/region) | data source |
 | [aws_s3_bucket.documents](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/data-sources/s3_bucket) | data source |
@@ -118,8 +117,8 @@
 | [aws_s3_bucket.guide_objects](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/data-sources/s3_bucket) | data source |
 | [aws_s3_bucket.guide_pdfs](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/data-sources/s3_bucket) | data source |
 | [aws_s3_bucket.logging](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/data-sources/s3_bucket) | data source |
-| [aws_subnet_ids.private](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/data-sources/subnet_ids) | data source |
-| [aws_subnet_ids.public](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/data-sources/subnet_ids) | data source |
+| [aws_subnets.private](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/data-sources/subnets) | data source |
+| [aws_subnets.public](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/data-sources/subnets) | data source |
 | [aws_vpc.this](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/data-sources/vpc) | data source |
 
 ## Inputs

--- a/terraform/physical/README.md
+++ b/terraform/physical/README.md
@@ -3,7 +3,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | 4.57.0 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | 2.18.1 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | 3.2.1 |

--- a/terraform/physical/README.md
+++ b/terraform/physical/README.md
@@ -65,20 +65,28 @@
 | [aws_iam_policy.cluster_access](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.cluster_autoscaler_policy](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.eks_worker](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/resources/iam_policy) | resource |
+| [aws_iam_policy.s3_replication](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/resources/iam_policy) | resource |
+| [aws_iam_role.s3_replication](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy_attachment.s3_replication](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_kms_alias.s3_kms_key](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/resources/kms_alias) | resource |
 | [aws_kms_key.bi](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/resources/kms_key) | resource |
 | [aws_kms_key.eks](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/resources/kms_key) | resource |
+| [aws_kms_key.s3_kms_key](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/resources/kms_key) | resource |
 | [aws_msk_cluster.this](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/resources/msk_cluster) | resource |
 | [aws_msk_configuration.this](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/resources/msk_configuration) | resource |
-| [aws_s3_bucket.guide_documents](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/resources/s3_bucket) | resource |
-| [aws_s3_bucket.guide_images](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/resources/s3_bucket) | resource |
-| [aws_s3_bucket.guide_objects](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/resources/s3_bucket) | resource |
-| [aws_s3_bucket.guide_pdfs](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/resources/s3_bucket) | resource |
+| [aws_s3_bucket.guide_buckets](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/resources/s3_bucket) | resource |
 | [aws_s3_bucket.logging_bucket](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/resources/s3_bucket) | resource |
-| [aws_s3_bucket_public_access_block.guide_documents_acl_block](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/resources/s3_bucket_public_access_block) | resource |
-| [aws_s3_bucket_public_access_block.guide_images_acl_block](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/resources/s3_bucket_public_access_block) | resource |
-| [aws_s3_bucket_public_access_block.guide_objects_acl_block](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/resources/s3_bucket_public_access_block) | resource |
-| [aws_s3_bucket_public_access_block.guide_pdfs_acl_block](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/resources/s3_bucket_public_access_block) | resource |
+| [aws_s3_bucket_acl.guide_buckets_acl](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/resources/s3_bucket_acl) | resource |
+| [aws_s3_bucket_acl.logging_bucket_acl](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/resources/s3_bucket_acl) | resource |
+| [aws_s3_bucket_cors_configuration.guide_documents](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/resources/s3_bucket_cors_configuration) | resource |
+| [aws_s3_bucket_logging.guide_buckets_logging](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/resources/s3_bucket_logging) | resource |
+| [aws_s3_bucket_policy.logging_policy](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/resources/s3_bucket_policy) | resource |
+| [aws_s3_bucket_public_access_block.guide_buckets_acl_block](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/resources/s3_bucket_public_access_block) | resource |
 | [aws_s3_bucket_public_access_block.logging_bucket_acl_block](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/resources/s3_bucket_public_access_block) | resource |
+| [aws_s3_bucket_replication_configuration.replication](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/resources/s3_bucket_replication_configuration) | resource |
+| [aws_s3_bucket_server_side_encryption_configuration.guide_buckets_encryption](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/resources/s3_bucket_server_side_encryption_configuration) | resource |
+| [aws_s3_bucket_versioning.guide_buckets_versioning](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/resources/s3_bucket_versioning) | resource |
+| [aws_s3_bucket_versioning.logging_bucket_versioning_block](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/resources/s3_bucket_versioning) | resource |
 | [aws_secretsmanager_secret.primary_database_credentials](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/resources/secretsmanager_secret) | resource |
 | [aws_secretsmanager_secret.replica_database_credentials](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/resources/secretsmanager_secret) | resource |
 | [aws_secretsmanager_secret_version.primary_database_credentials](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/resources/secretsmanager_secret_version) | resource |
@@ -100,6 +108,7 @@
 | [aws_ssm_document.bastion_mysql_config](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/resources/ssm_document) | resource |
 | [null_resource.cluster_urls](https://registry.terraform.io/providers/hashicorp/null/3.2.1/docs/resources/resource) | resource |
 | [null_resource.replication_control](https://registry.terraform.io/providers/hashicorp/null/3.2.1/docs/resources/resource) | resource |
+| [null_resource.s3_replication_job_init](https://registry.terraform.io/providers/hashicorp/null/3.2.1/docs/resources/resource) | resource |
 | [aws_ami.amazon_linux_2](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/data-sources/ami) | data source |
 | [aws_availability_zones.available](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/data-sources/availability_zones) | data source |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/data-sources/caller_identity) | data source |
@@ -108,15 +117,15 @@
 | [aws_iam_policy_document.cluster_access](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.cluster_autoscaler_pd](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.eks_worker](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.logging_policy](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.s3_replication](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.s3_replication_assume_role](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/data-sources/iam_policy_document) | data source |
 | [aws_kms_key.eks](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/data-sources/kms_key) | data source |
 | [aws_kms_key.rds](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/data-sources/kms_key) | data source |
+| [aws_kms_key.s3](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/data-sources/kms_key) | data source |
 | [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/data-sources/partition) | data source |
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/data-sources/region) | data source |
-| [aws_s3_bucket.documents](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/data-sources/s3_bucket) | data source |
-| [aws_s3_bucket.guide_images](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/data-sources/s3_bucket) | data source |
-| [aws_s3_bucket.guide_objects](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/data-sources/s3_bucket) | data source |
-| [aws_s3_bucket.guide_pdfs](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/data-sources/s3_bucket) | data source |
-| [aws_s3_bucket.logging](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/data-sources/s3_bucket) | data source |
+| [aws_s3_bucket.guide_buckets](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/data-sources/s3_bucket) | data source |
 | [aws_subnets.private](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/data-sources/subnets) | data source |
 | [aws_subnets.public](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/data-sources/subnets) | data source |
 | [aws_vpc.this](https://registry.terraform.io/providers/hashicorp/aws/4.57.0/docs/data-sources/vpc) | data source |
@@ -134,7 +143,6 @@
 | <a name="input_bi_vpn_access"></a> [bi\_vpn\_access](#input\_bi\_vpn\_access) | NOTE: This is mutually exclusive with public BI access, both cannot be enabled at the same time. If BI is enabled we can create an OpenVPN connection to the BI database for secure internet access to the server. | `bool` | `false` | no |
 | <a name="input_bi_vpn_user_list"></a> [bi\_vpn\_user\_list](#input\_bi\_vpn\_user\_list) | List of users to create OpenVPN configurations for usint mutual authentication. | `list(string)` | <pre>[<br>  "root"<br>]</pre> | no |
 | <a name="input_cf_template_version"></a> [cf\_template\_version](#input\_cf\_template\_version) | Version of the CloudFormation template that deployed this stack for validation | `number` | `0` | no |
-| <a name="input_create_s3_buckets"></a> [create\_s3\_buckets](#input\_create\_s3\_buckets) | Wheter to create the dozuki S3 buckets or not. | `bool` | `true` | no |
 | <a name="input_eks_desired_capacity"></a> [eks\_desired\_capacity](#input\_eks\_desired\_capacity) | This is what the node count will start out as. | `number` | `"3"` | no |
 | <a name="input_eks_instance_types"></a> [eks\_instance\_types](#input\_eks\_instance\_types) | The instance type of each node in the application's EKS worker node group. | `list(string)` | <pre>[<br>  "m5.large",<br>  "m5a.large",<br>  "m5d.large",<br>  "m5ad.large"<br>]</pre> | no |
 | <a name="input_eks_kms_key_id"></a> [eks\_kms\_key\_id](#input\_eks\_kms\_key\_id) | AWS KMS key identifier for EKS encryption. The identifier can be one of the following format: Key id, key ARN, alias name or alias ARN | `string` | `""` | no |
@@ -160,12 +168,8 @@
 | <a name="input_rds_multi_az"></a> [rds\_multi\_az](#input\_rds\_multi\_az) | If true we will tell RDS to automatically deploy and manage a highly available standby instance of your database. Enabling this doubles the cost of the RDS instance but without it you are susceptible to downtime if the AWS availability zone your RDS instance is in becomes unavailable. | `bool` | `true` | no |
 | <a name="input_rds_snapshot_identifier"></a> [rds\_snapshot\_identifier](#input\_rds\_snapshot\_identifier) | We can seed the database from an existing RDS snapshot in this region. Type the snapshot identifier in this field or leave blank to start with a fresh database. Note: If you do use a snapshot it's critical that during stack updates you continue to include the snapshot identifier in this parameter. Clearing this parameter after using it will cause AWS to spin up a new fresh DB and delete your old one. | `string` | `""` | no |
 | <a name="input_replicated_ui_access_cidrs"></a> [replicated\_ui\_access\_cidrs](#input\_replicated\_ui\_access\_cidrs) | These CIDRs will be allowed to connect to the app dashboard. This is where you upgrade to new versions as well as view cluster status and start/stop the cluster. You probably want to lock this down to your company network CIDR, especially if you chose 'true' for public access. | `list(string)` | <pre>[<br>  "0.0.0.0/0"<br>]</pre> | no |
-| <a name="input_s3_documents_bucket"></a> [s3\_documents\_bucket](#input\_s3\_documents\_bucket) | Name of the bucket to store documents. Use with 'create\_s3\_buckets' = false. | `string` | `""` | no |
-| <a name="input_s3_images_bucket"></a> [s3\_images\_bucket](#input\_s3\_images\_bucket) | Name of the bucket to store guide images. Use with 'create\_s3\_buckets' = false. | `string` | `""` | no |
-| <a name="input_s3_kms_key_id"></a> [s3\_kms\_key\_id](#input\_s3\_kms\_key\_id) | AWS KMS key identifier for S3 encryption. The identifier can be one of the following format: Key id, key ARN, alias name or alias ARN | `string` | `"alias/aws/s3"` | no |
-| <a name="input_s3_logging_bucket"></a> [s3\_logging\_bucket](#input\_s3\_logging\_bucket) | Name of the bucket to store bucket object access logs. Use with 'create\_s3\_buckets' = false. | `string` | `""` | no |
-| <a name="input_s3_objects_bucket"></a> [s3\_objects\_bucket](#input\_s3\_objects\_bucket) | Name of the bucket to store guide objects. Use with 'create\_s3\_buckets' = false. | `string` | `""` | no |
-| <a name="input_s3_pdfs_bucket"></a> [s3\_pdfs\_bucket](#input\_s3\_pdfs\_bucket) | Name of the bucket to store guide pdfs. Use with 'create\_s3\_buckets' = false. | `string` | `""` | no |
+| <a name="input_s3_existing_buckets"></a> [s3\_existing\_buckets](#input\_s3\_existing\_buckets) | List of the existing Dozuki buckets to use. Do not include the logging bucket. | <pre>list(object({<br>    type        = string<br>    bucket_name = string<br>  }))</pre> | `[]` | no |
+| <a name="input_s3_kms_key_id"></a> [s3\_kms\_key\_id](#input\_s3\_kms\_key\_id) | AWS KMS key identifier for S3 encryption. The identifier can be one of the following format: Key id, key ARN, alias name or alias ARN | `string` | `""` | no |
 | <a name="input_vpc_cidr"></a> [vpc\_cidr](#input\_vpc\_cidr) | The CIDR block for the VPC | `string` | `"172.16.0.0/16"` | no |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | The VPC ID where we'll be deploying our resources. (If creating a new VPC leave this field and subnets blank). When using an existing VPC be sure to tag at least 2 subnets with type = public and another 2 with tag type = private | `string` | `""` | no |
 
@@ -196,6 +200,8 @@
 | <a name="output_nlb_ssl_cert_parameter"></a> [nlb\_ssl\_cert\_parameter](#output\_nlb\_ssl\_cert\_parameter) | Parameter name for the NLB SSL cert |
 | <a name="output_nlb_ssl_key_parameter"></a> [nlb\_ssl\_key\_parameter](#output\_nlb\_ssl\_key\_parameter) | Parameter name for the NLB SSL cert key |
 | <a name="output_primary_db_secret"></a> [primary\_db\_secret](#output\_primary\_db\_secret) | Secretmanager ARN to MySQL credential storage |
+| <a name="output_s3_kms_key_id"></a> [s3\_kms\_key\_id](#output\_s3\_kms\_key\_id) | n/a |
+| <a name="output_s3_replicate_buckets"></a> [s3\_replicate\_buckets](#output\_s3\_replicate\_buckets) | n/a |
 | <a name="output_termination_handler_role_arn"></a> [termination\_handler\_role\_arn](#output\_termination\_handler\_role\_arn) | IAM Role arn for EKS node termination handler |
 | <a name="output_termination_handler_sqs_queue_id"></a> [termination\_handler\_sqs\_queue\_id](#output\_termination\_handler\_sqs\_queue\_id) | SQS Queue ID for EKS node termination handler |
 | <a name="output_vpc_id"></a> [vpc\_id](#output\_vpc\_id) | VPC ID |

--- a/terraform/physical/bastion.tf
+++ b/terraform/physical/bastion.tf
@@ -93,7 +93,7 @@ resource "aws_ssm_association" "bastion_kubernetes_config" {
 #tfsec:ignore:aws-autoscaling-enable-at-rest-encryption
 module "bastion" {
   source  = "terraform-aws-modules/autoscaling/aws"
-  version = "6.7.1"
+  version = "6.9.0"
 
   name = "${local.identifier}-bastion"
 

--- a/terraform/physical/eks.tf
+++ b/terraform/physical/eks.tf
@@ -1,3 +1,9 @@
+data "aws_kms_key" "eks" {
+  count = local.create_eks_kms ? 0 : 1
+
+  key_id = var.eks_kms_key_id
+}
+
 resource "aws_iam_policy" "cluster_autoscaler_policy" {
   name_prefix = "cluster-autoscaler"
   description = "EKS cluster-autoscaler policy for cluster ${module.eks_cluster.cluster_id}"

--- a/terraform/physical/eks.tf
+++ b/terraform/physical/eks.tf
@@ -145,7 +145,7 @@ data "aws_iam_policy_document" "eks_worker" {
     ]
 
     resources = [
-      data.aws_kms_key.s3.arn,
+      aws_kms_key.s3_kms_key.arn,
     ]
   }
 

--- a/terraform/physical/eks.tf
+++ b/terraform/physical/eks.tf
@@ -128,7 +128,7 @@ data "aws_iam_policy_document" "eks_worker_kms" {
     ]
 
     resources = [
-      aws_kms_key.s3_kms_key.arn,
+      aws_kms_key.s3.arn,
     ]
   }
 }
@@ -167,7 +167,7 @@ data "aws_iam_policy_document" "eks_worker" {
     # This is done to maintain backwards compatibility with <=3.1.
     # The actual KMS permissions exist in the `eks_worker_kms` policy resource.
     resources = [
-      data.aws_kms_key.s3-default.arn,
+      data.aws_kms_key.s3_default.arn
     ]
   }
 

--- a/terraform/physical/eks.tf
+++ b/terraform/physical/eks.tf
@@ -50,7 +50,7 @@ data "aws_iam_policy_document" "cluster_autoscaler_pd" {
 # IAM role that the bastion host can assume.
 module "cluster_access_role_assumable" {
   source  = "terraform-aws-modules/iam/aws//modules/iam-assumable-role"
-  version = "4.7.0"
+  version = "5.11.2"
 
   create_role = true
 
@@ -72,7 +72,7 @@ module "cluster_access_role_assumable" {
 # IAM role to access the EKS cluster. By default only the user that creates the cluster has access to it
 module "cluster_access_role" {
   source  = "terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc"
-  version = "4.7.0"
+  version = "5.11.2"
 
   create_role = true
   role_name   = local.cluster_access_role_name

--- a/terraform/physical/main.tf
+++ b/terraform/physical/main.tf
@@ -2,10 +2,10 @@ terraform {
   required_version = ">= 1.1.0"
 
   required_providers {
-    aws        = "3.70.0"
+    aws        = "4.57.0"
     random     = "3.4.3"
-    kubernetes = "2.13.1"
-    null       = "3.1.0"
+    kubernetes = "2.18.1"
+    null       = "3.2.1"
   }
 }
 provider "kubernetes" {

--- a/terraform/physical/main.tf
+++ b/terraform/physical/main.tf
@@ -57,7 +57,7 @@ locals {
 
   // We create this local to control creation of dynamic assets (you cannot use count *and* for_each in the same resource block)
   // The format of the s3_existing_buckets object is important and described in the variables.tf file.
-  existing_s3_bucket_names = local.use_existing_buckets ? var.s3_existing_buckets : []
+  s3_existing_buckets = local.use_existing_buckets ? var.s3_existing_buckets : []
 
   // Do not change these values without modifying the `moved` blocks in s3.tf
   create_s3_bucket_names = ["image", "obj", "pdf", "doc"]

--- a/terraform/physical/main.tf
+++ b/terraform/physical/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.1.0"
+  required_version = ">= 1.2.0"
 
   required_providers {
     aws        = "4.57.0"

--- a/terraform/physical/main.tf
+++ b/terraform/physical/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.2.0"
+  required_version = ">= 1.3.9"
 
   required_providers {
     aws        = "4.57.0"

--- a/terraform/physical/main.tf
+++ b/terraform/physical/main.tf
@@ -63,49 +63,15 @@ locals {
   create_vpc         = var.vpc_id == "" ? true : false
   vpc_id             = local.create_vpc ? module.vpc[0].vpc_id : var.vpc_id
   vpc_cidr           = local.create_vpc ? module.vpc[0].vpc_cidr_block : data.aws_vpc.this[0].cidr_block
-  public_subnet_ids  = local.create_vpc ? module.vpc[0].public_subnets : data.aws_subnet_ids.public[0].ids
-  private_subnet_ids = local.create_vpc ? module.vpc[0].private_subnets : data.aws_subnet_ids.private[0].ids
+  public_subnet_ids  = local.create_vpc ? module.vpc[0].public_subnets : data.aws_subnets.public[0].ids
+  private_subnet_ids = local.create_vpc ? module.vpc[0].private_subnets : data.aws_subnets.private[0].ids
 }
+
+# Provider and global data resources
 data "aws_eks_cluster" "main" {
   name = module.eks_cluster.cluster_id
 }
-
 data "aws_partition" "current" {}
 data "aws_availability_zones" "available" {}
 data "aws_region" "current" {}
 data "aws_caller_identity" "current" {}
-
-data "aws_vpc" "this" {
-  count = local.create_vpc ? 0 : 1
-  id    = var.vpc_id
-}
-data "aws_subnet_ids" "public" {
-  count = local.create_vpc ? 0 : 1
-
-  vpc_id = var.vpc_id
-
-  tags = {
-    type = "public"
-  }
-}
-data "aws_subnet_ids" "private" {
-  count = local.create_vpc ? 0 : 1
-
-  vpc_id = var.vpc_id
-
-  tags = {
-    type = "private"
-  }
-}
-
-data "aws_kms_key" "rds" {
-  key_id = var.rds_kms_key_id
-}
-data "aws_kms_key" "s3" {
-  key_id = var.s3_kms_key_id
-}
-data "aws_kms_key" "eks" {
-  count = local.create_eks_kms ? 0 : 1
-
-  key_id = var.eks_kms_key_id
-}

--- a/terraform/physical/modules/acm/ca.tf
+++ b/terraform/physical/modules/acm/ca.tf
@@ -3,7 +3,6 @@ resource "tls_private_key" "ca" {
   algorithm = "RSA"
 }
 resource "tls_self_signed_cert" "ca" {
-  key_algorithm   = "RSA"
   private_key_pem = tls_private_key.ca.private_key_pem
 
   dns_names = [local.ssl_ca_cn]

--- a/terraform/physical/modules/acm/cert.tf
+++ b/terraform/physical/modules/acm/cert.tf
@@ -10,7 +10,6 @@ resource "tls_private_key" "server" {
   algorithm = "RSA"
 }
 resource "tls_cert_request" "server" {
-  key_algorithm   = "RSA"
   private_key_pem = tls_private_key.server.private_key_pem
   dns_names       = [local.ssl_cert_cn]
 
@@ -19,8 +18,8 @@ resource "tls_cert_request" "server" {
   }
 }
 resource "tls_locally_signed_cert" "server" {
-  cert_request_pem      = tls_cert_request.server.cert_request_pem
-  ca_key_algorithm      = "RSA"
+  cert_request_pem = tls_cert_request.server.cert_request_pem
+
   ca_private_key_pem    = tls_private_key.ca.private_key_pem
   ca_cert_pem           = tls_self_signed_cert.ca.cert_pem
   validity_period_hours = 87600

--- a/terraform/physical/modules/acm/main.tf
+++ b/terraform/physical/modules/acm/main.tf
@@ -4,11 +4,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "3.70.0"
+      version = "4.57.0"
     }
     tls = {
       source  = "hashicorp/tls"
-      version = "3.1.0"
+      version = "4.0.4"
     }
   }
 }

--- a/terraform/physical/modules/acm/main.tf
+++ b/terraform/physical/modules/acm/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.2.0"
+  required_version = ">= 1.3.9"
 
   required_providers {
     aws = {

--- a/terraform/physical/modules/acm/main.tf
+++ b/terraform/physical/modules/acm/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.1.0"
+  required_version = ">= 1.2.0"
 
   required_providers {
     aws = {

--- a/terraform/physical/modules/vpn/config.tf
+++ b/terraform/physical/modules/vpn/config.tf
@@ -12,8 +12,8 @@ resource "tls_private_key" "client" {
   algorithm = "RSA"
 }
 resource "tls_cert_request" "client" {
-  count           = length(var.vpn-client-list)
-  key_algorithm   = "RSA"
+  count = length(var.vpn-client-list)
+
   private_key_pem = tls_private_key.client[count.index].private_key_pem
   subject {
     common_name  = "${local.identifier}.${data.aws_region.current.name}.vpn.${var.vpn-client-list[count.index]}-client"
@@ -21,9 +21,9 @@ resource "tls_cert_request" "client" {
   }
 }
 resource "tls_locally_signed_cert" "client" {
-  count                 = length(var.vpn-client-list)
-  cert_request_pem      = tls_cert_request.client[count.index].cert_request_pem
-  ca_key_algorithm      = "RSA"
+  count            = length(var.vpn-client-list)
+  cert_request_pem = tls_cert_request.client[count.index].cert_request_pem
+
   ca_private_key_pem    = module.ssl_cert.ssm_ca_key.value
   ca_cert_pem           = module.ssl_cert.ssm_ca_cert.value
   validity_period_hours = 87600
@@ -50,7 +50,7 @@ resource "aws_acm_certificate" "client" {
   )
 }
 
-resource "aws_s3_bucket_object" "vpn-config-file" {
+resource "aws_s3_object" "vpn-config-file" {
   count                  = length(var.vpn-client-list)
   bucket                 = aws_s3_bucket.vpn-config-files.id
   server_side_encryption = "aws:kms"

--- a/terraform/physical/modules/vpn/endpoint.tf
+++ b/terraform/physical/modules/vpn/endpoint.tf
@@ -2,6 +2,8 @@ resource "aws_ec2_client_vpn_endpoint" "vpn-client" {
   description            = "${local.identifier}-vpn-client"
   server_certificate_arn = module.ssl_cert.acm_server_arn
   client_cidr_block      = var.client_cidr_block
+  vpc_id                 = var.vpc_id
+  security_group_ids     = [aws_security_group.vpn.id]
 
   split_tunnel = true
   authentication_options {
@@ -23,7 +25,6 @@ resource "aws_ec2_client_vpn_endpoint" "vpn-client" {
 resource "aws_ec2_client_vpn_network_association" "vpn-client" {
   client_vpn_endpoint_id = aws_ec2_client_vpn_endpoint.vpn-client.id
   subnet_id              = var.subnet_id
-  security_groups        = [aws_security_group.vpn.id]
 }
 resource "aws_ec2_client_vpn_authorization_rule" "vpn-client" {
   client_vpn_endpoint_id = aws_ec2_client_vpn_endpoint.vpn-client.id

--- a/terraform/physical/modules/vpn/main.tf
+++ b/terraform/physical/modules/vpn/main.tf
@@ -4,11 +4,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "3.70.0"
+      version = "4.57.0"
     }
     tls = {
       source  = "hashicorp/tls"
-      version = "3.1.0"
+      version = "4.0.4"
     }
   }
 }

--- a/terraform/physical/modules/vpn/main.tf
+++ b/terraform/physical/modules/vpn/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.2.0"
+  required_version = ">= 1.3.9"
 
   required_providers {
     aws = {

--- a/terraform/physical/modules/vpn/main.tf
+++ b/terraform/physical/modules/vpn/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.1.0"
+  required_version = ">= 1.2.0"
 
   required_providers {
     aws = {

--- a/terraform/physical/modules/vpn/s3.tf
+++ b/terraform/physical/modules/vpn/s3.tf
@@ -1,6 +1,6 @@
 resource "aws_s3_bucket_versioning" "vpn_config_versioning_block" {
 
-  bucket = aws_s3_bucket.vpn-config-files
+  bucket = aws_s3_bucket.vpn-config-files.bucket
 
   versioning_configuration {
     status = "Enabled"

--- a/terraform/physical/modules/vpn/s3.tf
+++ b/terraform/physical/modules/vpn/s3.tf
@@ -1,23 +1,29 @@
+resource "aws_s3_bucket_versioning" "vpn_config_versioning_block" {
+
+  bucket = aws_s3_bucket.vpn-config-files
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
 #tfsec:ignore:aws-s3-enable-bucket-logging
 resource "aws_s3_bucket" "vpn-config-files" {
   bucket        = "${local.identifier}-${data.aws_region.current.name}-vpn-credentials"
   force_destroy = true
+}
 
-  versioning {
-    enabled = true
-  }
+resource "aws_s3_bucket_server_side_encryption_configuration" "vpn-config-files" {
 
-  server_side_encryption_configuration {
+  bucket = aws_s3_bucket.vpn-config-files.bucket
 
-    rule {
-      bucket_key_enabled = true
-      apply_server_side_encryption_by_default {
-        kms_master_key_id = var.s3_kms_key_id
-        sse_algorithm     = "aws:kms"
-      }
+  rule {
+    bucket_key_enabled = true
+    apply_server_side_encryption_by_default {
+      kms_master_key_id = var.s3_kms_key_id
+      sse_algorithm     = "aws:kms"
     }
-
   }
+
 }
 
 resource "aws_s3_bucket_public_access_block" "vpn-config-files" {

--- a/terraform/physical/monitoring.tf
+++ b/terraform/physical/monitoring.tf
@@ -1,12 +1,12 @@
 module "sns" {
   source  = "terraform-aws-modules/sns/aws"
-  version = "2.1.0"
+  version = "5.1.0"
   name    = local.identifier
 }
 
 module "cpu_alarm" {
   source  = "terraform-aws-modules/cloudwatch/aws//modules/metric-alarm"
-  version = "2.1.0"
+  version = "4.2.1"
 
   alarm_name        = "${local.identifier}-cpu-high"
   alarm_description = "CPU utilization high for ${local.identifier} worker nodes"
@@ -25,17 +25,17 @@ module "cpu_alarm" {
   }
 
   alarm_actions = [
-    module.sns.this_sns_topic_arn
+    module.sns.topic_arn
   ]
 
   ok_actions = [
-    module.sns.this_sns_topic_arn
+    module.sns.topic_arn
   ]
 }
 
 module "memory_alarm" {
   source  = "terraform-aws-modules/cloudwatch/aws//modules/metric-alarm"
-  version = "2.1.0"
+  version = "4.2.1"
 
   alarm_name        = "${local.identifier}-memory-high"
   alarm_description = "Memory utilization high for ${local.identifier} cluster"
@@ -54,17 +54,17 @@ module "memory_alarm" {
   }
 
   alarm_actions = [
-    module.sns.this_sns_topic_arn
+    module.sns.topic_arn
   ]
 
   ok_actions = [
-    module.sns.this_sns_topic_arn
+    module.sns.topic_arn
   ]
 }
 
 module "status_alarm" {
   source  = "terraform-aws-modules/cloudwatch/aws//modules/metric-alarm"
-  version = "2.1.0"
+  version = "4.2.1"
 
   alarm_name        = "${local.identifier}-status"
   alarm_description = "Status check for ${local.identifier} cluster"
@@ -83,17 +83,17 @@ module "status_alarm" {
   }
 
   alarm_actions = [
-    module.sns.this_sns_topic_arn
+    module.sns.topic_arn
   ]
 
   ok_actions = [
-    module.sns.this_sns_topic_arn
+    module.sns.topic_arn
   ]
 }
 
 module "nodes_alarm" {
   source  = "terraform-aws-modules/cloudwatch/aws//modules/metric-alarm"
-  version = "2.1.0"
+  version = "4.2.1"
 
   alarm_name        = "${local.identifier}-nodes-in-service"
   alarm_description = "Nodes in service under desired capacity for ${local.identifier} cluster"
@@ -112,10 +112,10 @@ module "nodes_alarm" {
   }
 
   alarm_actions = [
-    module.sns.this_sns_topic_arn
+    module.sns.topic_arn
   ]
 
   ok_actions = [
-    module.sns.this_sns_topic_arn
+    module.sns.topic_arn
   ]
 }

--- a/terraform/physical/nlb.tf
+++ b/terraform/physical/nlb.tf
@@ -41,7 +41,7 @@ resource "aws_security_group_rule" "grafana_access_http" {
 #tfsec:ignore:aws-elbv2-alb-not-public
 module "nlb" {
   source  = "terraform-aws-modules/alb/aws"
-  version = "6.6.1"
+  version = "8.4.0"
 
   name = local.identifier
 

--- a/terraform/physical/outputs.tf
+++ b/terraform/physical/outputs.tf
@@ -51,16 +51,22 @@ output "primary_db_secret" {
   value       = aws_secretsmanager_secret.primary_database_credentials.arn
 }
 output "guide_images_bucket" {
-  value = local.guide_images_bucket
+  value = lookup(aws_s3_bucket.guide_buckets["image"], "bucket", null)
 }
 output "guide_objects_bucket" {
-  value = local.guide_objects_bucket
+  value = lookup(aws_s3_bucket.guide_buckets["obj"], "bucket", null)
 }
 output "guide_pdfs_bucket" {
-  value = local.guide_pdfs_bucket
+  value = lookup(aws_s3_bucket.guide_buckets["pdf"], "bucket", null)
 }
 output "documents_bucket" {
-  value = local.documents_bucket
+  value = lookup(aws_s3_bucket.guide_buckets["doc"], "bucket", null)
+}
+output "s3_kms_key_id" {
+  value = aws_kms_key.s3_kms_key.arn
+}
+output "s3_replicate_buckets" {
+  value = local.use_existing_buckets
 }
 output "memcached_cluster_address" {
   value = aws_elasticache_cluster.this.cluster_address

--- a/terraform/physical/outputs.tf
+++ b/terraform/physical/outputs.tf
@@ -63,7 +63,7 @@ output "documents_bucket" {
   value = lookup(aws_s3_bucket.guide_buckets["doc"], "bucket", null)
 }
 output "s3_kms_key_id" {
-  value = aws_kms_key.s3_kms_key.arn
+  value = aws_kms_key.s3.arn
 }
 output "s3_replicate_buckets" {
   value = local.use_existing_buckets

--- a/terraform/physical/outputs.tf
+++ b/terraform/physical/outputs.tf
@@ -28,7 +28,7 @@ output "termination_handler_role_arn" {
 }
 output "termination_handler_sqs_queue_id" {
   description = "SQS Queue ID for EKS node termination handler"
-  value       = module.aws_node_termination_handler_sqs.sqs_queue_id
+  value       = module.aws_node_termination_handler_sqs.queue_id
 }
 output "nlb_dns_name" {
   description = "URL to deployed application"
@@ -80,7 +80,6 @@ output "bi_database_credential_secret" {
   description = "If BI is enabled, this is the ARN to the AWS SecretsManager secret that contains the connection information for the BI database."
   value       = try(aws_secretsmanager_secret.replica_database_credentials[0].arn, "")
 }
-
 output "bi_vpn_configuration_bucket" {
   description = "If BI is enabled, this is the S3 bucket that stores the OpenVPN configuration files for clients to connect to the BI database from the internet."
   value       = try(module.vpn[0].aws_vpn_configuration_bucket, "")
@@ -94,5 +93,5 @@ output "grafana_ssl_key_parameter" {
   value       = try(module.grafana_ssl_cert.ssm_server_key.name, "")
 }
 output "bastion_asg_name" {
-  value = module.bastion.this_autoscaling_group_name
+  value = module.bastion.autoscaling_group_name
 }

--- a/terraform/physical/rds.tf
+++ b/terraform/physical/rds.tf
@@ -10,6 +10,15 @@ moved {
   from = aws_secretsmanager_secret_version.replica_database[0]
   to   = aws_secretsmanager_secret_version.replica_database_credentials[0]
 }
+moved {
+  from = random_password.replica_database[0]
+  to   = module.replica_database[0].random_password.master_password[0]
+}
+moved {
+  from = random_password.primary_database
+  to   = module.primary_database.random_password.master_password[0]
+}
+
 data "aws_kms_key" "rds" {
   key_id = var.rds_kms_key_id
 }
@@ -135,7 +144,8 @@ module "primary_database" {
   kms_key_id            = data.aws_kms_key.rds.arn
   apply_immediately     = !var.protect_resources
 
-  username = "dozuki"
+  username               = "dozuki"
+  random_password_length = 40
 
   multi_az           = var.rds_multi_az
   ca_cert_identifier = local.ca_cert_identifier
@@ -211,7 +221,8 @@ module "replica_database" {
   apply_immediately     = !var.protect_resources
   publicly_accessible   = var.bi_public_access
 
-  username = "dozuki"
+  username               = "dozuki"
+  random_password_length = 40
 
   multi_az           = var.rds_multi_az
   ca_cert_identifier = local.ca_cert_identifier

--- a/terraform/physical/rds.tf
+++ b/terraform/physical/rds.tf
@@ -10,6 +10,9 @@ moved {
   from = aws_secretsmanager_secret_version.replica_database[0]
   to   = aws_secretsmanager_secret_version.replica_database_credentials[0]
 }
+data "aws_kms_key" "rds" {
+  key_id = var.rds_kms_key_id
+}
 module "primary_database_sg" {
   source  = "terraform-aws-modules/security-group/aws"
   version = "4.17.1"

--- a/terraform/physical/rds.tf
+++ b/terraform/physical/rds.tf
@@ -230,8 +230,7 @@ module "replica_database" {
 
   # DB subnet group
   subnet_ids             = local.bi_subnet_ids
-  create_db_subnet_group = var.bi_public_access ? true : false
-  db_subnet_group_name   = var.bi_public_access ? null : module.primary_database.db_subnet_group_id
+  create_db_subnet_group = true
 
   # DB parameter group
   create_db_parameter_group = false

--- a/terraform/physical/s3.tf
+++ b/terraform/physical/s3.tf
@@ -255,7 +255,7 @@ resource "null_resource" "s3_replication_job_init" {
   }
 
   provisioner "local-exec" {
-    command = "/usr/bin/env bash ./util/create-s3-batch.sh ${self.triggers["logging_bucket"]} ${self.triggers["source_bucket"]} ${self.triggers["replication_role"]} ${self.triggers["aws_profile"]} ${self.triggers["aws_account"]}"
+    command = "/usr/bin/env bash ./util/create-s3-batch.sh ${self.triggers["logging_bucket"]} ${self.triggers["source_bucket"]} ${self.triggers["replication_role"]} ${self.triggers["aws_account"]} ${self.triggers["aws_profile"]}"
   }
 }
 

--- a/terraform/physical/s3.tf
+++ b/terraform/physical/s3.tf
@@ -1,28 +1,292 @@
-data "aws_s3_bucket" "guide_images" {
-  count  = var.create_s3_buckets ? 0 : 1
-  bucket = var.s3_images_bucket
+// We use "moved" blocks to allow for upgrading from older version of the infra that used an older AWS provider as well
+// as individual S3 bucket blocks. (don't be alarmed if your IDE marks these "old" resources as errors, they should be)
+
+# Maintaining backwards compatibility to 3.1
+moved {
+  from = data.aws_s3_bucket.guide_images[0]
+  to   = data.aws_s3_bucket.guide_buckets["image"]
 }
-data "aws_s3_bucket" "guide_objects" {
-  count  = var.create_s3_buckets ? 0 : 1
-  bucket = var.s3_objects_bucket
+moved {
+  from = data.aws_s3_bucket.guide_documents[0]
+  to   = data.aws_s3_bucket.guide_buckets["doc"]
 }
-data "aws_s3_bucket" "guide_pdfs" {
-  count  = var.create_s3_buckets ? 0 : 1
-  bucket = var.s3_pdfs_bucket
+moved {
+  from = data.aws_s3_bucket.guide_objects[0]
+  to   = data.aws_s3_bucket.guide_buckets["obj"]
 }
-data "aws_s3_bucket" "documents" {
-  count  = var.create_s3_buckets ? 0 : 1
-  bucket = var.s3_documents_bucket
+moved {
+  from = data.aws_s3_bucket.guide_pdfs[0]
+  to   = data.aws_s3_bucket.guide_buckets["pdf"]
 }
-data "aws_s3_bucket" "logging" {
-  count  = var.create_s3_buckets ? 0 : 1
-  bucket = var.s3_logging_bucket
+moved {
+  from = aws_s3_bucket.guide_images[0]
+  to   = aws_s3_bucket.guide_buckets["image"]
+}
+moved {
+  from = aws_s3_bucket.guide_documents[0]
+  to   = aws_s3_bucket.guide_buckets["doc"]
+}
+moved {
+  from = aws_s3_bucket.guide_objects[0]
+  to   = aws_s3_bucket.guide_buckets["obj"]
+}
+moved {
+  from = aws_s3_bucket.guide_pdfs[0]
+  to   = aws_s3_bucket.guide_buckets["pdf"]
+}
+moved {
+  from = aws_s3_bucket_public_access_block.guide_images_acl_block[0]
+  to   = aws_s3_bucket_public_access_block.guide_buckets_acl_block["image"]
+}
+moved {
+  from = aws_s3_bucket_public_access_block.guide_documents_acl_block[0]
+  to   = aws_s3_bucket_public_access_block.guide_buckets_acl_block["doc"]
+}
+moved {
+  from = aws_s3_bucket_public_access_block.guide_objects_acl_block[0]
+  to   = aws_s3_bucket_public_access_block.guide_buckets_acl_block["obj"]
+}
+moved {
+  from = aws_s3_bucket_public_access_block.guide_pdfs_acl_block[0]
+  to   = aws_s3_bucket_public_access_block.guide_buckets_acl_block["pdf"]
+}
+# - End backwards Compatibility
+
+// If S3 key is provided by a variable, use that otherwise create a new one.
+data "aws_kms_key" "s3" {
+  count = var.s3_kms_key_id != "" ? 1 : 0
+
+  key_id = var.s3_kms_key_id
+}
+resource "aws_kms_key" "s3_kms_key" {
+  description             = "KMS key to encrypt S3 bucket contents"
+  deletion_window_in_days = 7
+}
+resource "aws_kms_alias" "s3_kms_key" {
+  name_prefix   = "alias/${local.identifier}/${data.aws_region.current.name}/s3/"
+  target_key_id = aws_kms_key.s3_kms_key.id
+}
+
+// If using existing buckets
+data "aws_s3_bucket" "guide_buckets" {
+
+  // If not using existing buckets the local variable will be empty and the resource will not be created.
+  // This loop says: for each entry in the existing_s3_bucket_names map, use the "type" attribute for the resource key
+  // (i.e. v.type = "pdf" then aws_s3_bucket.guide_buckets["pdf"])
+  for_each = { for k, v in local.existing_s3_bucket_names : v.type => v }
+
+  bucket = each.value.bucket_name
+
+  lifecycle {
+    precondition {
+      condition     = var.s3_kms_key_id != ""
+      error_message = "To use existing buckets, you must specify the KMS key ID used to encrypt its contents."
+    }
+  }
+}
+
+# Begin S3 Replication for existing buckets
+data "aws_iam_policy_document" "s3_replication_assume_role" {
+  count = local.use_existing_buckets ? 1 : 0
+
+  statement {
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["s3.${data.aws_partition.current.dns_suffix}", "batchoperations.s3.${data.aws_partition.current.dns_suffix}"]
+    }
+
+    actions = ["sts:AssumeRole"]
+  }
+}
+
+resource "aws_iam_role" "s3_replication" {
+  count = local.use_existing_buckets ? 1 : 0
+
+  name               = "${local.identifier}-${data.aws_region.current.name}-s3-replication-role"
+  assume_role_policy = data.aws_iam_policy_document.s3_replication_assume_role[0].json
+}
+
+data "aws_iam_policy_document" "s3_replication" {
+  count = local.use_existing_buckets ? 1 : 0
+
+  depends_on = [data.aws_s3_bucket.guide_buckets]
+
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "s3:GetReplicationConfiguration",
+      "s3:ListBucket",
+      "s3:PutInventoryConfiguration"
+    ]
+
+    resources = local.s3_source_bucket_arn_list
+  }
+
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "s3:GetObjectVersionForReplication",
+      "s3:GetObjectVersionAcl",
+      "s3:GetObjectVersionTagging",
+      "s3:InitiateReplication",
+      "s3:GetObject"
+    ]
+
+    resources = local.s3_source_bucket_arn_list_with_objects
+  }
+
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "s3:ReplicateObject",
+      "s3:ReplicateDelete",
+      "s3:ReplicateTags",
+      "s3:GetObject",
+      "s3:GetObjectVersion",
+      "s3:GetObjectVersionForReplication",
+      "s3:PutObject"
+    ]
+
+    resources = local.s3_destination_bucket_arn_list_with_objects
+  }
+
+  statement {
+    effect = "Allow"
+
+    actions = ["s3:GetObject",
+      "s3:GetObjectVersion",
+    "s3:PutObject"]
+
+    resources = ["${aws_s3_bucket.logging_bucket.arn}/*"]
+  }
+
+  statement {
+    effect = "Allow"
+
+    actions = ["kms:Decrypt"]
+
+    condition {
+      test     = "StringLike"
+      variable = "kms:ViaService"
+      values   = ["s3.${data.aws_region.current.name}.${data.aws_partition.current.dns_suffix}"]
+    }
+    condition {
+      test     = "StringLike"
+      variable = "kms:EncryptionContext:${data.aws_partition.current.partition}:s3:arn"
+      values   = local.s3_source_bucket_arn_list_with_objects
+    }
+
+    resources = [data.aws_kms_key.s3[0].arn]
+  }
+
+  statement {
+    effect = "Allow"
+
+    actions = ["kms:Encrypt"]
+
+    condition {
+      test     = "StringLike"
+      variable = "kms:ViaService"
+      values   = ["s3.${data.aws_region.current.name}.${data.aws_partition.current.dns_suffix}"]
+    }
+    condition {
+      test     = "StringLike"
+      variable = "kms:EncryptionContext:${data.aws_partition.current.partition}:s3:arn"
+      values   = local.s3_destination_bucket_arn_list_with_objects
+    }
+
+    resources = [aws_kms_key.s3_kms_key.arn]
+  }
+}
+
+resource "aws_iam_policy" "s3_replication" {
+  count = local.use_existing_buckets ? 1 : 0
+
+  name   = "${local.identifier}-${data.aws_region.current.name}-s3-replication-policy"
+  policy = data.aws_iam_policy_document.s3_replication[0].json
+}
+
+resource "aws_iam_role_policy_attachment" "s3_replication" {
+  count = local.use_existing_buckets ? 1 : 0
+
+  role       = aws_iam_role.s3_replication[0].name
+  policy_arn = aws_iam_policy.s3_replication[0].arn
+}
+
+resource "aws_s3_bucket_replication_configuration" "replication" {
+  for_each = { for k, v in local.existing_bucket_map : v.type => v }
+
+  role   = aws_iam_role.s3_replication[0].arn
+  bucket = each.value.source
+
+  rule {
+    status = "Enabled"
+
+    source_selection_criteria {
+      sse_kms_encrypted_objects {
+        status = "Enabled"
+      }
+    }
+
+    destination {
+      bucket        = each.value.destination
+      storage_class = "STANDARD"
+      encryption_configuration {
+        replica_kms_key_id = aws_kms_key.s3_kms_key.arn
+      }
+    }
+  }
+}
+
+resource "null_resource" "s3_replication_job_init" {
+  for_each = { for k, v in local.existing_bucket_map : v.type => v }
+
+  triggers = {
+    aws_account      = data.aws_caller_identity.current.account_id
+    aws_profile      = var.aws_profile
+    logging_bucket   = aws_s3_bucket.logging_bucket.arn
+    source_bucket    = each.value.source
+    replication_role = aws_iam_role.s3_replication[0].arn
+  }
+
+  provisioner "local-exec" {
+    command = "/usr/bin/env bash ./util/create-s3-batch.sh ${self.triggers["logging_bucket"]} ${self.triggers["source_bucket"]} ${self.triggers["replication_role"]} ${self.triggers["aws_profile"]} ${self.triggers["aws_account"]}"
+  }
+}
+
+# - End S3 Replication
+
+resource "aws_s3_bucket_policy" "logging_policy" {
+  bucket = aws_s3_bucket.logging_bucket.id
+  policy = data.aws_iam_policy_document.logging_policy.json
+}
+
+data "aws_iam_policy_document" "logging_policy" {
+  statement {
+    principals {
+      type        = "Service"
+      identifiers = ["logging.s3.amazonaws.com"]
+    }
+
+    actions = [
+      "s3:PutObject"
+    ]
+
+    resources = [
+      aws_s3_bucket.logging_bucket.arn,
+      "${aws_s3_bucket.logging_bucket.arn}/*",
+    ]
+  }
 }
 
 resource "aws_s3_bucket_public_access_block" "logging_bucket_acl_block" {
-  count = var.create_s3_buckets ? 1 : 0
 
-  bucket = aws_s3_bucket.logging_bucket[0].id
+  bucket = aws_s3_bucket.logging_bucket.id
 
   block_public_acls       = true
   block_public_policy     = true
@@ -30,210 +294,89 @@ resource "aws_s3_bucket_public_access_block" "logging_bucket_acl_block" {
   restrict_public_buckets = true
 }
 
-# Let's disable logging on the logging bucket to prevent creating a blackhole that destroys the universe.
+resource "aws_s3_bucket_acl" "logging_bucket_acl" {
+
+  bucket = aws_s3_bucket.logging_bucket.id
+
+  acl = "log-delivery-write"
+}
+
+resource "aws_s3_bucket_versioning" "logging_bucket_versioning_block" {
+
+  bucket = aws_s3_bucket.logging_bucket.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+// Let's disable logging on the logging bucket to prevent creating a black hole that destroys the universe.
 #tfsec:ignore:aws-s3-enable-bucket-logging
 resource "aws_s3_bucket" "logging_bucket" {
-  count = var.create_s3_buckets ? 1 : 0
 
   bucket_prefix = "${local.identifier}-log-${data.aws_region.current.name}"
-  acl           = "private"
   force_destroy = !var.protect_resources
-
-  versioning {
-    enabled = true
-  }
-
-  server_side_encryption_configuration {
-
-    rule {
-      bucket_key_enabled = true
-      apply_server_side_encryption_by_default {
-        kms_master_key_id = var.s3_kms_key_id
-        sse_algorithm     = "aws:kms"
-      }
-    }
-
-  }
-
-  lifecycle {
-    ignore_changes = [
-      bucket,
-      bucket_prefix
-    ]
-  }
 }
-resource "aws_s3_bucket_public_access_block" "guide_images_acl_block" {
-  count = var.create_s3_buckets ? 1 : 0
 
-  bucket = aws_s3_bucket.guide_images[0].id
+# Begin creating buckets and associated bucket resources dynamically
+resource "aws_s3_bucket" "guide_buckets" {
+  for_each = toset(local.create_s3_bucket_names)
+
+  bucket_prefix = "${local.identifier}-${each.key}-${data.aws_region.current.name}"
+  force_destroy = !var.protect_resources
+}
+resource "aws_s3_bucket_logging" "guide_buckets_logging" {
+  for_each = toset(local.create_s3_bucket_names)
+
+  bucket = lookup(lookup(aws_s3_bucket.guide_buckets, each.key), "bucket")
+
+  target_bucket = aws_s3_bucket.logging_bucket.bucket
+  target_prefix = "${each.key}/"
+}
+resource "aws_s3_bucket_public_access_block" "guide_buckets_acl_block" {
+  for_each = aws_s3_bucket.guide_buckets
+
+  bucket = each.value.id
 
   block_public_acls       = true
   block_public_policy     = true
   ignore_public_acls      = true
   restrict_public_buckets = true
 }
-resource "aws_s3_bucket" "guide_images" {
-  count = var.create_s3_buckets ? 1 : 0
+resource "aws_s3_bucket_acl" "guide_buckets_acl" {
+  for_each = aws_s3_bucket.guide_buckets
 
-  bucket_prefix = "${local.identifier}-image-${data.aws_region.current.name}"
-  acl           = "private"
-  force_destroy = !var.protect_resources
+  bucket = each.value.id
+  acl    = "private"
+}
+resource "aws_s3_bucket_versioning" "guide_buckets_versioning" {
+  for_each = aws_s3_bucket.guide_buckets
 
-  versioning {
-    enabled = true
+  bucket = each.value.id
+
+  versioning_configuration {
+    status = "Enabled"
   }
+}
 
-  logging {
-    target_bucket = local.logging_bucket
-    target_prefix = "guide-images"
-  }
+resource "aws_s3_bucket_server_side_encryption_configuration" "guide_buckets_encryption" {
+  for_each = aws_s3_bucket.guide_buckets
 
-  server_side_encryption_configuration {
+  bucket = each.value.id
 
-    rule {
-      bucket_key_enabled = true
-      apply_server_side_encryption_by_default {
-        kms_master_key_id = var.s3_kms_key_id
-        sse_algorithm     = "aws:kms"
-      }
+  rule {
+    bucket_key_enabled = false
+    apply_server_side_encryption_by_default {
+      kms_master_key_id = aws_kms_key.s3_kms_key.arn
+      sse_algorithm     = "aws:kms"
     }
-
   }
 
-  lifecycle {
-    ignore_changes = [
-      bucket,
-      bucket_prefix
-    ]
-  }
 }
-resource "aws_s3_bucket_public_access_block" "guide_objects_acl_block" {
-  count = var.create_s3_buckets ? 1 : 0
 
-  bucket = aws_s3_bucket.guide_objects[0].id
+resource "aws_s3_bucket_cors_configuration" "guide_documents" {
 
-  block_public_acls       = true
-  block_public_policy     = true
-  ignore_public_acls      = true
-  restrict_public_buckets = true
-}
-resource "aws_s3_bucket" "guide_objects" {
-  count = var.create_s3_buckets ? 1 : 0
-
-  bucket_prefix = "${local.identifier}-obj-${data.aws_region.current.name}"
-  acl           = "private"
-  force_destroy = !var.protect_resources
-
-  versioning {
-    enabled = true
-  }
-
-  logging {
-    target_bucket = local.logging_bucket
-    target_prefix = "guide-objects"
-  }
-
-  server_side_encryption_configuration {
-
-    rule {
-      bucket_key_enabled = true
-      apply_server_side_encryption_by_default {
-        kms_master_key_id = var.s3_kms_key_id
-        sse_algorithm     = "aws:kms"
-      }
-    }
-
-  }
-
-  lifecycle {
-    ignore_changes = [
-      bucket,
-      bucket_prefix
-    ]
-  }
-}
-resource "aws_s3_bucket_public_access_block" "guide_pdfs_acl_block" {
-  count = var.create_s3_buckets ? 1 : 0
-
-  bucket = aws_s3_bucket.guide_pdfs[0].id
-
-  block_public_acls       = true
-  block_public_policy     = true
-  ignore_public_acls      = true
-  restrict_public_buckets = true
-}
-resource "aws_s3_bucket" "guide_pdfs" {
-  count = var.create_s3_buckets ? 1 : 0
-
-  bucket_prefix = "${local.identifier}-pdf-${data.aws_region.current.name}"
-  acl           = "private"
-  force_destroy = !var.protect_resources
-
-  versioning {
-    enabled = true
-  }
-
-  logging {
-    target_bucket = local.logging_bucket
-    target_prefix = "guide-pdfs"
-  }
-
-  server_side_encryption_configuration {
-
-    rule {
-      bucket_key_enabled = true
-      apply_server_side_encryption_by_default {
-        kms_master_key_id = var.s3_kms_key_id
-        sse_algorithm     = "aws:kms"
-      }
-    }
-
-  }
-
-  lifecycle {
-    ignore_changes = [
-      bucket,
-      bucket_prefix
-    ]
-  }
-}
-resource "aws_s3_bucket_public_access_block" "guide_documents_acl_block" {
-  count = var.create_s3_buckets ? 1 : 0
-
-  bucket = aws_s3_bucket.guide_documents[0].id
-
-  block_public_acls       = true
-  block_public_policy     = true
-  ignore_public_acls      = true
-  restrict_public_buckets = true
-}
-resource "aws_s3_bucket" "guide_documents" {
-  count = var.create_s3_buckets ? 1 : 0
-
-  bucket_prefix = "${local.identifier}-doc-${data.aws_region.current.name}"
-  acl           = "private"
-  force_destroy = !var.protect_resources
-
-  versioning {
-    enabled = true
-  }
-
-  logging {
-    target_bucket = local.logging_bucket
-    target_prefix = "guide-documents"
-  }
-
-  server_side_encryption_configuration {
-
-    rule {
-      bucket_key_enabled = true
-      apply_server_side_encryption_by_default {
-        kms_master_key_id = var.s3_kms_key_id
-        sse_algorithm     = "aws:kms"
-      }
-    }
-
-  }
+  bucket = aws_s3_bucket.guide_buckets["doc"].id
 
   cors_rule {
     allowed_methods = ["GET"]
@@ -242,11 +385,6 @@ resource "aws_s3_bucket" "guide_documents" {
     expose_headers  = ["Accept-Ranges", "Content-Encoding", "Content-Length", "Content-Range"]
     max_age_seconds = 3000
   }
-
-  lifecycle {
-    ignore_changes = [
-      bucket,
-      bucket_prefix
-    ]
-  }
 }
+
+# - End dynamic S3 resource creation

--- a/terraform/physical/s3.tf
+++ b/terraform/physical/s3.tf
@@ -318,6 +318,19 @@ resource "aws_s3_bucket" "logging_bucket" {
   force_destroy = !var.protect_resources
 }
 
+resource "aws_s3_bucket_server_side_encryption_configuration" "logging_bucket_encryption" {
+
+  bucket = aws_s3_bucket.logging_bucket.bucket
+
+  rule {
+    bucket_key_enabled = false
+    apply_server_side_encryption_by_default {
+      kms_master_key_id = aws_kms_key.s3_kms_key.arn
+      sse_algorithm     = "aws:kms"
+    }
+  }
+}
+
 # Begin creating buckets and associated bucket resources dynamically
 resource "aws_s3_bucket" "guide_buckets" {
   for_each = toset(local.create_s3_bucket_names)

--- a/terraform/physical/s3.tf
+++ b/terraform/physical/s3.tf
@@ -71,9 +71,9 @@ resource "aws_kms_alias" "s3_kms_key" {
 data "aws_s3_bucket" "guide_buckets" {
 
   // If not using existing buckets the local variable will be empty and the resource will not be created.
-  // This loop says: for each entry in the existing_s3_bucket_names map, use the "type" attribute for the resource key
+  // This loop says: for each entry in the s3_existing_buckets map, use the "type" attribute for the resource key
   // (i.e. v.type = "pdf" then aws_s3_bucket.guide_buckets["pdf"])
-  for_each = { for k, v in local.existing_s3_bucket_names : v.type => v }
+  for_each = { for k, v in local.s3_existing_buckets : v.type => v }
 
   bucket = each.value.bucket_name
 

--- a/terraform/physical/s3.tf
+++ b/terraform/physical/s3.tf
@@ -50,6 +50,10 @@ moved {
   from = aws_s3_bucket_public_access_block.guide_pdfs_acl_block[0]
   to   = aws_s3_bucket_public_access_block.guide_buckets_acl_block["pdf"]
 }
+# Backwards compatibility kms key for existing clusters.
+data "aws_kms_key" "s3-default" {
+  key_id = "alias/aws/s3"
+}
 # - End backwards Compatibility
 
 // If S3 key is provided by a variable, use that otherwise create a new one.

--- a/terraform/physical/util/create-s3-batch.sh
+++ b/terraform/physical/util/create-s3-batch.sh
@@ -6,14 +6,13 @@ AWS_LOGGING_BUCKET="$1"
 AWS_SOURCE_BUCKET="$2"
 AWS_REPLICATION_ROLE="$3"
 AWS_ACCOUNT="$4"
-AWS_PROFILE="$5"
+# AWS_PROFILE in $5
 
 AWS_PREFIX=""
 
-if [ "$AWS_PROFILE" != "" ]; then
-  AWS_PREFIX="AWS_PROFILE=$AWS_PROFILE"
+if [ "${5:-}" != "" ]; then
+  AWS_PREFIX="AWS_PROFILE=$5"
 fi
-
 
 $AWS_PREFIX aws s3control create-job \
   --account-id "$AWS_ACCOUNT" \

--- a/terraform/physical/util/create-s3-batch.sh
+++ b/terraform/physical/util/create-s3-batch.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+AWS_LOGGING_BUCKET="$1"
+AWS_SOURCE_BUCKET="$2"
+AWS_REPLICATION_ROLE="$3"
+AWS_PROFILE="$4"
+AWS_ACCOUNT="$5"
+
+aws s3control create-job \
+  --account-id "$AWS_ACCOUNT" \
+  --profile "$AWS_PROFILE" \
+  --operation '{"S3ReplicateObject":{}}' \
+  --report "{\"Bucket\":\"$AWS_LOGGING_BUCKET\",\"Prefix\":\"batch-replication-report\", \"Format\":\"Report_CSV_20180820\",\"Enabled\":true,\"ReportScope\":\"AllTasks\"}" \
+  --manifest-generator "{\"S3JobManifestGenerator\": {\"SourceBucket\": \"arn:aws:s3:::$AWS_SOURCE_BUCKET\", \"EnableManifestOutput\": false, \"Filter\": {\"EligibleForReplication\": true, \"ObjectReplicationStatuses\": [\"NONE\",\"FAILED\"]}}}" \
+  --priority 1 \
+  --role-arn "$AWS_REPLICATION_ROLE" \
+  --no-confirmation-required

--- a/terraform/physical/util/create-s3-batch.sh
+++ b/terraform/physical/util/create-s3-batch.sh
@@ -5,12 +5,18 @@ set -euo pipefail
 AWS_LOGGING_BUCKET="$1"
 AWS_SOURCE_BUCKET="$2"
 AWS_REPLICATION_ROLE="$3"
-AWS_PROFILE="$4"
-AWS_ACCOUNT="$5"
+AWS_ACCOUNT="$4"
+AWS_PROFILE="$5"
 
-aws s3control create-job \
+AWS_PREFIX=""
+
+if [ "$AWS_PROFILE" != "" ]; then
+  AWS_PREFIX="AWS_PROFILE=$AWS_PROFILE"
+fi
+
+
+$AWS_PREFIX aws s3control create-job \
   --account-id "$AWS_ACCOUNT" \
-  --profile "$AWS_PROFILE" \
   --operation '{"S3ReplicateObject":{}}' \
   --report "{\"Bucket\":\"$AWS_LOGGING_BUCKET\",\"Prefix\":\"batch-replication-report\", \"Format\":\"Report_CSV_20180820\",\"Enabled\":true,\"ReportScope\":\"AllTasks\"}" \
   --manifest-generator "{\"S3JobManifestGenerator\": {\"SourceBucket\": \"arn:aws:s3:::$AWS_SOURCE_BUCKET\", \"EnableManifestOutput\": false, \"Filter\": {\"EligibleForReplication\": true, \"ObjectReplicationStatuses\": [\"NONE\",\"FAILED\"]}}}" \

--- a/terraform/physical/variables.tf
+++ b/terraform/physical/variables.tf
@@ -86,43 +86,16 @@ variable "highly_available_nat_gateway" {
 variable "s3_kms_key_id" {
   description = "AWS KMS key identifier for S3 encryption. The identifier can be one of the following format: Key id, key ARN, alias name or alias ARN"
   type        = string
-  default     = "alias/aws/s3"
-}
-
-variable "create_s3_buckets" {
-  description = "Wheter to create the dozuki S3 buckets or not."
-  type        = bool
-  default     = true
-}
-
-variable "s3_objects_bucket" {
-  description = "Name of the bucket to store guide objects. Use with 'create_s3_buckets' = false."
-  type        = string
   default     = ""
 }
 
-variable "s3_images_bucket" {
-  description = "Name of the bucket to store guide images. Use with 'create_s3_buckets' = false."
-  type        = string
-  default     = ""
-}
-
-variable "s3_documents_bucket" {
-  description = "Name of the bucket to store documents. Use with 'create_s3_buckets' = false."
-  type        = string
-  default     = ""
-}
-
-variable "s3_pdfs_bucket" {
-  description = "Name of the bucket to store guide pdfs. Use with 'create_s3_buckets' = false."
-  type        = string
-  default     = ""
-}
-
-variable "s3_logging_bucket" {
-  description = "Name of the bucket to store bucket object access logs. Use with 'create_s3_buckets' = false."
-  type        = string
-  default     = ""
+variable "s3_existing_buckets" {
+  description = "List of the existing Dozuki buckets to use. Do not include the logging bucket."
+  type = list(object({
+    type        = string
+    bucket_name = string
+  }))
+  default = []
 }
 
 variable "rds_kms_key_id" {

--- a/terraform/physical/variables.tf
+++ b/terraform/physical/variables.tf
@@ -41,7 +41,7 @@ variable "cf_template_version" {
 
   validation {
     // Allow for 0 so we can override this check when deploying from workstations or tests.
-    condition     = var.cf_template_version == 0 || var.cf_template_version >= 2
+    condition     = var.cf_template_version == 0 || var.cf_template_version >= 3
     error_message = "CloudFormation template version is out of date. Update your CloudFormation to deploy this version of the infrastructure."
   }
 }

--- a/terraform/physical/variables.tf
+++ b/terraform/physical/variables.tf
@@ -96,6 +96,16 @@ variable "s3_existing_buckets" {
     bucket_name = string
   }))
   default = []
+
+  validation {
+    condition     = length(var.s3_existing_buckets) == 0 || length(var.s3_existing_buckets) == 4
+    error_message = "You must specify all 4 guide buckets; no logging bucket."
+  }
+
+  validation {
+    condition     = length(var.s3_existing_buckets) == 0 || sort([for _, bucket in var.s3_existing_buckets : bucket.type]) == tolist(["doc", "image", "obj", "pdf"])
+    error_message = "You must include all 4 bucket types and 'type' must be one of 'doc', 'image', 'obj', or 'pdf'."
+  }
 }
 
 variable "rds_kms_key_id" {

--- a/terraform/physical/vpc.tf
+++ b/terraform/physical/vpc.tf
@@ -1,6 +1,6 @@
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
-  version = "3.14.1"
+  version = "3.19.0"
 
   count = local.create_vpc ? 1 : 0
 
@@ -19,6 +19,7 @@ module "vpc" {
   create_flow_log_cloudwatch_log_group = true
   create_flow_log_cloudwatch_iam_role  = true
   flow_log_max_aggregation_interval    = 60
+  create_database_subnet_group         = false
 
   public_subnets = [for i in range(local.azs_count) : cidrsubnet(var.vpc_cidr, 4, i)]
 
@@ -29,7 +30,6 @@ module "vpc" {
   }
 
   private_subnets = [for i in range(local.azs_count, local.azs_count * 2) : cidrsubnet(var.vpc_cidr, 4, i)]
-
   private_subnet_tags = {
     "kubernetes.io/cluster/${local.identifier}" = "shared"
     "kubernetes.io/role/internal-elb"           = "1"

--- a/terraform/physical/vpc.tf
+++ b/terraform/physical/vpc.tf
@@ -1,3 +1,32 @@
+data "aws_vpc" "this" {
+  count = local.create_vpc ? 0 : 1
+  id    = var.vpc_id
+}
+
+data "aws_subnets" "public" {
+  count = local.create_vpc ? 0 : 1
+
+  filter {
+    name   = "vpc-id"
+    values = [var.vpc_id]
+  }
+  tags = {
+    type = "public"
+  }
+}
+
+data "aws_subnets" "private" {
+  count = local.create_vpc ? 0 : 1
+
+  filter {
+    name   = "vpc-id"
+    values = [var.vpc_id]
+  }
+  tags = {
+    type = "private"
+  }
+}
+
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
   version = "3.19.0"


### PR DESCRIPTION
# Problem
Our migration system had a fundamental flaw. We could take an existing RDS snapshot and existing S3 buckets to launch a new instance, however that old instance still has a terraform state entry for those S3 buckets. What happens when that old unneeded instance is torn down? The answer is the customer data goes away. 

# Solution
The easiest solution is to simply perform state surgery on that old instance and remove the references to those buckets before deleting and while that works it's far from ideal. One forgotten move or misstep and all of our customer's data is gone forever. I believe this potential calamity is reason enough to invest in a safer replication strategy.

We now create new buckets for each environment regardless of migration state. If migrating, we will setup replication rules on the old buckets and fire off batch replication jobs to copy existing objects from the source buckets to the destination buckets leaving a clear safety separation between environments.

## Caveats
As you may have noticed this has some caveats:
1. S3 bucket replication configurations only apply to **new** objects created after the configuration is applied. To copy **existing** objects, an S3 batch job is required. 
2. We fire off an S3 batch job to copy existing objects but it's asynchronous. It's possible to make this a synchronous process by adding additional logic to the batch creation script but I opted for an async approach due to the unknown and potentially expansive load times some of our larger customer's migrations would take causing TF timeouts and all kinds of messy results. Safety over convenience. So a manual verification of batch job completion is required before the old stack is torn down.
3. Potentially the most annoying caveat and the one the irks me the most is the fact that we have now tied our new state to our old stack (a reversal of what we had before but with zero danger) by creating the replication configuration on the source buckets. That old stack can no longer be torn down fully while the replication configuration is in place (can't delete the bucket when there's still a replication config attached). So to remedy this you would need to re-run this new stack (migration target) with migration disabled so it deletes the replication config thereby freeing up that old stack for deletion. 

Unfortunately there's a bit of a one-two approach to this but I believe on the whole it's a net positive gain for data safety and reliability. 

## Additional Changes
1. To support configuring replication in this way we needed to upgrade to the latest version of the AWS provider. This came with it many refactored resources. The functionality of said resources stays almost the same but the syntax and module implementation slightly differs. 
2. Since we're upgrading the AWS provider we might as well update the other providers we use as well. 
3. Some minor refactors for cleanliness and semantics. Like moving all the data resources out of the `main.tf` into their respective files.
4. Fix replicated install script from trying to re-install on ephemeral environments. 

## QA
I have tested the following scenarios:
* Deploying min, bi, hooks via workstation and cloudformation and validating the app works
* Deploying v3.1 min & full via workstation and cloudformation then upgrading to this branch and verifying nothing bad happens in the TF apply and the app still works
* Deploying this branch, migrating to a new copy of this branch and validating s3 buckets are replicated


Deploying to <= v3.1 and migrating to a new copy of this branch is not supported. Update the source instance first before migration.

Some potential issues that cropped up:
* if we upgrade a customer from <=v3.1 to this version then the ~database passwords~, self-signed certificates, and s3 KMS key will be changed. 
  * ~This requires a full reboot of the application with some minor downtime (<5 minutes) to load the new db credentials.~ (Fixed in 2fb7b5de8fbb07dae000ac13d025f047cab79dc2)
  * ~The bastion instance will need to be recycled to load the new db credentials.~
  * If this new upgraded stack were to ever be migrated in the future someone would need to run a batch job to normalize all the objects in the buckets to use the same key since any objects created before this update will be using the default KMS key and any after will be using the bespoke key. 


