### PR TITLE
Restore frontegg database creation job for webhooks environments

### DIFF
--- a/terraform/logical/README.md
+++ b/terraform/logical/README.md
@@ -39,13 +39,16 @@ No modules.
 | [kubernetes_cluster_role.dozuki_list_role](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/cluster_role) | resource |
 | [kubernetes_cluster_role_binding.dozuki_list_role_binding](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/cluster_role_binding) | resource |
 | [kubernetes_config_map.grafana_create_db_script](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/config_map) | resource |
+| [kubernetes_config_map_v1.frontegg_db_script](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/config_map_v1) | resource |
 | [kubernetes_job.dms_start](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/job) | resource |
 | [kubernetes_job.grafana_db_create](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/job) | resource |
+| [kubernetes_job_v1.frontegg_db_create](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/job_v1) | resource |
 | [kubernetes_namespace.app](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/namespace) | resource |
 | [kubernetes_namespace.cert_manager](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/namespace) | resource |
 | [kubernetes_role.dozuki_subsite_role](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/role) | resource |
 | [kubernetes_role_binding.dozuki_subsite_role_binding](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/role_binding) | resource |
 | [kubernetes_secret.dozuki_infra_credentials](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret) | resource |
+| [kubernetes_secret_v1.frontegg_db_credentials](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret_v1) | resource |
 | [random_password.grafana_admin](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_eks_cluster.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/eks_cluster) | data source |

--- a/terraform/logical/static/frontegg-db.sql
+++ b/terraform/logical/static/frontegg-db.sql
@@ -1,0 +1,1 @@
+create database if not exists frontegg_events; create database if not exists frontegg_webhooks;

--- a/terraform/logical/webhooks.tf
+++ b/terraform/logical/webhooks.tf
@@ -1,0 +1,99 @@
+resource "kubernetes_secret_v1" "frontegg_db_credentials" {
+  count = var.enable_webhooks ? 1 : 0
+
+  metadata {
+    name      = "frontegg-db-credentials"
+    namespace = kubernetes_namespace.app.metadata[0].name
+  }
+  type = "Opaque"
+
+  data = {
+    host     = local.db_master_host
+    username = local.db_master_username
+    password = local.db_master_password
+  }
+}
+
+resource "kubernetes_config_map_v1" "frontegg_db_script" {
+  count = var.enable_webhooks ? 1 : 0
+
+  metadata {
+    name      = "frontegg-db-script"
+    namespace = kubernetes_namespace.app.metadata[0].name
+  }
+
+  data = {
+    "frontegg-db.sql" = file("static/frontegg-db.sql")
+  }
+}
+
+resource "kubernetes_job_v1" "frontegg_db_create" {
+  count      = var.enable_webhooks ? 1 : 0
+  depends_on = [helm_release.app]
+
+  metadata {
+    name      = "frontegg-db-create"
+    namespace = kubernetes_namespace.app.metadata[0].name
+  }
+  spec {
+    template {
+      metadata {}
+      spec {
+        container {
+          name  = "frontegg-db-create"
+          image = "mysql:9.3"
+          env {
+            name = "MYSQL_HOST"
+            value_from {
+              secret_key_ref {
+                name = kubernetes_secret_v1.frontegg_db_credentials[0].metadata[0].name
+                key  = "host"
+              }
+            }
+          }
+          env {
+            name = "MYSQL_USER"
+            value_from {
+              secret_key_ref {
+                name = kubernetes_secret_v1.frontegg_db_credentials[0].metadata[0].name
+                key  = "username"
+              }
+            }
+          }
+          env {
+            name = "MYSQL_PWD"
+            value_from {
+              secret_key_ref {
+                name = kubernetes_secret_v1.frontegg_db_credentials[0].metadata[0].name
+                key  = "password"
+              }
+            }
+          }
+          command = [
+            "sh",
+            "-c",
+            "mysql --host=$MYSQL_HOST --user=$MYSQL_USER < /scripts/frontegg-db.sql"
+          ]
+          volume_mount {
+            name       = "scripts"
+            mount_path = "/scripts"
+            read_only  = true
+          }
+        }
+        volume {
+          name = "scripts"
+          config_map {
+            name = kubernetes_config_map_v1.frontegg_db_script[0].metadata[0].name
+          }
+        }
+        restart_policy = "Never"
+      }
+    }
+    backoff_limit = 10
+  }
+  wait_for_completion = true
+
+  timeouts {
+    create = "5m"
+  }
+}


### PR DESCRIPTION
## Summary
- Restore `frontegg_events` and `frontegg_webhooks` database creation job that was removed in fd5809a when frontegg was moved to KOTS
- The connectivity subchart services (event-service, webhook-service) require these databases to exist before they can start
- Job is gated on `enable_webhooks` and runs after the helm release is installed

## Changes since initial review
- **Replaced** `imega/mysql-client:10.6.4` with hardened MySQL image per review feedback
- **Improved** credential handling: DB host/user/password stored in a Kubernetes Secret and injected via `secretKeyRef` instead of inline CLI arguments
- **Updated** `kubernetes_config_map` to `kubernetes_config_map_v1`

## Test plan
- [x] Deployed to ddv-test hooks — job completed, both databases created
- [x] event-service and webhook-service started successfully after database creation
- [ ] Verify hardened MySQL image pulls successfully and mysql client works with Aurora