### PR TITLE
Fix CloudWatch alarms stuck in INSUFFICIENT_DATA

### DIFF
--- a/terraform/physical/README.md
+++ b/terraform/physical/README.md
@@ -61,6 +61,7 @@
 | [aws_dms_replication_instance.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dms_replication_instance) | resource |
 | [aws_dms_replication_subnet_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dms_replication_subnet_group) | resource |
 | [aws_dms_replication_task.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dms_replication_task) | resource |
+| [aws_eks_addon.cloudwatch_observability](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_addon) | resource |
 | [aws_eks_pod_identity_association.app_default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_pod_identity_association) | resource |
 | [aws_eks_pod_identity_association.app_migration_wait](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_pod_identity_association) | resource |
 | [aws_eks_pod_identity_association.cert_manager](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_pod_identity_association) | resource |
@@ -75,11 +76,14 @@
 | [aws_iam_policy.s3_replication](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_role.app_pod_identity](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.cert_manager_pod_identity](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role.cloudwatch_agent_pod_identity](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.lambda_execution](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.s3_replication](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy_attachment.app_pod_identity_worker](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.app_pod_identity_worker_kms](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.cert_manager_pod_identity](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.cloudwatch_agent_server](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.cloudwatch_agent_xray](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.lambda_basic_execution](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.lambda_iam_alias](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.s3_replication](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |

--- a/terraform/physical/eks.tf
+++ b/terraform/physical/eks.tf
@@ -346,3 +346,67 @@ resource "aws_eks_pod_identity_association" "cert_manager" {
   service_account = "cert-manager"
   role_arn        = aws_iam_role.cert_manager_pod_identity.arn
 }
+
+# Container Insights: CloudWatch agent (amazon-cloudwatch-observability addon).
+#
+# EKS Auto Mode gives nodes a deliberately minimal role (only EKS worker + ECR pull),
+# so the agent must get its CloudWatch permissions via Pod Identity. Without an
+# association the cloudwatch-agent SA falls back to the node role and every publish
+# (cloudwatch:PutMetricData, logs:PutLogEvents, xray:PutTraceSegments) is AccessDenied:
+# the ContainerInsights namespace stays empty and the node_* cluster alarms sit in
+# INSUFFICIENT_DATA. Both the metrics agent and fluent-bit run as the cloudwatch-agent
+# SA, so one association covers metrics and logs.
+resource "aws_iam_role" "cloudwatch_agent_pod_identity" {
+  name = "${local.identifier}-${data.aws_region.current.id}-cw-agent-pod-identity"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Service = "pods.eks.amazonaws.com"
+        }
+        Action = [
+          "sts:AssumeRole",
+          "sts:TagSession"
+        ]
+      }
+    ]
+  })
+
+  tags = local.tags
+}
+
+resource "aws_iam_role_policy_attachment" "cloudwatch_agent_server" {
+  role       = aws_iam_role.cloudwatch_agent_pod_identity.name
+  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/CloudWatchAgentServerPolicy"
+}
+
+# The agent's bundled OTel collector exports traces to X-Ray; without this the agent
+# logs a continuous stream of AccessDenied errors for xray:PutTraceSegments.
+resource "aws_iam_role_policy_attachment" "cloudwatch_agent_xray" {
+  role       = aws_iam_role.cloudwatch_agent_pod_identity.name
+  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/AWSXRayDaemonWriteAccess"
+}
+
+# Managed addon. The pod_identity_association wires the role to the cloudwatch-agent SA
+# in the amazon-cloudwatch namespace (EKS creates the association and annotates the SA).
+# addon_version is left unset so EKS selects the default compatible with the cluster's
+# Kubernetes version. OVERWRITE resolves field-level conflicts on managed resources;
+# it does NOT adopt a pre-existing addon — a cluster that already has this addon
+# installed out-of-band must have it removed (or imported) once before first apply.
+resource "aws_eks_addon" "cloudwatch_observability" {
+  cluster_name = module.eks_cluster.cluster_name
+  addon_name   = "amazon-cloudwatch-observability"
+
+  pod_identity_association {
+    role_arn        = aws_iam_role.cloudwatch_agent_pod_identity.arn
+    service_account = "cloudwatch-agent"
+  }
+
+  resolve_conflicts_on_create = "OVERWRITE"
+  resolve_conflicts_on_update = "OVERWRITE"
+
+  tags = local.tags
+}

--- a/terraform/physical/monitoring.tf
+++ b/terraform/physical/monitoring.tf
@@ -164,6 +164,13 @@ module "disk_alarm" {
   ]
 }
 
