### PR TITLE
Correction to KOTS Configuration Update: Preventing Overwrites with --merge Tag

### DIFF
--- a/terraform/logical/replicated.tf
+++ b/terraform/logical/replicated.tf
@@ -111,7 +111,7 @@ if ! kubectl kots get apps -n ${kubernetes_namespace.kots_app.metadata[0].name} 
     --wait-duration=10m
 else
   # If app is already installed, update the config with any changed values from this run.
-  kubectl kots set config ${local.app_slug} --config-file ${local_file.replicated_bootstrap_config.filename}
+  kubectl kots set config ${local.app_slug} --merge --config-file ${local_file.replicated_bootstrap_config.filename}
 fi
 
 EOT


### PR DESCRIPTION
In the course of incorporating the feature to update the KOTS configuration each time the terraform reruns the logical module, I mistakenly caused the entire configuration to be overwritten. This error stemmed from an assumption that the default behavior would be a "merge", but this turned out to be incorrect. To rectify this, it is necessary to explicitly use the --merge tag. Doing so will prevent the function from inadvertently erasing any customized settings made from the dashboard.