### PR TITLE
Bump MSK Kafka version 2.7.0 → 3.7.x

### DIFF
--- a/terraform/physical/kafka.tf
+++ b/terraform/physical/kafka.tf
@@ -57,7 +57,7 @@ resource "aws_security_group_rule" "kafka_ingress_cidr_blocks" {
 resource "aws_msk_configuration" "this" {
   count = var.enable_webhooks ? 1 : 0
 
-  kafka_versions = ["2.7.0"]
+  kafka_versions = ["3.7.x"]
   name           = "${local.identifier}-kafka-config"
 
   server_properties = <<PROPERTIES
@@ -70,7 +70,7 @@ resource "aws_msk_cluster" "this" {
   count = var.enable_webhooks ? 1 : 0
 
   cluster_name           = "${local.identifier}-kafka"
-  kafka_version          = "2.7.0"
+  kafka_version          = "3.7.x"
   number_of_broker_nodes = var.azs_count
 
   broker_node_group_info {


### PR DESCRIPTION
## Summary
- AWS dropped support for Kafka 2.7.0 — new MSK cluster creation fails with `Unsupported KafkaVersion`
- Bump to 3.7.x (latest stable non-KRaft version)
- Existing clusters on 2.7.0 will need an in-place version upgrade applied separately

## Test plan
- [x] Deployed hooks stack on ddv-test (076248559428) — MSK cluster created successfully with 3.7.x
- [ ] Verify existing production MSK clusters can be upgraded in-place (separate operation)