### PR TITLE
Add required image_tag/nextjs_tag to skeleton environment templates

### DIFF
--- a/live/.skel/environments/bi/env.hcl
+++ b/live/.skel/environments/bi/env.hcl
@@ -6,7 +6,6 @@ locals {
   enable_bi = true
   rds_multi_az = false
   highly_available_nat_gateway = false
-  dozuki_customer_id_parameter_name = "/dozuki/workstation/kots/default/customer_id"
   protect_resources = false
   bi_public_access = false
   bi_access_cidrs = ["0.0.0.0/0"]
@@ -14,4 +13,6 @@ locals {
   grafana_access_cidrs = ["0.0.0.0/0"]
   alarm_email = "ddv@dozuki.com"
   bi_dms_enabled = false //will still use DMS if public access is enabled regardless of this setting
+  image_tag   = "CHANGE_ME"
+  nextjs_tag  = "CHANGE_ME"
 }

--- a/live/.skel/environments/full/env.hcl
+++ b/live/.skel/environments/full/env.hcl
@@ -6,11 +6,12 @@ locals {
   enable_bi = true
   rds_multi_az = true
   highly_available_nat_gateway = false
-  dozuki_customer_id_parameter_name = "/dozuki/workstation/kots/webhooks/customer_id"
   protect_resources = false
   bi_public_access = false
   bi_access_cidrs = ["0.0.0.0/0"]
   bi_vpn_access = false
   grafana_access_cidrs = ["0.0.0.0/0"]
   alarm_email = "ddv@dozuki.com"
+  image_tag   = "CHANGE_ME"
+  nextjs_tag  = "CHANGE_ME"
 }

--- a/live/.skel/environments/hooks/env.hcl
+++ b/live/.skel/environments/hooks/env.hcl
@@ -6,7 +6,8 @@ locals {
   enable_bi = false
   rds_multi_az = false
   highly_available_nat_gateway = false
-  dozuki_customer_id_parameter_name = "/dozuki/workstation/kots/webhooks/customer_id"
   protect_resources = false
   alarm_email = "ddv@dozuki.com"
+  image_tag   = "CHANGE_ME"
+  nextjs_tag  = "CHANGE_ME"
 }

--- a/live/.skel/environments/min/env.hcl
+++ b/live/.skel/environments/min/env.hcl
@@ -6,7 +6,8 @@ locals {
   enable_bi = false
   rds_multi_az = false
   highly_available_nat_gateway = false
-  dozuki_customer_id_parameter_name = "/dozuki/workstation/kots/default/customer_id"
   protect_resources = false
   alarm_email = "ddv@dozuki.com"
+  image_tag   = "CHANGE_ME"
+  nextjs_tag  = "CHANGE_ME"
 }


### PR DESCRIPTION
## Summary
- Add `image_tag` and `nextjs_tag` required variables to all skeleton env.hcl templates (min, hooks, full, bi)
- Without these, new environment deployments fail at plan time since the logical module requires them (no defaults)
- Remove stale `dozuki_customer_id_parameter_name` (KOTS-era variable no longer referenced)

## Test plan
- [x] Verified new hooks environment deployed successfully with these variables set