### PR TITLE
Sync app-values.yaml with helm chart Bitnami removal

### DIFF
--- a/terraform/logical/static/app-values.yaml
+++ b/terraform/logical/static/app-values.yaml
@@ -927,17 +927,6 @@ ingress-nginx:
       worker-processes: "auto"
       custom-http-errors: "503"
 
-redis:
-  architecture: "standalone"
-  tls:
-    authClients: false
-  auth:
-    enabled: false
-
-mongodb:
-  auth:
-    enabled: false
-
 rustici:
   password: '${rustici_password}'
   managedPassword: '${rustici_managed_password}'
@@ -948,51 +937,6 @@ memcached:
   host: "${memcached_host}"
   # This enabled flag is for the local installation of memcache so true = install memcache on cluster (onprem)
   enabled: false
-
-  # Use a specific image if needed for air-gapped
-  image:
-    registry: docker.io
-    repository: bitnami/memcached
-    tag: 1.6.21-debian-11-r0
-    pullPolicy: IfNotPresent
-
-  # Minimal single node configuration
-  replicaCount: 1
-
-  # Architecture: standalone for single node
-  architecture: standalone
-
-  # Minimal resource allocation
-  resources:
-    limits:
-      memory: 64Mi
-      cpu: 50m
-    requests:
-      memory: 32Mi
-      cpu: 25m
-
-  # Service configuration
-  service:
-    type: ClusterIP
-    port: 11211
-
-  # Disable persistence for minimal setup
-  persistence:
-    enabled: false
-
-  # Minimal memory allocation for cache (in MB)
-  memcachedMaxMemory: 32
-
-  # Connection limit
-  memcachedConnLimit: 1024
-
-  # Disable metrics for minimal setup
-  metrics:
-    enabled: false
-
-  # Security - disable SASL for simplicity
-  auth:
-    enabled: false
 
 # OpenSearch configuration
 opensearch:
@@ -1010,7 +954,7 @@ opensearch:
   # Image configuration
   image:
     repository: "opensearchproject/opensearch"
-    tag: "2.18.0"
+    tag: "3.4.0"
     pullPolicy: "IfNotPresent"
 
   # Security disabled for dev - no auth required


### PR DESCRIPTION
## Summary
- Remove redis/mongodb value blocks from Terraform-templated app-values.yaml (replaced by inline templates in the helm chart)
- Trim memcached section to only `host` and `enabled` (Bitnami-specific fields removed)
- Update OpenSearch image tag 2.18.0 → 3.4.0

## Dependency
- **Must be deployed alongside** Dozuki/helm#23 (`upgrade-deps-replace-bitnami`) — the helm chart and app-values.yaml changes are paired

## Test plan
- [x] Deployed to ddv-test min and hooks — all pods healthy
- [x] OpenSearch 3.4.0 confirmed running