### PR TITLE
fix(ci): repair Infracost config (drop removed terraform_binary field, repoint stale path)

### DIFF
--- a/infracost.yml
+++ b/infracost.yml
@@ -1,5 +1,10 @@
 version: 0.1
 
 projects:
-  - path: live/development
-    terraform_binary: terragrunt
+  # Representative Dozuki reference environment (all features enabled).
+  # Infracost auto-detects the Terragrunt physical/ and logical/ projects
+  # under this path; no terraform_binary field is needed (it was removed
+  # from the Infracost config schema).
+  - path: live/standard/us-east-1/full
+    name: standard-us-east-1-full
+    usage_file: infracost-usage.yml


### PR DESCRIPTION
## Problem

The **Infracost** check has been concluding as `skipped` on every PR (including the recent #146) with:

```
Invalid config YAML
Error loading config file: invalid config YAML: ... line 5: field terraform_binary not found
```

Two issues, both dating to the original 2021 `infracost.yml`:

1. **`terraform_binary` was removed from the Infracost config schema.** Infracost auto-detects Terragrunt from the project path, so the field is no longer valid and the loader rejects the whole file.
2. **`path: live/development` no longer exists** — the `live/` tree was restructured into `live/standard/<region>/<env>/{physical,logical}`, so even with the field removed the path would fail.

## Fix

```yaml
projects:
  - path: live/standard/us-east-1/full
    name: standard-us-east-1-full
    usage_file: infracost-usage.yml
```

- Drops the obsolete `terraform_binary` field.
- Repoints at `live/standard/us-east-1/full` — a Dozuki reference environment with all features enabled. Infracost auto-detects both the `physical/` and `logical/` Terragrunt projects under it.
- Wires in `infracost-usage.yml`, which the old config never actually referenced.

Validated: YAML parses, no invalid fields, path and usage file both resolve.

## Notes / follow-ups

- `infracost-usage.yml` still has **pre-modernization resource addresses** (old EKS node-group / bastion / docdb module names from before the Auto Mode rewrite). These are harmless — Infracost ignores unmatched usage entries — but the file could be regenerated in a follow-up so the usage-based estimates are accurate again.
- This makes the config **valid** so the check stops skipping. If the Infracost Cloud runner lacks the Terragrunt/AWS access to fully evaluate these envs at runtime, that's a separate concern from the config-load error fixed here.
- Independent of #146 (Release v6.1); can merge in either order.