+# RDS alarm dimensions use local.identifier (the value passed to the rds module's
+# `identifier`), NOT module.primary_database.db_instance_id. The rds module is pinned
+# to v5.6.0, whose db_instance_id output returns aws_db_instance.this.id — and under
+# AWS provider v5+ that .id is the resource ID (db-XXXX), not the instance identifier.
+# CloudWatch's AWS/RDS namespace keys on the identifier, so the resource ID matches no
+# metric and every RDS alarm sits in INSUFFICIENT_DATA. local.identifier is correct by
+# construction and immune to provider/module-version drift.
 module "rds_cpu_alarm" {
   source  = "terraform-aws-modules/cloudwatch/aws//modules/metric-alarm"
   version = "~> 5.0"
@@ -181,7 +188,7 @@ module "rds_cpu_alarm" {
   period              = 300
 
   dimensions = {
-    DBInstanceIdentifier = module.primary_database.db_instance_id
+    DBInstanceIdentifier = local.identifier
   }
 
   alarm_actions = [
@@ -219,7 +226,7 @@ module "rds_free_memory_alarm" {
   statistic   = "Average"
 
   dimensions = {
-    DBInstanceIdentifier = module.primary_database.db_instance_id
+    DBInstanceIdentifier = local.identifier
   }
 
   tags = {
@@ -244,7 +251,7 @@ module "rds_swap_usage_alarm" {
   period              = "300"
 
   dimensions = {
-    DBInstanceIdentifier = module.primary_database.db_instance_id
+    DBInstanceIdentifier = local.identifier
   }
 
   alarm_actions = [
@@ -280,7 +287,7 @@ resource "aws_cloudwatch_metric_alarm" "rds_storage_space_alarm" {
       period      = "300"
       stat        = "Average"
       dimensions = {
-        DBInstanceIdentifier = module.primary_database.db_instance_id
+        DBInstanceIdentifier = local.identifier
       }
     }
   }
@@ -303,7 +310,7 @@ module "rds_connections_alarm" {
   period              = 60
 
   dimensions = {
-    DBInstanceIdentifier = module.primary_database.db_instance_id
+    DBInstanceIdentifier = local.identifier
   }
 
   alarm_actions = [
@@ -331,7 +338,7 @@ module "rds_read_latency_alarm" {
   statistic   = "Average"
 
   dimensions = {
-    DBInstanceIdentifier = module.primary_database.db_instance_id
+    DBInstanceIdentifier = local.identifier
   }
 
   alarm_actions = [module.sns.topic_arn]
@@ -354,7 +361,7 @@ module "rds_write_latency_alarm" {
   statistic   = "Average"
 
   dimensions = {
-    DBInstanceIdentifier = module.primary_database.db_instance_id
+    DBInstanceIdentifier = local.identifier
   }
 
   alarm_actions = [module.sns.topic_arn]


### PR DESCRIPTION
## Problem

Most CloudWatch alarms on a customer stack sit in **INSUFFICIENT_DATA** despite the instances running for weeks. Investigation found **two independent root causes**, both affecting any current/Auto Mode deploy (older stacks predate them and are fine).

### 1. RDS alarms — wrong metric dimension

All `AWS/RDS` alarms set `DBInstanceIdentifier = module.primary_database.db_instance_id`. A live check showed the dimension resolving to the RDS **resource ID** (`db-XXXXXXXX…`) instead of the instance identifier, while correctly-working stacks show the plain identifier.

The rds module is pinned to **v5.6.0**, whose `db_instance_id` output is `aws_db_instance.this.id`. Under **AWS provider v5+**, `aws_db_instance.id` returns the resource ID (`db-XXXX`), not the instance identifier. CloudWatch's `AWS/RDS` namespace keys on the identifier, so the dimension matches no published metric → every RDS alarm is stuck. Stacks applied under provider v4 (where `.id` was the identifier) are unaffected.

**Fix:** point all 7 RDS alarm dimensions at `local.identifier` — the value already passed to the module as `identifier =`, so it *is* the DB identifier by construction, and it's immune to provider/module-version drift. (Bumping the module isn't viable: latest needs Terraform ≥1.11.1 vs our Spacelift-pinned 1.5.7, and newer versions removed the `db_instance_id` output anyway.)

### 2. Container Insights alarms — agent can't authenticate

`*-cpu-high`, `*-memory-utilization`, `*-out-of-disk` read the `ContainerInsights` namespace, which has **0** metrics for the new cluster (a working cluster has hundreds). The `amazon-cloudwatch-observability` addon is installed and its pods run, but it has no `serviceAccountRoleArn`/pod-identity. EKS Auto Mode gives nodes a minimal role, so the agent falls back to it and every publish is denied:

```
AccessDeniedException: ...assumed-role/<cluster>-eks-auto-.../i-...
  is not authorized to perform: logs:PutLogEvents / xray:PutTraceSegments
```

The node role carries only `AmazonEKSWorkerNodeMinimalPolicy` + `AmazonEC2ContainerRegistryPullOnly`. Auto Mode intentionally keeps it minimal and expects workloads to get permissions via Pod Identity. The addon was also installed **out-of-band** (not in Terraform).

**Fix:** manage the addon in `eks.tf` with an IAM role (`CloudWatchAgentServerPolicy` + `AWSXRayDaemonWriteAccess`) bound to the `cloudwatch-agent` SA via `pod_identity_association`. Both the metrics agent and fluent-bit run as that SA, so one association covers metrics and logs.

## Changes
- `terraform/physical/monitoring.tf` — 7 RDS alarm dimensions → `local.identifier` (+ explanatory comment)
- `terraform/physical/eks.tf` — `amazon-cloudwatch-observability` addon + IAM role + pod-identity association
- `terraform/physical/README.md` — regenerated

## ⚠️ One-time step for any stack that already has the addon
A stack with the addon installed manually will hit `ResourceInUseException` on Terraform's `CreateAddon` at first apply. Before applying, remove the orphaned addon once so Terraform creates the managed one:

```
aws eks delete-addon --cluster-name <cluster> --addon-name amazon-cloudwatch-observability --region <region>
```

(Safe — the orphan publishes nothing today.) New stacks have no addon and apply cleanly. RDS alarm changes are dimension-only (no resource replacement).

## Validation
- `terraform fmt` clean; `terraform validate`/tflint pass (the only `validate` errors are a pre-existing unrelated `dns` aliased-provider/state artifact from validating outside the Terragrunt wrapper)
- Root causes confirmed live: RDS alarm dimension = resource ID; ContainerInsights namespace empty; agent logs show `AccessDenied` against the Auto Mode node role; node role lacks CloudWatch policies