### PR TITLE
feat: enable EKS control-plane audit logging on customer env clusters

### DIFF
--- a/terraform/physical/eks.tf
+++ b/terraform/physical/eks.tf
@@ -214,6 +214,12 @@ module "eks_cluster" {
   endpoint_public_access  = true
   endpoint_private_access = true
 
+  # Control-plane log streaming to CloudWatch (audit, api, authenticator,
+  # controllerManager, scheduler). Required by SOC2 / Vanta and other
+  # compliance frameworks. Configurable via var.eks_enabled_log_types;
+  # default is all 5. Retention defaults to 90 days (module default).
+  enabled_log_types = var.eks_enabled_log_types
+
   encryption_config = {
     provider_key_arn = local.eks_kms_key
     resources        = ["secrets"]

--- a/terraform/physical/variables.tf
+++ b/terraform/physical/variables.tf
@@ -344,6 +344,12 @@ variable "eks_k8s_version" {
   default     = null
 }
 
+variable "eks_enabled_log_types" {
+  description = "EKS control-plane log types to stream to CloudWatch Logs. Defaults to all 5 (audit, api, authenticator, controllerManager, scheduler) for compliance (SOC2 / Vanta require audit logs at minimum). Set to [] to disable cluster logging entirely (not recommended)."
+  type        = list(string)
+  default     = ["api", "audit", "authenticator", "controllerManager", "scheduler"]
+}
+
 variable "enable_webhooks" {
   description = "This option will spin up a managed Kafka & Redis cluster to support private webhooks."
   type        = bool


### PR DESCRIPTION
## Summary

Adds \`eks_enabled_log_types\` variable to the physical layer (default: all 5 EKS control-plane log types) and wires it into the EKS module call. Streams \`api\`, \`audit\`, \`authenticator\`, \`controllerManager\`, \`scheduler\` to CloudWatch Logs with 90-day retention (module default).

## Why

Vanta + SOC2 + general compliance frameworks require audit logging on the EKS control plane. This is the customer-env-side counterpart to Dozuki/infra-tf#14 (which enables the same on the vault-cluster module).

Together, these two PRs ensure every EKS cluster Dozuki provisions (vault platform + ECP markets + MCP customers) emits audit logs by default.

## Compliance posture

Combined with the existing EKS Access Entries model (no anonymous access; all API ops require sigv4 IAM auth), the audit logs satisfy the standard compensating-controls argument for keeping the public endpoint reachable. The public endpoint exposure itself isn't a real security risk because there is no network-only attack surface — but auditors want forensic visibility into API access regardless.

## Customer impact

This is the default for all customer env physical applies going forward. Customers can opt out by setting \`eks_enabled_log_types = []\` in their env.hcl, though it's not recommended.

CloudWatch Logs cost is negligible at Dozuki's traffic volumes (a few dollars per cluster per month).

## Test plan

- [ ] Merge
- [ ] On the next customer env physical plan, confirm the diff shows \`enabled_log_types\` being set + a CloudWatch Log Group resource being created
- [ ] Confirm audit log events flow to the log group after apply