### PR TITLE
fix: set AWS_REGION on s3_replication_job_init local-exec

### DIFF
--- a/terraform/physical/s3.tf
+++ b/terraform/physical/s3.tf
@@ -299,6 +299,12 @@ resource "null_resource" "s3_replication_job_init" {
   }
 
   provisioner "local-exec" {
+    # Set AWS_REGION explicitly because Spacelift workers don't inherit
+    # a default region; without this the aws CLI calls inside the script
+    # fail with "An error occurred (NoRegion): You must specify a region."
+    environment = {
+      AWS_REGION = data.aws_region.current.id
+    }
     command = "/usr/bin/env bash ./util/create-s3-batch.sh ${self.triggers["logging_bucket"]} ${self.triggers["source_bucket"]} ${self.triggers["replication_role"]} ${self.triggers["aws_account"]} ${self.triggers["aws_partition"]} ${self.triggers["aws_profile"]}"
   }
 }


### PR DESCRIPTION
## Summary

Set `AWS_REGION` env var on the `null_resource.s3_replication_job_init` `local-exec` provisioner so the aws CLI calls inside `util/create-s3-batch.sh` can resolve a region.

## Why

When the physical layer runs in Spacelift (or any environment where the worker shell doesn't have `AWS_REGION` / `AWS_DEFAULT_REGION` set), the apply fails with:

```
null_resource.s3_replication_job_init["image"] (local-exec): aws: [ERROR]: An error occurred (NoRegion): You must specify a region. You can also configure your region by running "aws configure".
```

Hit during a customer environment bring-up that included the legacy-bucket migration step.

## Fix

Adds an `environment` block on the provisioner setting `AWS_REGION = data.aws_region.current.id`. The script doesn't need to change — its existing aws CLI invocations pick up the env var.

## Test plan

- [ ] Merge
- [ ] Re-trigger a customer physical stack that exercises the s3-batch path
- [ ] Confirm `s3_replication_job_init` resources apply successfully (4 of them, one per bucket type: doc, image, obj, pdf)