### PR TITLE
Add missing S3 permissions to support new tagging in app code

### DIFF
--- a/terraform/physical/eks.tf
+++ b/terraform/physical/eks.tf
@@ -143,7 +143,12 @@ data "aws_iam_policy_document" "eks_worker" {
       "s3:GetObjectAcl",
       "s3:ListBucket",
       "s3:ListObjectsV2",
-      "s3:CopyObject"
+      "s3:CopyObject",
+      "s3:DeleteObjectTagging",
+      "s3:ReplicateTags",
+      "s3:PutObjectVersionTagging",
+      "s3:PutObjectTagging",
+      "s3:DeleteObjectVersionTagging"
     ]
 
     resources = [


### PR DESCRIPTION
We've started tagging all objects uploaded to s3 from within the application so these new permissions are required for the EKS node instance role.