### PR TITLE
Isolated Run Script for Live Environment

### DIFF
--- a/live/Dockerfile
+++ b/live/Dockerfile
@@ -1,5 +1,5 @@
 # Use the specified base image
-FROM devopsinfra/docker-terragrunt:aws-tf-1.3.9-tg-0.44.0
+FROM devopsinfra/docker-terragrunt:aws-latest
 
 # Set environment variables for kubectl version
 ENV KUBE_VERSION="v1.23.0"

--- a/live/Dockerfile
+++ b/live/Dockerfile
@@ -1,0 +1,18 @@
+# Use the specified base image
+FROM devopsinfra/docker-terragrunt:aws-tf-1.3.9-tg-0.44.0
+
+# Set environment variables for kubectl version
+ENV KUBE_VERSION="v1.23.0"
+
+# Install kubectl and required dependencies
+RUN set -ex \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates curl \
+    && curl -LO https://storage.googleapis.com/kubernetes-release/release/${KUBE_VERSION}/bin/linux/amd64/kubectl \
+    && chmod +x kubectl \
+    && mv kubectl /usr/local/bin/ \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Set the default command
+CMD ["bash"]

--- a/live/generate_live_env.sh
+++ b/live/generate_live_env.sh
@@ -1,27 +1,48 @@
 #!/usr/bin/env bash
+set -euo pipefail
 
+# Iterate over both standard and gov partitions
 for partition in standard gov; do
+  # Remove existing partition directory, if any, and create a new one
   if [ -d "$partition" ]; then
     rm -fr "$partition"
   fi
-  mkdir $partition
-  pushd $partition || exit
+  mkdir "$partition"
+
+  # Move into the partition directory
+  pushd "$partition" >/dev/null || exit
+
+  # Copy the account.hcl file for the partition
   cp ../.skel/partitions/$partition/account.hcl .
+
+  # Read the list of regions for the partition from the regions.txt file
   while IFS= read -r region
   do
       echo "Creating live environments for $region"
+
+      # Remove existing region directory, if any, and create a new one
       if [ -d "$region" ]; then
         rm -fr "$region"
       fi
       mkdir "$region"
