### PR TITLE
Azure physical layer (Plan 1: contract + physical-azure)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 terraform.tfstate.d/
 **/.terragrunt*
 *.tfvars
+!terraform/physical-azure/examples/**/*.tfvars
 tfvars
 .idea
 *.iml

--- a/terraform/CONTRACT.md
+++ b/terraform/CONTRACT.md
@@ -18,17 +18,22 @@ config layer, not produced by the cloud layer.
 | `s3_documents_bucket` | Documents bucket | `documents_bucket` | `documents_bucket` |
 | `s3_kms_key_id` | Object-store KMS key | `s3_kms_key_id` | N/A — `""` (SeaweedFS volumes ride Azure Storage encryption at rest) |
 | `s3_replicate_buckets` | Migration-from-existing-buckets flag | `s3_replicate_buckets` | N/A — `false` |
-| `vpc_id` | Network ID | `vpc_id` | `vnet_id` |
-| `azs_count` | AZ count | `azs_count` | N/A — `3` (zonal layout is Azure-internal) |
+| `vpc_id` | Network ID † | `vpc_id` | `vnet_id` |
+| `azs_count` | AZ count † | `azs_count` | N/A — `3` (zonal layout is Azure-internal) |
 | `vault_address` | HashiCorp Vault address (secret backend) | `"http://" + vault_endpoint_dns + ":8200"` | N/A — Azure uses Key Vault via ESO (`key_vault_uri`) |
 | `msk_bootstrap_brokers` | Kafka brokers (webhooks) | `msk_bootstrap_brokers` | N/A — `""` (webhooks unsupported on Azure; `enable_webhooks = false`) |
 | `dms_task_arn` / `dms_enabled` | BI replication | `dms_task_arn` / `dms_enabled` | N/A — `""` / `false` (BI deferred past Azure v1) |
 | `bi_database_credential_secret` | BI DB secret | `bi_database_credential_secret` | N/A — `""` |
 | `nlb_https_target_group_arn` | LB binding (HTTPS) | `nlb_https_target_group_arn` | N/A — `""` (Azure: Envoy Gateway uses a `LoadBalancer` Service; Azure cloud controller provisions the LB) |
 | `nlb_http_target_group_arn` | LB binding (HTTP) | `nlb_http_target_group_arn` | N/A — `""` |
-| `eks_cluster_access_role_arn` | Cluster access IAM role | `eks_cluster_access_role_arn` | N/A — `""` (Azure auth is via `az aks get-credentials` / kubelogin) |
-| `cluster_primary_sg` | Cluster primary SG | `cluster_primary_sg` | N/A — `""` |
-| `private_subnet_ids` | Private subnets | `private_subnet_ids` | `aks_subnet_id` (single-element list semantics differ; logical does not consume this on Azure) |
+| `eks_cluster_access_role_arn` | Cluster access IAM role † | `eks_cluster_access_role_arn` | N/A — `""` (Azure auth is via `az aks get-credentials` / kubelogin) |
+| `cluster_primary_sg` | Cluster primary SG † | `cluster_primary_sg` | N/A — `""` |
+| `private_subnet_ids` | Private subnets † | `private_subnet_ids` | `aks_subnet_id` (single-element list semantics differ; logical does not consume this on Azure) |
+
+† Wired in `live/common.hcl` but not declared in `terraform/logical/variables.tf` —
+the logical layer does not consume these today (Terraform ignores undeclared
+`TF_VAR_*`). Azure config wiring may omit them; they are documented for parity
+with the AWS terragrunt wiring only.
 
 ## Azure-only outputs (consumed by logical when `cloud = "azure"`)
 

