### PR TITLE
Fix S3 bucket re-create when name or prefix changes during upgrade

### DIFF
--- a/terraform/physical/s3.tf
+++ b/terraform/physical/s3.tf
@@ -321,6 +321,13 @@ resource "aws_s3_bucket" "logging_bucket" {
 
   bucket_prefix = "${local.identifier}-log-${data.aws_region.current.name}"
   force_destroy = !var.protect_resources
+
+  lifecycle {
+    ignore_changes = [
+      bucket,
+      bucket_prefix
+    ]
+  }
 }
 
 resource "aws_s3_bucket_server_side_encryption_configuration" "logging_bucket_encryption" {
@@ -342,6 +349,13 @@ resource "aws_s3_bucket" "guide_buckets" {
 
   bucket_prefix = "${local.identifier}-${each.key}-${data.aws_region.current.name}"
   force_destroy = !var.protect_resources
+
+  lifecycle {
+    ignore_changes = [
+      bucket,
+      bucket_prefix
+    ]
+  }
 }
 resource "aws_s3_bucket_logging" "guide_buckets_logging" {
   for_each = toset(local.create_s3_bucket_names)


### PR DESCRIPTION
This came up while updating one of our customers from a very old version of the infra to the latest v3.2. In the time between the releases we changed our bucket naming scheme and this triggers a re-create by default for s3 bucket resources. 

I've added lifecycle ignore blocks to the relevant resources to prevent recreation when the bucket name or prefix changes.