-      pushd "$region" || exit
+
+      # Move into the region directory
+      pushd "$region" >/dev/null || exit
+
+        # Copy the environment files from the .skel directory
         cp -R ../../.skel/environments/* .
+
+        # Create a region.hcl file with the region-specific information
         cat << EOF > region.hcl
 locals {
   aws_region = "$region"
 }
 EOF
-      popd || exit
+
+      # Move back to the partition directory
+      popd >/dev/null || exit
   done < <(grep -v '^ *#' < ../.skel/partitions/$partition/regions.txt)
-  popd || exit
+
+  # Move back to the initial directory
+  popd >/dev/null || exit
 done

--- a/live/isolated_run.sh
+++ b/live/isolated_run.sh
@@ -1,0 +1,171 @@
+#!/bin/bash
+
+# This script allows you to run multiple terraform commands on multiple branches or change sets at the same time
+# You will no longer need to wait for one run to finish before you can test the next change, nor will you have to juggle
+# changesets or stashes when you want to deploy a different branch for testing.
+
+# Check for the existence of required commands
+for cmd in git docker rsync; do
+  if ! command -v $cmd >/dev/null 2>&1; then
+    echo "Error: $cmd is not installed or not in the PATH"
+    exit 1
+  fi
+done
+
+# Check if the Docker client can connect to the Docker host
+if ! docker info >/dev/null 2>&1; then
+  echo "Error: Docker client cannot connect to the Docker host"
+  exit 1
+fi
+
+# Commands to run on script exit to ensure cleanup.
+cleanup() {
+  # Wait for the container to complete
+  docker wait "$container_id"
+
+  docker rm "$container_id"
+
+  git worktree remove "${WORKTREE_DIR}" --force
+
+  if git rev-parse --verify "${TEST_BRANCH}" >/dev/null 2>&1; then
+    git branch -D "${TEST_BRANCH}"
+  fi
+
+  if git rev-parse --verify "${TEMP_BRANCH}" >/dev/null 2>&1; then
+    git branch -D "${TEMP_BRANCH}"
+  fi
+
+  rm -fr "${TEMP_DIR}"
+
+  echo "Cleanup complete."
+}
+
+# Default values
+AWS_REGION=""
+ENV=""
+TERRAGRUNT_COMMAND=""
+BRANCH_NAME=""
+COPY_LIVE=true
+CLEAR_TF=false
+
+# Define a function to display the usage
+usage() {
+  echo "Usage: ./isolated-run.sh (-r|--region) <region> (-e|--env) <env> (-c|--command) <terragrunt-command> [-b|--branch <branchname>] [-l|--copy_live <true|false>] [-f|--clear_tf <true|false>]"
+}
+
+# Parse command-line arguments using shift for both short and long options
+while [[ "$#" -gt 0 ]]; do
+  case $1 in
+    -r|--region)
+      AWS_REGION="${2:-}"
+      shift
+      ;;
+    -e|--env)
+      ENV="${2:-}"
+      shift
+      ;;
+    -c|--command)
+      TERRAGRUNT_COMMAND="${2:-}"
+      shift
+      ;;
+    -b|--branch)
+      BRANCH_NAME="${2:-}"
+      shift
+      ;;
+    -l|--copy_live)
+      COPY_LIVE="${2:-}"
+      shift
+      ;;
+    -f|--clear_tf)
+      CLEAR_TF="${2:-}"
+      shift
+      ;;
+    *)
+      usage
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+# Check if the required arguments are provided
+if [ -z "$AWS_REGION" ] || [ -z "$ENV" ] || [ -z "$TERRAGRUNT_COMMAND" ]; then
+  usage
+  exit 1
+fi
+
+# Capture script error or exit command and run the cleanup function to ensure resources are deleted in a failure.
+trap cleanup EXIT
+
+TIMESTAMP=$(date "+%Y-%m-%d_%H:%M:%S")
+
+# Replace spaces in the command with dashes so its file/directory safe.
+COMMAND_SUFFIX="${TERRAGRUNT_COMMAND// /-}"
+
+TEMP_DIR=$(mktemp -d)
+
+WORKTREE_DIR="${TEMP_DIR}/worktree"
+
+# If no branch is provided, we assume you want a copy of the currently checked out branch.
+if [ "$BRANCH_NAME" == "" ]; then
+  BRANCH_NAME=$(git branch --show-current)
+  TEMP_BRANCH="temp-${BRANCH_NAME}"
+  TEST_BRANCH="test-${AWS_REGION}-$ENV"
+
+  # Save uncommitted changes and create the temp branch
+  git stash save "temp-changes" > /dev/null 2>&1
+  git checkout -b "${TEMP_BRANCH}" > /dev/null 2>&1
+  git stash apply > /dev/null 2>&1
+  git commit -am 'committing working changes to temp branch' > /dev/null 2>&1
+
+  # Get the commit hash of the last commit in TEMP_BRANCH
+  TEMP_COMMIT_HASH=$(git rev-parse HEAD)
+
+  # Create the test branch, cherry-pick the temp branch commit, and delete the temp branch
+  git checkout -b "${TEST_BRANCH}" "${BRANCH_NAME}" > /dev/null 2>&1
+  git cherry-pick "${TEMP_COMMIT_HASH}" > /dev/null 2>&1
+  git branch -D "${TEMP_BRANCH}" > /dev/null 2>&1
+
+  # Go back to the original branch and pop the stash
+  git checkout "${BRANCH_NAME}" > /dev/null 2>&1
+  git stash pop > /dev/null 2>&1
+
+  # Add the worktree with the test branch
+  git worktree add "${WORKTREE_DIR}" "${TEST_BRANCH}" > /dev/null
+else
+  # Set to true when deploying a different branch since we will likely need to refresh the terraform folders.
+  CLEAR_TF="true"
+  git worktree add "${WORKTREE_DIR}" "${BRANCH_NAME}" > /dev/null
+fi
+
+if [ "${COPY_LIVE}" == "true" ]; then
+  rsync -av --progress --exclude '.git' ./ "${WORKTREE_DIR}"/live > /dev/null 2>&1
+  INITIAL_CMD=""
+  if [ "${CLEAR_TF}" == "true" ]; then
+    find "${WORKTREE_DIR}" -name '.terra*' -exec rm -rf {} +
+  fi
+else
+  INITIAL_CMD="cd live && ./generate_live_env.sh && cd .. &&"
+fi
+
+LOG_DIR="logs/${BRANCH_NAME}/${AWS_REGION}/${ENV}/${COMMAND_SUFFIX}"
+LOG_FILE="${LOG_DIR}/${TIMESTAMP}.log"
+CONTAINER_NAME="${BRANCH_NAME}_${AWS_REGION}_${ENV}_${COMMAND_SUFFIX}"
+
+mkdir -p "${LOG_DIR}"
+
+docker build -t terraform-live-env . > /dev/null 2>&1
+
+# Run the Terragrunt command in the Docker container
+container_id=$(docker run -d \
+  -e AWS_PROFILE=default \
+  -e AWS_REGION="$AWS_REGION" \
+  --name "${CONTAINER_NAME}" \
+  -v "$WORKTREE_DIR:/data" \
+  -v ~/.aws:/root/.aws \
+  terraform-live-env:latest sh -c "${INITIAL_CMD} cd live/standard/${AWS_REGION}/${ENV} && terragrunt ${TERRAGRUNT_COMMAND} --terragrunt-non-interactive")
+
+# Fetch the logs from the container and write them to a log file
+docker logs -f "$container_id" > "$LOG_FILE" 2>&1 &
+echo "To follow logs:"
+echo "tail -f \"$LOG_FILE\""

--- a/live/terragrunt.hcl
+++ b/live/terragrunt.hcl
@@ -9,9 +9,9 @@ locals {
   environment_vars = read_terragrunt_config(find_in_parent_folders("env.hcl"))
 
   # Extract the variables we need for easy access
-  account_id   = local.account_vars.locals.aws_account_id
-  aws_region   = local.region_vars.locals.aws_region
-  aws_profile  = local.account_vars.locals.aws_profile
+  account_id   = get_env("TG_AWS_ACCT_ID", local.account_vars.locals.aws_account_id)
+  aws_region   = get_env("TG_AWS_REGION", local.region_vars.locals.aws_region)
+  aws_profile  = get_env("TG_AWS_PROFILE", local.account_vars.locals.aws_profile)
 }
 
 # Generate an AWS provider block


### PR DESCRIPTION
This is a shell script and small Dockerfile to allow developers to run multiple iterations of the terraform on their workstations without being tied to the source material. This is helpful when testing changes and upgrades to old versions.

The previous workflow for testing changes looked like:
1. Stash working changeset
2. Check out previous tag or master
3. Trigger deploy of checked out version
4. wait.......... coffee....
5. Once completed we then check out the working branch
6. apply the stash of our working changes
7. Trigger deploy of new version on top of the old version to test upgrading.
8. wait........ coffee.....
9. profit?

All the while during those wait periods you were unable to make any changes to the terraform or live environment due to the multi root module configuration we use. It might've loaded the physical module into the cache but the logical module hadn't been touched yet so no changes can be made lest you create an issue when it's time for the logical module to run. 

Now with this script the workflow looks like this:
1. Execute `isolated_run.sh` with your parameters including the region, environment, terragrunt command, git branch (or current) and some optional flags.
2. Continue working on the code or do whatever while the docker container runs your command in the background, completely isolated with it's own copy of the terraform.