--- a/terraform/CONTRACT.md
+++ b/terraform/CONTRACT.md
@@ -1,0 +1,52 @@
+# Physical → Logical Contract
+
+The logical layer consumes physical-layer outputs. On AWS this wiring lives in
+`live/common.hcl` (terragrunt dependency block). On Azure it lives in the
+`cloudprem-azure-config` boilerplate. A physical layer for any cloud MUST
+provide the values below; "N/A" values are wired as literal constants in the
+config layer, not produced by the cloud layer.
+
+| Logical input | Meaning | AWS source (`terraform/physical` output) | Azure source (`terraform/physical-azure` output) |
+|---|---|---|---|
+| `eks_cluster_id` | K8s cluster name | `eks_cluster_id` | `cluster_name` |
+| `dns_domain_name` | App FQDN | `dns_domain_name` (Route53-managed) | `dns_domain_name` (passthrough of `external_fqdn`; customer-managed DNS) |
+| `primary_db_secret` | Locator of DB credentials secret | `primary_db_secret` (Secrets Manager ARN) | `db_credentials_secret_id` (Key Vault secret versionless ID) |
+| `memcached_cluster_address` | Cache endpoint | `memcached_cluster_address` (ElastiCache) | N/A — logical deploys in-cluster memcached when `cloud = "azure"` and uses its Service DNS name |
+| `s3_images_bucket` | Guide images bucket | `guide_images_bucket` (S3) | `guide_images_bucket` (SeaweedFS bucket name; created by logical) |
+| `s3_objects_bucket` | Guide objects bucket | `guide_objects_bucket` | `guide_objects_bucket` |
+| `s3_pdfs_bucket` | Guide PDFs bucket | `guide_pdfs_bucket` | `guide_pdfs_bucket` |
+| `s3_documents_bucket` | Documents bucket | `documents_bucket` | `documents_bucket` |
+| `s3_kms_key_id` | Object-store KMS key | `s3_kms_key_id` | N/A — `""` (SeaweedFS volumes ride Azure Storage encryption at rest) |
+| `s3_replicate_buckets` | Migration-from-existing-buckets flag | `s3_replicate_buckets` | N/A — `false` |
+| `vpc_id` | Network ID | `vpc_id` | `vnet_id` |
+| `azs_count` | AZ count | `azs_count` | N/A — `3` (zonal layout is Azure-internal) |
+| `vault_address` | HashiCorp Vault address (secret backend) | `"http://" + vault_endpoint_dns + ":8200"` | N/A — Azure uses Key Vault via ESO (`key_vault_uri`) |
+| `msk_bootstrap_brokers` | Kafka brokers (webhooks) | `msk_bootstrap_brokers` | N/A — `""` (webhooks unsupported on Azure; `enable_webhooks = false`) |
+| `dms_task_arn` / `dms_enabled` | BI replication | `dms_task_arn` / `dms_enabled` | N/A — `""` / `false` (BI deferred past Azure v1) |
+| `bi_database_credential_secret` | BI DB secret | `bi_database_credential_secret` | N/A — `""` |
+| `nlb_https_target_group_arn` | LB binding (HTTPS) | `nlb_https_target_group_arn` | N/A — `""` (Azure: Envoy Gateway uses a `LoadBalancer` Service; Azure cloud controller provisions the LB) |
+| `nlb_http_target_group_arn` | LB binding (HTTP) | `nlb_http_target_group_arn` | N/A — `""` |
+| `eks_cluster_access_role_arn` | Cluster access IAM role | `eks_cluster_access_role_arn` | N/A — `""` (Azure auth is via `az aks get-credentials` / kubelogin) |
+| `cluster_primary_sg` | Cluster primary SG | `cluster_primary_sg` | N/A — `""` |
+| `private_subnet_ids` | Private subnets | `private_subnet_ids` | `aks_subnet_id` (single-element list semantics differ; logical does not consume this on Azure) |
+
+## Azure-only outputs (consumed by logical when `cloud = "azure"`)
+
+| Output | Meaning |
+|---|---|
+| `resource_group_name` | Resource group containing all resources |
+| `location` | Azure region |
+| `tenant_id` | Entra tenant ID (ESO ClusterSecretStore config) |
+| `key_vault_uri` | Key Vault URI for ESO backend |
+| `key_vault_id` | Key Vault resource ID |
+| `eso_identity_client_id` | Client ID of the workload-identity UAI that ESO's service account annotates |
+| `cluster_oidc_issuer_url` | AKS OIDC issuer (federated credentials) |
+| `node_resource_group` | AKS-managed resource group (where the cloud controller puts LBs/disks) |
+| `db_host` | MySQL Flexible Server FQDN |
+
+## Secret shape
+
+`db_credentials_secret_id` / `primary_db_secret` must resolve to a JSON
+document with keys: `host`, `port`, `username`, `password`. (AWS: Secrets
+Manager secret created by `terraform/physical` rds.tf; Azure: Key Vault secret
+`database-credentials`.)

--- a/terraform/physical-azure/aks.tf
+++ b/terraform/physical-azure/aks.tf
@@ -1,0 +1,60 @@
+resource "azurerm_kubernetes_cluster" "this" {
+  name                = "${local.identifier}-aks"
+  location            = azurerm_resource_group.this.location
+  resource_group_name = azurerm_resource_group.this.name
+  dns_prefix          = local.identifier
+  kubernetes_version  = var.aks_kubernetes_version
+
+  sku_tier                  = "Standard"
+  automatic_upgrade_channel = "patch"
+
+  oidc_issuer_enabled       = true
+  workload_identity_enabled = true
+
+  default_node_pool {
+    name                 = "system"
+    vm_size              = var.aks_node_vm_size
+    auto_scaling_enabled = true
+    min_count            = var.aks_node_count_min
+    max_count            = var.aks_node_count_max
+    vnet_subnet_id       = azurerm_subnet.aks.id
+    tags                 = local.tags
+
+    upgrade_settings {
+      max_surge = "10%"
+    }
+  }
+
+  identity {
+    type = "SystemAssigned"
+  }
+
+  network_profile {
+    network_plugin      = "azure"
+    network_plugin_mode = "overlay"
+    pod_cidr            = "192.168.0.0/16"
+    service_cidr        = "172.16.0.0/16"
+    dns_service_ip      = "172.16.0.10"
+    load_balancer_sku   = "standard"
+    outbound_type       = "loadBalancer"
+  }
+
+  oms_agent {
+    log_analytics_workspace_id = azurerm_log_analytics_workspace.this.id
+  }
+
+  tags = local.tags
+
+  lifecycle {
+    ignore_changes = [kubernetes_version]
+  }
+}
+
+# Image pulls come from the customer's ACR (synced from GHCR at deploy time).
+resource "azurerm_role_assignment" "aks_acr_pull" {
+  count = var.acr_id != "" ? 1 : 0
+
+  scope                = var.acr_id
+  role_definition_name = "AcrPull"
+  principal_id         = azurerm_kubernetes_cluster.this.kubelet_identity[0].object_id
+}

