### PR TITLE
Use HTTPS URL for the chart submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "terraform/logical/charts/dozuki"]
 	path = terraform/logical/charts/dozuki
-	url = git@github.com:Dozuki/helm.git
+	url = https://github.com/Dozuki/helm.git


### PR DESCRIPTION
Switches the chart submodule from `git@github.com:` to `https://` so token-based consumers (cost estimation tooling, CI) can authenticate it with standard git credentials — their sandboxes cannot run ssh.

SSH-key consumers are unaffected when paired with a scoped rewrite (`git config url.git@github.com:Dozuki/helm.git.insteadOf https://github.com/Dozuki/helm.git`) — the deploy pipeline change adding exactly that is queued to merge first.

Note: existing local checkouts need `git submodule sync` after pulling. A follow-up PR will apply the same change to `master`.