### PR TITLE
Enhancing DMS Performance: Updates to Replication Setup and Schema Mapping Strategy

### DIFF
--- a/terraform/physical/bi.tf
+++ b/terraform/physical/bi.tf
@@ -119,7 +119,7 @@ resource "aws_dms_endpoint" "target" {
   ssl_mode                    = "verify-full"
   endpoint_type               = "target"
   engine_name                 = "mysql"
-  extra_connection_attributes = "afterConnectScript=call mysql.rds_set_configuration('binlog retention hours', 24);"
+  extra_connection_attributes = "afterConnectScript=call mysql.rds_set_configuration('binlog retention hours', 24);Initstmt=SET FOREIGN_KEY_CHECKS=0;"
   port                        = 3306
   kms_key_arn                 = aws_kms_key.bi[0].arn
 
@@ -194,7 +194,8 @@ module "rds_replica_database" {
 
   create_random_password = false
 
-  multi_az           = var.rds_multi_az
+  // No need for multi-az for a read replica
+  multi_az           = false
   ca_cert_identifier = local.ca_cert_identifier
 
   vpc_security_group_ids = [module.bi_database_sg.security_group_id]
@@ -237,7 +238,8 @@ module "dms_replica_database" {
   random_password_length = 40
   create_random_password = true
 
-  multi_az           = var.rds_multi_az
+  // Multi-az causes issues with DMS so we disable it.
+  multi_az           = false
   ca_cert_identifier = local.ca_cert_identifier
 
   maintenance_window = "Sun:19:00-Sun:23:00"

--- a/terraform/physical/static/dms_mapping.json
+++ b/terraform/physical/static/dms_mapping.json
@@ -3,9 +3,9 @@
     {
       "rule-type": "selection",
       "rule-id": "1",
-      "rule-name": "1",
+      "rule-name": "include-guide",
       "object-locator": {
-        "schema-name": "%",
+        "schema-name": "%_guide",
         "table-name": "%"
       },
       "rule-action": "include",
@@ -14,40 +14,7 @@
     {
       "rule-type": "selection",
       "rule-id": "2",
-      "rule-name": "2",
-      "object-locator": {
-        "schema-name": "mysql",
-        "table-name": "%"
-      },
-      "rule-action": "exclude",
-      "filters": []
-    },
-    {
-      "rule-type": "selection",
-      "rule-id": "3",
-      "rule-name": "3",
-      "object-locator": {
-        "schema-name": "performance_schema",
-        "table-name": "%"
-      },
-      "rule-action": "exclude",
-      "filters": []
-    },
-    {
-      "rule-type": "selection",
-      "rule-id": "4",
-      "rule-name": "4",
-      "object-locator": {
-        "schema-name": "frontegg_%",
-        "table-name": "%"
-      },
-      "rule-action": "exclude",
-      "filters": []
-    },
-    {
-      "rule-type": "selection",
-      "rule-id": "5",
-      "rule-name": "5",
+      "rule-name": "exclude-sessions",
       "object-locator": {
         "schema-name": "%",
         "table-name": "sessions"
@@ -57,11 +24,44 @@
     },
     {
       "rule-type": "selection",
-      "rule-id": "6",
-      "rule-name": "6",
+      "rule-id": "3",
+      "rule-name": "exclude-pwreset",
       "object-locator": {
         "schema-name": "%",
         "table-name": "user_password_reset"
+      },
+      "rule-action": "exclude",
+      "filters": []
+    },
+    {
+      "rule-type": "selection",
+      "rule-id": "4",
+      "rule-name": "exclude-wiki-url",
+      "object-locator": {
+        "schema-name": "%",
+        "table-name": "wiki_urls"
+      },
+      "rule-action": "exclude",
+      "filters": []
+    },
+    {
+      "rule-type": "selection",
+      "rule-id": "5",
+      "rule-name": "exclude-oid-nonce",
+      "object-locator": {
+        "schema-name": "%",
+        "table-name": "oid_nonces"
+      },
+      "rule-action": "exclude",
+      "filters": []
+    },
+    {
+      "rule-type": "selection",
+      "rule-id": "6",
+      "rule-name": "exclude-oid-assoc",
+      "object-locator": {
+        "schema-name": "%",
+        "table-name": "oid_associations"
       },
       "rule-action": "exclude",
       "filters": []


### PR DESCRIPTION
In our ongoing efforts to minimize the failure rate of DMS, we have implemented several alterations to our conditional replication setup and our approach to establishing and connecting to the replica database. Most importantly, we now completely turn off multi-az for the target replica, aligning with AWS' best-practice recommendation. Likewise, we have disabled foreign key checks in the target database to further enhance performance and reliability.

The most significant shift, however, is in our strategy for schema mapping. Rather than solely relying on an exclusive blacklist, we've transitioned to a dual-pronged approach that incorporates both a whitelist and a blacklist as needed. This shift aims to better manage and mitigate any potential errors by excluding databases and tables that should remain untouched or may pose an increased risk of replication errors.