--- a/terraform/physical-azure/aks.tf
+++ b/terraform/physical-azure/aks.tf
@@ -7,10 +7,33 @@ resource "azurerm_kubernetes_cluster" "this" {
 
   sku_tier                  = "Standard"
   automatic_upgrade_channel = "patch"
+  node_os_upgrade_channel   = "NodeImage"
 
   oidc_issuer_enabled       = true
   workload_identity_enabled = true
 
+  # Entra-integrated RBAC is opt-in: requires a customer-supplied admin group.
+  # Without it, operators use local accounts via az aks get-credentials.
+  local_account_disabled = length(var.aks_admin_group_object_ids) > 0
+
+  dynamic "azure_active_directory_role_based_access_control" {
+    for_each = length(var.aks_admin_group_object_ids) > 0 ? [1] : []
+
+    content {
+      azure_rbac_enabled     = true
+      admin_group_object_ids = var.aks_admin_group_object_ids
+    }
+  }
+
+  dynamic "api_server_access_profile" {
+    for_each = length(var.aks_api_allowed_cidrs) > 0 ? [1] : []
+
+    content {
+      authorized_ip_ranges = var.aks_api_allowed_cidrs
+    }
+  }
+
+  # Single shared pool for v1: no tainted system pool; "system" is just a name.
   default_node_pool {
     name                 = "system"
     vm_size              = var.aks_node_vm_size
@@ -32,6 +55,7 @@ resource "azurerm_kubernetes_cluster" "this" {
   network_profile {
     network_plugin      = "azure"
     network_plugin_mode = "overlay"
+    network_policy      = "azure"
     pod_cidr            = "192.168.0.0/16"
     service_cidr        = "172.16.0.0/16"
     dns_service_ip      = "172.16.0.10"
@@ -41,6 +65,25 @@ resource "azurerm_kubernetes_cluster" "this" {
 
   oms_agent {
     log_analytics_workspace_id = azurerm_log_analytics_workspace.this.id
+  }
+
+  # Bound auto-upgrade disruption to a window (single pool hosts everything).
+  maintenance_window_auto_upgrade {
+    frequency   = "Weekly"
+    interval    = 1
+    duration    = 4
+    day_of_week = "Sunday"
+    start_time  = "03:00"
+    utc_offset  = "+00:00"
+  }
+
+  maintenance_window_node_os {
+    frequency   = "Weekly"
+    interval    = 1
+    duration    = 4
+    day_of_week = "Sunday"
+    start_time  = "03:00"
+    utc_offset  = "+00:00"
   }
 
   tags = local.tags

--- a/terraform/physical-azure/examples/dev/dev.tfvars
+++ b/terraform/physical-azure/examples/dev/dev.tfvars
@@ -1,0 +1,16 @@
+# Dev/smoke-test values for Azure commercial cloud.
+# Usage (requires an Azure subscription + `az login`):
+#   terraform -chdir=terraform/physical-azure init -backend=false
+#   terraform -chdir=terraform/physical-azure plan -var-file=examples/dev/dev.tfvars -var subscription_id=$ARM_SUBSCRIPTION_ID
+
+azure_environment          = "public"
+location                   = "eastus2"
+customer                   = "azdev"
+environment                = "dev"
+protect_resources          = false
+external_fqdn              = "azdev.dozuki.com"
+alarm_email                = "devops@dozuki.com"
+mysql_high_availability    = false
+mysql_geo_redundant_backup = false
+aks_node_count_min         = 2
+aks_node_count_max         = 3

--- a/terraform/physical-azure/examples/dev/dev.tfvars
+++ b/terraform/physical-azure/examples/dev/dev.tfvars
@@ -2,14 +2,19 @@
 # Usage (requires an Azure subscription + `az login`):
 #   terraform -chdir=terraform/physical-azure init -backend=false
 #   terraform -chdir=terraform/physical-azure plan -var-file=examples/dev/dev.tfvars -var subscription_id=$ARM_SUBSCRIPTION_ID
+#
+# kv_allowed_cidrs is effectively REQUIRED for apply: the Key Vault firewall
+# denies by default, and seeding the database secret needs your egress IP
+# (e.g. `curl -s ifconfig.me`). Plan works without it; apply will not.
 
-azure_environment          = "public"
-location                   = "eastus2"
-customer                   = "azdev"
-environment                = "dev"
-protect_resources          = false
-external_fqdn              = "azdev.dozuki.com"
-alarm_email                = "devops@dozuki.com"
+azure_environment = "public"
+location          = "eastus2"
+customer          = "azdev"
+environment       = "dev"
+protect_resources = false
+external_fqdn     = "azdev.dozuki.com"
+alarm_email       = "devops@dozuki.com"
+# kv_allowed_cidrs   = ["203.0.113.4"] # your deployment egress IP — see header
 mysql_high_availability    = false
 mysql_geo_redundant_backup = false
 aks_node_count_min         = 2

--- a/terraform/physical-azure/identity.tf
+++ b/terraform/physical-azure/identity.tf
@@ -1,0 +1,21 @@
+resource "azurerm_user_assigned_identity" "eso" {
+  name                = "${local.identifier}-eso"
+  location            = azurerm_resource_group.this.location
+  resource_group_name = azurerm_resource_group.this.name
+  tags                = local.tags
+}
+
+resource "azurerm_federated_identity_credential" "eso" {
+  name                = "${local.identifier}-eso"
+  resource_group_name = azurerm_resource_group.this.name
+  parent_id           = azurerm_user_assigned_identity.eso.id
+  issuer              = azurerm_kubernetes_cluster.this.oidc_issuer_url
+  subject             = "system:serviceaccount:dozuki:dozuki-external-secrets"
+  audience            = ["api://AzureADTokenExchange"]
+}
+
+resource "azurerm_role_assignment" "eso_kv_secrets_user" {
+  scope                = azurerm_key_vault.this.id
+  role_definition_name = "Key Vault Secrets User"
+  principal_id         = azurerm_user_assigned_identity.eso.principal_id
+}

--- a/terraform/physical-azure/keyvault.tf
+++ b/terraform/physical-azure/keyvault.tf
@@ -1,0 +1,29 @@
+# Key Vault names: 3-24 chars, globally unique.
+# "kv-" + identifier_compact (max 15) + "-" + 4-char suffix = max 23.
+resource "azurerm_key_vault" "this" {
+  name                       = "kv-${local.identifier_compact}-${random_string.suffix.result}"
+  location                   = azurerm_resource_group.this.location
+  resource_group_name        = azurerm_resource_group.this.name
+  tenant_id                  = data.azurerm_client_config.current.tenant_id
+  sku_name                   = "standard"
+  rbac_authorization_enabled = true
+  purge_protection_enabled   = var.protect_resources
+  soft_delete_retention_days = 7
+  tags                       = local.tags
+}
+
+# The deploying principal manages secret content (e.g. seeding database-credentials).
+resource "azurerm_role_assignment" "deployer_kv_admin" {
+  scope                = azurerm_key_vault.this.id
+  role_definition_name = "Key Vault Administrator"
+  principal_id         = data.azurerm_client_config.current.object_id
+}
+
+resource "azurerm_management_lock" "key_vault" {
+  count = var.protect_resources ? 1 : 0
+
+  name       = "${local.identifier}-kv-lock"
+  scope      = azurerm_key_vault.this.id
+  lock_level = "CanNotDelete"
+  notes      = "protect_resources is enabled; remove this lock before destroying."
+}

--- a/terraform/physical-azure/keyvault.tf
+++ b/terraform/physical-azure/keyvault.tf
@@ -1,7 +1,7 @@
 # Key Vault names: 3-24 chars, globally unique.
 # "kv-" + identifier_compact (max 15) + "-" + 4-char suffix = max 23.
-# v1 intentionally leaves the vault endpoint publicly reachable: deploys are
-# operator-driven from outside the VNet and ESO reaches it from the cluster.
+# Deny-by-default firewall: in-cluster access (ESO) rides the AKS subnet's
+# Key Vault service endpoint; the deployer seeds secrets through kv_allowed_cidrs.
 # Follow-up: private endpoint + public_network_access_enabled = false.
 resource "azurerm_key_vault" "this" {
   name                       = "kv-${local.identifier_compact}-${random_string.suffix.result}"
@@ -12,7 +12,15 @@ resource "azurerm_key_vault" "this" {
   rbac_authorization_enabled = true
   purge_protection_enabled   = var.protect_resources
   soft_delete_retention_days = 30
-  tags                       = local.tags
+
+  network_acls {
+    default_action             = "Deny"
+    bypass                     = "AzureServices"
+    virtual_network_subnet_ids = [azurerm_subnet.aks.id]
+    ip_rules                   = var.kv_allowed_cidrs
+  }
+
+  tags = local.tags
 }
 
 # The deploying principal seeds and manages secret content (e.g. database-credentials).

--- a/terraform/physical-azure/keyvault.tf
+++ b/terraform/physical-azure/keyvault.tf
@@ -1,5 +1,8 @@
 # Key Vault names: 3-24 chars, globally unique.
 # "kv-" + identifier_compact (max 15) + "-" + 4-char suffix = max 23.
+# v1 intentionally leaves the vault endpoint publicly reachable: deploys are
+# operator-driven from outside the VNet and ESO reaches it from the cluster.
+# Follow-up: private endpoint + public_network_access_enabled = false.
 resource "azurerm_key_vault" "this" {
   name                       = "kv-${local.identifier_compact}-${random_string.suffix.result}"
   location                   = azurerm_resource_group.this.location
@@ -8,14 +11,14 @@ resource "azurerm_key_vault" "this" {
   sku_name                   = "standard"
   rbac_authorization_enabled = true
   purge_protection_enabled   = var.protect_resources
-  soft_delete_retention_days = 7
+  soft_delete_retention_days = 30
   tags                       = local.tags
 }
 
-# The deploying principal manages secret content (e.g. seeding database-credentials).
-resource "azurerm_role_assignment" "deployer_kv_admin" {
+# The deploying principal seeds and manages secret content (e.g. database-credentials).
+resource "azurerm_role_assignment" "deployer_kv_secrets" {
   scope                = azurerm_key_vault.this.id
-  role_definition_name = "Key Vault Administrator"
+  role_definition_name = "Key Vault Secrets Officer"
   principal_id         = data.azurerm_client_config.current.object_id
 }
 

--- a/terraform/physical-azure/keyvault.tf
+++ b/terraform/physical-azure/keyvault.tf
@@ -38,3 +38,11 @@ resource "azurerm_management_lock" "key_vault" {
   lock_level = "CanNotDelete"
   notes      = "protect_resources is enabled; remove this lock before destroying."
 }
+
+# Azure RBAC grants take time to propagate to the Key Vault data plane; without
+# this, the first secret write after vault creation often fails with 403.
+resource "time_sleep" "kv_rbac_propagation" {
+  create_duration = "60s"
+
+  depends_on = [azurerm_role_assignment.deployer_kv_secrets]
+}

--- a/terraform/physical-azure/main.tf
+++ b/terraform/physical-azure/main.tf
@@ -10,6 +10,10 @@ terraform {
       source  = "hashicorp/random"
       version = "~> 3.0"
     }
+    time = {
+      source  = "hashicorp/time"
+      version = "~> 0.13"
+    }
   }
 }
 

--- a/terraform/physical-azure/main.tf
+++ b/terraform/physical-azure/main.tf
@@ -1,0 +1,66 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 4.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.0"
+    }
+  }
+}
+
+provider "azurerm" {
+  subscription_id = var.subscription_id
+  environment     = var.azure_environment
+
+  features {
+    key_vault {
+      purge_soft_delete_on_destroy = !var.protect_resources
+    }
+  }
+}
+
+data "azurerm_client_config" "current" {}
+
+locals {
+  identifier         = var.customer != "" ? "${var.customer}-${var.environment}" : "dozuki-${var.environment}"
+  identifier_compact = replace(local.identifier, "-", "")
+
+  tags = {
+    Terraform   = "true"
+    Project     = "cloudprem"
+    Identifier  = local.identifier
+    Environment = var.environment
+  }
+
+  # Private DNS zone suffixes differ between Azure public and Azure Government.
+  mysql_private_dns_zone = var.azure_environment == "usgovernment" ? "privatelink.mysql.database.usgovcloudapi.net" : "privatelink.mysql.database.azure.com"
+}
+
+# Disambiguates globally-unique names (Key Vault, MySQL server FQDN).
+resource "random_string" "suffix" {
+  length  = 4
+  lower   = true
+  numeric = true
+  upper   = false
+  special = false
+}
+
+resource "azurerm_resource_group" "this" {
+  name     = "${local.identifier}-cloudprem"
+  location = var.location
+  tags     = local.tags
+}
+
+resource "azurerm_log_analytics_workspace" "this" {
+  name                = "${local.identifier}-logs"
+  location            = azurerm_resource_group.this.location
+  resource_group_name = azurerm_resource_group.this.name
+  sku                 = "PerGB2018"
+  retention_in_days   = 30
+  tags                = local.tags
+}

--- a/terraform/physical-azure/monitoring.tf
+++ b/terraform/physical-azure/monitoring.tf
@@ -65,6 +65,32 @@ resource "azurerm_monitor_metric_alert" "mysql_storage" {
   tags = local.tags
 }
 
+resource "azurerm_monitor_metric_alert" "mysql_memory" {
+  count = var.alarm_email != "" ? 1 : 0
+
+  name                = "${local.identifier}-mysql-memory"
+  resource_group_name = azurerm_resource_group.this.name
+  scopes              = [azurerm_mysql_flexible_server.this.id]
+  description         = "MySQL memory above 90% for 15 minutes."
+  severity            = 2
+  frequency           = "PT5M"
+  window_size         = "PT15M"
+
+  criteria {
+    metric_namespace = "Microsoft.DBforMySQL/flexibleServers"
+    metric_name      = "memory_percent"
+    aggregation      = "Average"
+    operator         = "GreaterThan"
+    threshold        = 90
+  }
+
+  action {
+    action_group_id = azurerm_monitor_action_group.alarms[0].id
+  }
+
+  tags = local.tags
+}
+
 resource "azurerm_monitor_metric_alert" "aks_node_cpu" {
   count = var.alarm_email != "" ? 1 : 0
 

--- a/terraform/physical-azure/monitoring.tf
+++ b/terraform/physical-azure/monitoring.tf
@@ -1,0 +1,92 @@
+resource "azurerm_monitor_action_group" "alarms" {
+  count = var.alarm_email != "" ? 1 : 0
+
+  name                = "${local.identifier}-alarms"
+  resource_group_name = azurerm_resource_group.this.name
+  short_name          = "cpalarms"
+
+  email_receiver {
+    name          = "ops"
+    email_address = var.alarm_email
+  }
+
+  tags = local.tags
+}
+
+resource "azurerm_monitor_metric_alert" "mysql_cpu" {
+  count = var.alarm_email != "" ? 1 : 0
+
+  name                = "${local.identifier}-mysql-cpu"
+  resource_group_name = azurerm_resource_group.this.name
+  scopes              = [azurerm_mysql_flexible_server.this.id]
+  description         = "MySQL CPU above 80% for 15 minutes."
+  severity            = 2
+  frequency           = "PT5M"
+  window_size         = "PT15M"
+
+  criteria {
+    metric_namespace = "Microsoft.DBforMySQL/flexibleServers"
+    metric_name      = "cpu_percent"
+    aggregation      = "Average"
+    operator         = "GreaterThan"
+    threshold        = 80
+  }
+
+  action {
+    action_group_id = azurerm_monitor_action_group.alarms[0].id
+  }
+
+  tags = local.tags
+}
+
+resource "azurerm_monitor_metric_alert" "mysql_storage" {
+  count = var.alarm_email != "" ? 1 : 0
+
+  name                = "${local.identifier}-mysql-storage"
+  resource_group_name = azurerm_resource_group.this.name
+  scopes              = [azurerm_mysql_flexible_server.this.id]
+  description         = "MySQL storage above 85%."
+  severity            = 1
+  frequency           = "PT5M"
+  window_size         = "PT15M"
+
+  criteria {
+    metric_namespace = "Microsoft.DBforMySQL/flexibleServers"
+    metric_name      = "storage_percent"
+    aggregation      = "Average"
+    operator         = "GreaterThan"
+    threshold        = 85
+  }
+
+  action {
+    action_group_id = azurerm_monitor_action_group.alarms[0].id
+  }
+
+  tags = local.tags
+}
+
+resource "azurerm_monitor_metric_alert" "aks_node_cpu" {
+  count = var.alarm_email != "" ? 1 : 0
+
+  name                = "${local.identifier}-aks-node-cpu"
+  resource_group_name = azurerm_resource_group.this.name
+  scopes              = [azurerm_kubernetes_cluster.this.id]
+  description         = "AKS node CPU above 90% for 15 minutes."
+  severity            = 2
+  frequency           = "PT5M"
+  window_size         = "PT15M"
+
+  criteria {
+    metric_namespace = "Microsoft.ContainerService/managedClusters"
+    metric_name      = "node_cpu_usage_percentage"
+    aggregation      = "Average"
+    operator         = "GreaterThan"
+    threshold        = 90
+  }
+
+  action {
+    action_group_id = azurerm_monitor_action_group.alarms[0].id
+  }
+
+  tags = local.tags
+}

--- a/terraform/physical-azure/mysql.tf
+++ b/terraform/physical-azure/mysql.tf
@@ -13,20 +13,22 @@ resource "azurerm_mysql_flexible_server" "this" {
 
   version  = var.mysql_version
   sku_name = var.mysql_sku_name
-  zone     = "1"
+  zone     = var.mysql_zone
 
   delegated_subnet_id = azurerm_subnet.mysql.id
   private_dns_zone_id = azurerm_private_dns_zone.mysql.id
 
-  backup_retention_days        = 14
-  geo_redundant_backup_enabled = var.protect_resources
+  backup_retention_days        = var.mysql_backup_retention_days
+  geo_redundant_backup_enabled = var.mysql_geo_redundant_backup
 
+  # ZoneRedundant HA requires a region with availability zones; in zone-less
+  # regions set mysql_high_availability = false.
   dynamic "high_availability" {
     for_each = var.mysql_high_availability ? [1] : []
 
     content {
       mode                      = "ZoneRedundant"
-      standby_availability_zone = "2"
+      standby_availability_zone = var.mysql_standby_zone
     }
   }
 

--- a/terraform/physical-azure/mysql.tf
+++ b/terraform/physical-azure/mysql.tf
@@ -1,0 +1,74 @@
+resource "random_password" "database" {
+  length  = 32
+  special = false
+}
+
+resource "azurerm_mysql_flexible_server" "this" {
+  name                = "${local.identifier}-mysql-${random_string.suffix.result}"
+  location            = azurerm_resource_group.this.location
+  resource_group_name = azurerm_resource_group.this.name
+
+  administrator_login    = "dozuki"
+  administrator_password = random_password.database.result
+
+  version  = var.mysql_version
+  sku_name = var.mysql_sku_name
+  zone     = "1"
+
+  delegated_subnet_id = azurerm_subnet.mysql.id
+  private_dns_zone_id = azurerm_private_dns_zone.mysql.id
+
+  backup_retention_days        = 14
+  geo_redundant_backup_enabled = var.protect_resources
+
+  dynamic "high_availability" {
+    for_each = var.mysql_high_availability ? [1] : []
+
+    content {
+      mode                      = "ZoneRedundant"
+      standby_availability_zone = "2"
+    }
+  }
+
+  storage {
+    size_gb           = var.mysql_storage_gb
+    auto_grow_enabled = true
+  }
+
+  tags = local.tags
+
+  depends_on = [azurerm_private_dns_zone_virtual_network_link.mysql]
+}
+
+# Azure defaults this ON; the app connects without TLS today (parity with RDS).
+resource "azurerm_mysql_flexible_server_configuration" "require_secure_transport" {
+  name                = "require_secure_transport"
+  resource_group_name = azurerm_resource_group.this.name
+  server_name         = azurerm_mysql_flexible_server.this.name
+  value               = "OFF"
+}
+
+resource "azurerm_management_lock" "mysql" {
+  count = var.protect_resources ? 1 : 0
+
+  name       = "${local.identifier}-mysql-lock"
+  scope      = azurerm_mysql_flexible_server.this.id
+  lock_level = "CanNotDelete"
+  notes      = "protect_resources is enabled; remove this lock before destroying."
+}
+
+# Same JSON shape as the AWS Secrets Manager secret (see terraform/CONTRACT.md).
+resource "azurerm_key_vault_secret" "database_credentials" {
+  name         = "database-credentials"
+  key_vault_id = azurerm_key_vault.this.id
+  content_type = "application/json"
+
+  value = jsonencode({
+    host     = azurerm_mysql_flexible_server.this.fqdn
+    port     = 3306
+    username = azurerm_mysql_flexible_server.this.administrator_login
+    password = random_password.database.result
+  })
+
+  depends_on = [time_sleep.kv_rbac_propagation]
+}

--- a/terraform/physical-azure/outputs.tf
+++ b/terraform/physical-azure/outputs.tf
@@ -1,0 +1,89 @@
+output "cluster_name" {
+  description = "AKS cluster name."
+  value       = azurerm_kubernetes_cluster.this.name
+}
+
+output "cluster_oidc_issuer_url" {
+  description = "OIDC issuer URL for workload-identity federation."
+  value       = azurerm_kubernetes_cluster.this.oidc_issuer_url
+}
+
+output "node_resource_group" {
+  description = "AKS-managed resource group (cloud controller places LBs and disks here)."
+  value       = azurerm_kubernetes_cluster.this.node_resource_group
+}
+
+output "resource_group_name" {
+  description = "Resource group containing all CloudPrem resources."
+  value       = azurerm_resource_group.this.name
+}
+
+output "location" {
+  description = "Azure region."
+  value       = azurerm_resource_group.this.location
+}
+
+output "tenant_id" {
+  description = "Entra tenant ID."
+  value       = data.azurerm_client_config.current.tenant_id
+}
+
+output "vnet_id" {
+  description = "VNet resource ID."
+  value       = azurerm_virtual_network.this.id
+}
+
+output "aks_subnet_id" {
+  description = "Subnet hosting AKS nodes."
+  value       = azurerm_subnet.aks.id
+}
+
+output "dns_domain_name" {
+  description = "FQDN the application is served on (customer-managed DNS)."
+  value       = var.external_fqdn
+}
+
+output "db_host" {
+  description = "MySQL Flexible Server FQDN."
+  value       = azurerm_mysql_flexible_server.this.fqdn
+}
+
+output "db_credentials_secret_id" {
+  description = "Key Vault secret (versionless ID) holding database credentials JSON."
+  value       = azurerm_key_vault_secret.database_credentials.versionless_id
+}
+
+output "key_vault_uri" {
+  description = "Key Vault URI for the ESO ClusterSecretStore."
+  value       = azurerm_key_vault.this.vault_uri
+}
+
+output "key_vault_id" {
+  description = "Key Vault resource ID."
+  value       = azurerm_key_vault.this.id
+}
+
+output "eso_identity_client_id" {
+  description = "Client ID of the external-secrets workload identity."
+  value       = azurerm_user_assigned_identity.eso.client_id
+}
+
+output "guide_images_bucket" {
+  description = "SeaweedFS bucket name for guide images (created in-cluster by the logical layer)."
+  value       = "${local.identifier}-guide-images"
+}
+
+output "guide_objects_bucket" {
+  description = "SeaweedFS bucket name for guide objects."
+  value       = "${local.identifier}-guide-objects"
+}
+
+output "guide_pdfs_bucket" {
+  description = "SeaweedFS bucket name for guide PDFs."
+  value       = "${local.identifier}-guide-pdfs"
+}
+
+output "documents_bucket" {
+  description = "SeaweedFS bucket name for documents."
+  value       = "${local.identifier}-documents"
+}

--- a/terraform/physical-azure/variables.tf
+++ b/terraform/physical-azure/variables.tf
@@ -1,0 +1,119 @@
+variable "subscription_id" {
+  description = "Azure subscription ID to deploy into."
+  type        = string
+}
+
+variable "azure_environment" {
+  description = "Azure cloud environment: public or usgovernment."
+  type        = string
+  default     = "public"
+
+  validation {
+    condition     = contains(["public", "usgovernment"], var.azure_environment)
+    error_message = "azure_environment must be public or usgovernment."
+  }
+}
+
+variable "location" {
+  description = "Azure region (e.g. eastus2, usgovvirginia)."
+  type        = string
+}
+
+variable "customer" {
+  description = "Customer name, used in resource naming and tagging."
+  type        = string
+  default     = ""
+
+  validation {
+    condition     = var.customer == "" || can(regex("^[a-z0-9][a-z0-9-]{0,8}[a-z0-9]$", var.customer))
+    error_message = "customer must be 1-10 characters, lowercase alphanumeric or hyphens, starting and ending with an alphanumeric character."
+  }
+}
+
+variable "environment" {
+  description = "Environment of the application."
+  type        = string
+  default     = "dev"
+
+  validation {
+    condition     = length(var.environment) <= 5
+    error_message = "environment must be 5 characters or fewer."
+  }
+}
+
+variable "protect_resources" {
+  description = "Enables deletion protection: management locks on the database and Key Vault purge protection."
+  type        = bool
+  default     = true
+}
+
+variable "external_fqdn" {
+  description = "FQDN the application is served on. DNS is customer-managed on Azure; this value is passed through to the logical layer."
+  type        = string
+}
+
+variable "vnet_cidr" {
+  description = "Address space for the VNet."
+  type        = string
+  default     = "10.10.0.0/16"
+}
+
+variable "acr_id" {
+  description = "Resource ID of the customer's Azure Container Registry. When set, the AKS kubelet identity is granted AcrPull on it."
+  type        = string
+  default     = ""
+}
+
+variable "alarm_email" {
+  description = "Email address for metric alert notifications. Empty disables alerting."
+  type        = string
+  default     = ""
+}
+
+variable "aks_kubernetes_version" {
+  description = "Kubernetes version for AKS. Null tracks the AKS default."
+  type        = string
+  default     = null
+}
+
+variable "aks_node_vm_size" {
+  description = "VM size for the AKS node pool."
+  type        = string
+  default     = "Standard_D4s_v5"
+}
+
+variable "aks_node_count_min" {
+  description = "Minimum node count for the autoscaling node pool."
+  type        = number
+  default     = 2
+}
+
+variable "aks_node_count_max" {
+  description = "Maximum node count for the autoscaling node pool."
+  type        = number
+  default     = 6
+}
+
+variable "mysql_sku_name" {
+  description = "Azure Database for MySQL Flexible Server SKU."
+  type        = string
+  default     = "GP_Standard_D2ds_v4"
+}
+
+variable "mysql_version" {
+  description = "MySQL engine version."
+  type        = string
+  default     = "8.0.21"
+}
+
+variable "mysql_storage_gb" {
+  description = "Storage size in GB for MySQL."
+  type        = number
+  default     = 100
+}
+
+variable "mysql_high_availability" {
+  description = "Enable zone-redundant high availability for MySQL."
+  type        = bool
+  default     = true
+}

--- a/terraform/physical-azure/variables.tf
+++ b/terraform/physical-azure/variables.tf
@@ -117,3 +117,9 @@ variable "mysql_high_availability" {
   type        = bool
   default     = true
 }
+
+variable "kv_allowed_cidrs" {
+  description = "Public egress IPs/CIDRs of the deployment workstation or VM, allowed through the Key Vault firewall to seed secrets. Use bare IPs for single addresses (Azure rejects /32). Required at apply time."
+  type        = list(string)
+  default     = []
+}

--- a/terraform/physical-azure/variables.tf
+++ b/terraform/physical-azure/variables.tf
@@ -123,3 +123,32 @@ variable "kv_allowed_cidrs" {
   type        = list(string)
   default     = []
 }
+
+variable "mysql_zone" {
+  description = "Availability zone for the MySQL primary. Null lets Azure choose; required null in regions without availability zones."
+  type        = string
+  default     = null
+}
+
+variable "mysql_standby_zone" {
+  description = "Availability zone for the MySQL HA standby. Null lets Azure choose. Only used when mysql_high_availability is true."
+  type        = string
+  default     = null
+}
+
+variable "mysql_backup_retention_days" {
+  description = "Backup retention in days for MySQL."
+  type        = number
+  default     = 14
+
+  validation {
+    condition     = var.mysql_backup_retention_days >= 1 && var.mysql_backup_retention_days <= 35
+    error_message = "mysql_backup_retention_days must be between 1 and 35."
+  }
+}
+
+variable "mysql_geo_redundant_backup" {
+  description = "Geo-redundant backups for MySQL. Immutable after server creation: changing it forces a destroy/recreate of the database server."
+  type        = bool
+  default     = true
+}

--- a/terraform/physical-azure/variables.tf
+++ b/terraform/physical-azure/variables.tf
@@ -152,3 +152,15 @@ variable "mysql_geo_redundant_backup" {
   type        = bool
   default     = true
 }
+
+variable "aks_api_allowed_cidrs" {
+  description = "Public IPs/CIDRs allowed to reach the AKS API server. Empty leaves the endpoint open (v1 default); the bootstrap passes the operator's egress IP."
+  type        = list(string)
+  default     = []
+}
+
+variable "aks_admin_group_object_ids" {
+  description = "Entra ID group object IDs granted cluster-admin via Azure RBAC. When set, local cluster accounts are disabled and kubectl requires kubelogin (az aks get-credentials without --admin)."
+  type        = list(string)
+  default     = []
+}

--- a/terraform/physical-azure/vnet.tf
+++ b/terraform/physical-azure/vnet.tf
@@ -12,6 +12,8 @@ resource "azurerm_subnet" "aks" {
   resource_group_name  = azurerm_resource_group.this.name
   virtual_network_name = azurerm_virtual_network.this.name
   address_prefixes     = [cidrsubnet(var.vnet_cidr, 4, 0)] # e.g. 10.10.0.0/20
+
+  service_endpoints = ["Microsoft.KeyVault"]
 }
 
 # MySQL Flexible Server requires a delegated subnet.

--- a/terraform/physical-azure/vnet.tf
+++ b/terraform/physical-azure/vnet.tf
@@ -1,0 +1,45 @@
+resource "azurerm_virtual_network" "this" {
+  name                = "${local.identifier}-vnet"
+  location            = azurerm_resource_group.this.location
+  resource_group_name = azurerm_resource_group.this.name
+  address_space       = [var.vnet_cidr]
+  tags                = local.tags
+}
+
+# Node subnet. Pods use the CNI overlay CIDR, not this subnet.
+resource "azurerm_subnet" "aks" {
+  name                 = "${local.identifier}-aks"
+  resource_group_name  = azurerm_resource_group.this.name
+  virtual_network_name = azurerm_virtual_network.this.name
+  address_prefixes     = [cidrsubnet(var.vnet_cidr, 4, 0)] # e.g. 10.10.0.0/20
+}
+
+# MySQL Flexible Server requires a delegated subnet.
+resource "azurerm_subnet" "mysql" {
+  name                 = "${local.identifier}-mysql"
+  resource_group_name  = azurerm_resource_group.this.name
+  virtual_network_name = azurerm_virtual_network.this.name
+  address_prefixes     = [cidrsubnet(var.vnet_cidr, 8, 16)] # e.g. 10.10.16.0/24
+
+  delegation {
+    name = "mysql-flexible-server"
+
+    service_delegation {
+      name    = "Microsoft.DBforMySQL/flexibleServers"
+      actions = ["Microsoft.Network/virtualNetworks/subnets/join/action"]
+    }
+  }
+}
+
+resource "azurerm_private_dns_zone" "mysql" {
+  name                = local.mysql_private_dns_zone
+  resource_group_name = azurerm_resource_group.this.name
+  tags                = local.tags
+}
+
+resource "azurerm_private_dns_zone_virtual_network_link" "mysql" {
+  name                  = "${local.identifier}-mysql"
+  resource_group_name   = azurerm_resource_group.this.name
+  private_dns_zone_name = azurerm_private_dns_zone.mysql.name
+  virtual_network_id    = azurerm_virtual_network.this.id
+}


### PR DESCRIPTION
## Summary
- Formalizes the physical->logical output contract (`terraform/CONTRACT.md`)
- Adds `terraform/physical-azure`: AKS (workload identity, opt-in Entra RBAC, network policy, maintenance windows), MySQL Flexible Server (optional zone-redundant HA, configurable zones/retention, management locks), Key Vault (RBAC, deny-by-default firewall, ESO workload-identity federation), VNet, Azure Monitor alerts (MySQL cpu/storage/memory, AKS node cpu)
- Security review items addressed during implementation: KV network ACLs + deployer allowlist, opt-in AAD RBAC with local-account disable, immutable-at-creation network_policy set now, RBAC-propagation guard before secret seeding
- Validated offline (`terraform validate`, fmt, tflint via pre-commit); smoke plan pending an Azure subscription (none exists yet)

## Security posture notes (deliberate v1 trade-offs)
- AKS API server is public unless `aks_api_allowed_cidrs` is set, and local cluster accounts remain enabled unless `aks_admin_group_object_ids` is supplied (Entra RBAC is opt-in because admin group IDs are customer-tenant values). The deploy bootstrap (Plan 3) passes the operator egress IP for both allowlists.
- MySQL `require_secure_transport = OFF` is an explicit app-parity decision; traffic is confined to the VNet via the delegated subnet. Revisit when the app config supports TLS with the Azure CA bundle.
- Key Vault keeps `bypass = AzureServices` plus deny-by-default ACLs; private endpoint + `public_network_access_enabled = false` is the tracked follow-up.

## Not yet wired end-to-end (by design)
This physical layer cannot drive the current `terraform/logical` yet: the cloud switch, in-cluster memcached/SeaweedFS, and the six N/A-on-Azure constant passthroughs (`memcached_cluster_address`, `msk_bootstrap_brokers`, `dms_task_arn`, `vault_address`, `nlb_*_target_group_arn`) land in Plan 2. Merge-ready in isolation per `terraform/CONTRACT.md`.

## First-apply note
`kv_allowed_cidrs` is effectively required at apply time (deny-by-default Key Vault firewall); the dev example documents this.
