### PR TITLE
Implementing `name_prefix` for Unique Database Credential Secrets

### DIFF
--- a/terraform/physical/bi.tf
+++ b/terraform/physical/bi.tf
@@ -272,6 +272,13 @@ resource "aws_secretsmanager_secret" "replica_database_credentials" {
   name_prefix = "${local.identifier}-replica-database"
 
   recovery_window_in_days = var.protect_resources ? 7 : 0
+
+  lifecycle {
+    ignore_changes = [
+      name,
+      name_prefix
+    ]
+  }
 }
 
 resource "aws_secretsmanager_secret_version" "replica_database_credentials" {

--- a/terraform/physical/rds.tf
+++ b/terraform/physical/rds.tf
@@ -169,8 +169,14 @@ module "primary_database" {
 resource "aws_secretsmanager_secret" "primary_database_credentials" {
   name_prefix = "${local.identifier}-database"
 
-  recovery_window_in_days = 0
-  //  kms_key_id              = data.aws_kms_key.rds.arn
+  recovery_window_in_days = var.protect_resources ? 7 : 0
+
+  lifecycle {
+    ignore_changes = [
+      name,
+      name_prefix
+    ]
+  }
 }
 
 resource "aws_secretsmanager_secret_version" "primary_database_credentials" {


### PR DESCRIPTION
This PR addresses a long-standing issue related to the handling of database credential secrets.

Previously, we attempted to solve the problem by setting a 0-day deletion window. While technically feasible, this approach is not suitable for production workloads due to potential risks.

Instead, the proposed solution leverages the name_prefix attribute for secrets to ensure uniqueness. This mitigates the risk of secret name collisions, particularly when enabling, disabling, and re-enabling features such as BI.

The issue at hand arises under the following conditions:

A stack is created with BI enabled (or it's enabled after creation).
BI is subsequently disabled.
Attempting to re-enable BI results in a failure due to a secret name collision.
This failure occurs because the deletion window attribute is set to 7 days when protect_resources is set to true - a common setting in production environments. In such cases, attempting to re-enable BI before the deletion window has elapsed triggers a secret name collision.

By adopting the name_prefix approach, we circumvent this issue. Now, re-enabling a feature will create a new secret with a unique suffix, while the old secret can safely delete itself after the 7-day window.

Moreover, to prevent this switch to name_prefix from causing unwanted secret re-creation during stack upgrades, a lifecycle ignore_changes block has been introduced. This block instructs Terraform not to trigger a re-create or update if a difference in name or name_prefix is detected.

This change will make our system more resilient to configuration changes and reduce potential disruptions in our production environments.