### PR TITLE
BI Condition Fix & Template Lock Update

### DIFF
--- a/terraform/physical/bi.tf
+++ b/terraform/physical/bi.tf
@@ -178,7 +178,7 @@ module "rds_replica_database" {
   source  = "terraform-aws-modules/rds/aws"
   version = "5.6.0"
 
-  count = local.dms_enabled ? 0 : 1
+  count = var.enable_bi ? local.dms_enabled ? 0 : 1 : 0
 
   identifier = "${local.identifier}-rds-replica"
 

--- a/terraform/physical/variables.tf
+++ b/terraform/physical/variables.tf
@@ -64,7 +64,7 @@ variable "cf_template_version" {
 
   validation {
     // Allow for 0 so we can override this check when deploying from workstations or tests.
-    condition     = var.cf_template_version == 0 || var.cf_template_version >= 4
+    condition     = var.cf_template_version == 0 || var.cf_template_version >= 5
     error_message = "CloudFormation template version is out of date. Update your CloudFormation to deploy this version of the infrastructure."
   }
 }


### PR DESCRIPTION
A small bug slipped through the last major PR where the RDS RR resource would be created even if BI was disabled due to the condition only checking for dms. 

Additionally we need to increment the cloudformation template lock version to reflect the new changes to identifier/customer and alarming config.