### PR TITLE
Use HTTPS URL for the chart submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "terraform/logical/charts/dozuki"]
 	path = terraform/logical/charts/dozuki
-	url = git@github.com:Dozuki/helm.git
+	url = https://github.com/Dozuki/helm.git


### PR DESCRIPTION
Same change as #142 (already on the deploy integration branch), applied to master: the chart submodule moves from `git@github.com:` to `https://` so token-based consumers (cost estimation tooling, CI sandboxes without ssh) can authenticate with standard git credentials. SSH-key consumers keep working via a scoped `git config url.<ssh>.insteadOf <https>` rewrite. Existing local checkouts need a one-time `git submodule sync` after pulling.