### PR TITLE
feat(physical): Aurora Serverless v2 path behind db_engine toggle (Plan A)

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -11,8 +11,16 @@ jobs:
     name: 'Terraform'
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        module: [physical, logical]
+        include:
+          # The physical layer uses the rds-aurora module (master_password_wo),
+          # which requires Terraform/OpenTofu >= 1.11.1 — run it on OpenTofu 1.12.x.
+          - module: physical
+            tool: tofu
+          # The logical layer stays on the Spacelift-pinned Terraform 1.5.7 toolchain.
+          - module: logical
+            tool: terraform
 
     # Use the Bash shell regardless whether the GitHub Actions runner is ubuntu-latest, macos-latest, or windows-latest
     defaults:
@@ -24,18 +32,25 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v4
 
+    - name: Setup OpenTofu
+      if: matrix.tool == 'tofu'
+      uses: opentofu/setup-opentofu@v1
+      with:
+        tofu_version: "1.12.2"
+
     - name: Setup Terraform
+      if: matrix.tool == 'terraform'
       uses: hashicorp/setup-terraform@v3
       with:
         terraform_version: 1.5.7
 
-    - name: Terraform ${{ matrix.module }} Module Init
-      run: terraform init
+    - name: ${{ matrix.module }} Module Init
+      run: ${{ matrix.tool }} init
       working-directory: ./terraform/${{ matrix.module }}
 
-    # Checks that all Terraform configuration files adhere to a canonical format
-    - name: Terraform Format Check
-      run: terraform fmt -check
+    # Checks that all configuration files adhere to a canonical format
+    - name: Format Check
+      run: ${{ matrix.tool }} fmt -check
       working-directory: ./terraform/${{ matrix.module }}
 
     # Performs linting on the Terraform files
@@ -52,4 +67,3 @@ jobs:
     # tfsec removed — deprecated in favor of Trivy. The reviewdog/action-tfsec
     # action crashes on tfsec v1.28.0 output parsing. Migrate to Trivy in a
     # follow-up PR if static security scanning is needed in CI.
-

--- a/terraform/physical/aurora.tf
+++ b/terraform/physical/aurora.tf
@@ -1,0 +1,69 @@
+# Aurora MySQL 8.4 Serverless v2 cluster (active when var.db_engine == "aurora").
+# Produces the same connection facts as the RDS path via local.db (db.tf).
+
+resource "random_password" "aurora" {
+  count   = local.db_is_aurora ? 1 : 0
+  length  = 40
+  special = false
+}
+
+module "aurora" {
+  source  = "terraform-aws-modules/rds-aurora/aws"
+  version = "10.2.0"
+
+  count = local.db_is_aurora ? 1 : 0
+
+  name            = local.identifier
+  engine          = "aurora-mysql"
+  engine_mode     = "provisioned"
+  engine_version  = var.aurora_engine_version
+  master_username = local.db_username
+
+  manage_master_user_password = false
+  master_password_wo          = random_password.aurora[0].result
+  master_password_wo_version  = 1
+
+  serverlessv2_scaling_configuration = {
+    min_capacity = var.aurora_min_acu
+    max_capacity = var.aurora_max_acu
+  }
+  instances = merge(
+    { writer = { instance_class = "db.serverless", performance_insights_enabled = true } },
+    var.rds_multi_az ? { reader = { instance_class = "db.serverless", performance_insights_enabled = true } } : {}
+  )
+
+  vpc_security_group_ids = [module.primary_database_sg.security_group_id]
+  subnets                = local.private_subnet_ids
+  create_db_subnet_group = true
+
+  storage_encrypted = true
+  kms_key_id        = local.rds_kms_key_arn
+
+  snapshot_identifier = var.aurora_snapshot_identifier != "" ? var.aurora_snapshot_identifier : null
+
+  cluster_parameter_group = {
+    family = "aurora-mysql8.4"
+    parameters = [
+      { name = "binlog_format", value = "ROW", apply_method = "pending-reboot" },
+      { name = "binlog_row_image", value = "full", apply_method = "pending-reboot" },
+      { name = "binlog_checksum", value = "NONE", apply_method = "pending-reboot" },
+    ]
+  }
+
+  db_parameter_group = {
+    family = "aurora-mysql8.4"
+    parameters = [
+      { name = "group_concat_max_len", value = "33554432", apply_method = "pending-reboot" },
+    ]
+  }
+
+  apply_immediately            = !var.protect_resources
+  deletion_protection          = var.protect_resources
+  skip_final_snapshot          = !var.protect_resources
+  copy_tags_to_snapshot        = true
+  backup_retention_period      = var.rds_backup_retention_period
+  preferred_backup_window      = "17:00-19:00"
+  preferred_maintenance_window = "sun:19:00-sun:23:00"
+
+  tags = local.tags
+}

--- a/terraform/physical/bastion.tf
+++ b/terraform/physical/bastion.tf
@@ -47,7 +47,7 @@ resource "aws_ssm_association" "bastion_mysql_config" {
   document_version = aws_ssm_document.bastion_mysql_config.latest_version
 
   parameters = {
-    RDSEndpoint : module.primary_database.db_instance_address
+    RDSEndpoint : local.db_host
     RDSCredentialSecret : aws_secretsmanager_secret.primary_database_credentials.id
     Region : data.aws_region.current.id
   }

--- a/terraform/physical/bi.tf
+++ b/terraform/physical/bi.tf
@@ -176,7 +176,7 @@ module "rds_replica_database" {
   source  = "terraform-aws-modules/rds/aws"
   version = "5.6.0"
 
-  count = var.enable_bi ? local.dms_enabled ? 0 : 1 : 0
+  count = var.enable_bi && !local.dms_enabled && var.db_engine == "rds" ? 1 : 0
 
   identifier = "${local.identifier}-rds-replica"
 
@@ -287,12 +287,12 @@ resource "aws_secretsmanager_secret_version" "replica_database_credentials" {
 
   secret_id = aws_secretsmanager_secret.replica_database_credentials[0].id
   secret_string = jsonencode({
-    dbInstanceIdentifier = local.bi_db.db_instance_id
-    resourceId           = local.bi_db.db_instance_resource_id
-    host                 = local.bi_db.db_instance_address
-    port                 = local.bi_db.db_instance_port
+    dbInstanceIdentifier = local.dms_enabled ? module.dms_replica_database[0].db_instance_id : local.db_identifier
+    resourceId           = local.dms_enabled ? module.dms_replica_database[0].db_instance_resource_id : local.db_resource_id
+    host                 = local.bi_host
+    port                 = local.dms_enabled ? module.dms_replica_database[0].db_instance_port : local.db_port
     engine               = "mysql"
-    username             = local.dms_enabled ? module.dms_replica_database[0].db_instance_username : module.primary_database[0].db_instance_username
-    password             = local.dms_enabled ? module.dms_replica_database[0].db_instance_password : module.primary_database[0].db_instance_password
+    username             = local.dms_enabled ? module.dms_replica_database[0].db_instance_username : local.db_username
+    password             = local.dms_enabled ? module.dms_replica_database[0].db_instance_password : local.db_password
   })
 }

--- a/terraform/physical/bi.tf
+++ b/terraform/physical/bi.tf
@@ -104,9 +104,9 @@ resource "aws_dms_endpoint" "source" {
   port                        = 3306
   kms_key_arn                 = aws_kms_key.bi[0].arn
 
-  username    = module.primary_database.db_instance_username
-  password    = module.primary_database.db_instance_password
-  server_name = module.primary_database.db_instance_address
+  username    = local.db_username
+  password    = local.db_password
+  server_name = local.db_host
 
   tags = local.tags
 }
@@ -186,7 +186,7 @@ module "rds_replica_database" {
   port                        = 3306
   instance_class              = data.aws_rds_orderable_db_instance.default.instance_class
   max_allocated_storage       = var.rds_max_allocated_storage
-  replicate_source_db         = module.primary_database.db_instance_id
+  replicate_source_db         = module.primary_database[0].db_instance_id
   storage_encrypted           = true
   kms_key_id                  = data.aws_kms_key.rds.arn
   apply_immediately           = !var.protect_resources
@@ -207,7 +207,7 @@ module "rds_replica_database" {
 
   # DB parameter group
   create_db_parameter_group = false
-  parameter_group_name      = aws_db_parameter_group.default.name
+  parameter_group_name      = aws_db_parameter_group.default[0].name
 
   create_db_option_group = false
 
@@ -260,7 +260,7 @@ module "dms_replica_database" {
 
   # DB parameter group
   create_db_parameter_group = false
-  parameter_group_name      = aws_db_parameter_group.default.name
+  parameter_group_name      = aws_db_parameter_group.default[0].name
 
   create_db_option_group = false
 
@@ -292,7 +292,7 @@ resource "aws_secretsmanager_secret_version" "replica_database_credentials" {
     host                 = local.bi_db.db_instance_address
     port                 = local.bi_db.db_instance_port
     engine               = "mysql"
-    username             = local.dms_enabled ? module.dms_replica_database[0].db_instance_username : module.primary_database.db_instance_username
-    password             = local.dms_enabled ? module.dms_replica_database[0].db_instance_password : module.primary_database.db_instance_password
+    username             = local.dms_enabled ? module.dms_replica_database[0].db_instance_username : module.primary_database[0].db_instance_username
+    password             = local.dms_enabled ? module.dms_replica_database[0].db_instance_password : module.primary_database[0].db_instance_password
   })
 }

--- a/terraform/physical/db.tf
+++ b/terraform/physical/db.tf
@@ -1,0 +1,18 @@
+# Single source of truth for the active database's connection facts, selected by
+# var.db_engine. Both module.primary_database (rds) and module.aurora (aurora)
+# are count-gated, so exactly one is present. Consumed by the credentials secret
+# (rds.tf), DMS endpoints (bi.tf), and outputs.tf.
+locals {
+  db_is_aurora = var.db_engine == "aurora"
+
+  db_host = local.db_is_aurora ? module.aurora[0].cluster_endpoint : module.primary_database[0].db_instance_address
+  db_port = local.db_is_aurora ? module.aurora[0].cluster_port : module.primary_database[0].db_instance_port
+
+  db_username = "dozuki"
+  db_password = local.db_is_aurora ? random_password.aurora[0].result : module.primary_database[0].db_instance_password
+
+  db_identifier  = local.db_is_aurora ? module.aurora[0].cluster_id : module.primary_database[0].db_instance_id
+  db_resource_id = local.db_is_aurora ? module.aurora[0].cluster_resource_id : module.primary_database[0].db_instance_resource_id
+
+  db_reader_endpoint = local.db_is_aurora ? module.aurora[0].cluster_reader_endpoint : ""
+}

--- a/terraform/physical/dr.tf
+++ b/terraform/physical/dr.tf
@@ -109,7 +109,7 @@ resource "aws_db_instance_automated_backups_replication" "primary" {
   source_db_instance_arn = local.dr_source_db_arn
   kms_key_id             = aws_kms_key.dr_rds[0].arn
 
-  depends_on = [module.primary_database]
+  depends_on = [module.primary_database, module.aurora]
 }
 
 # Destination buckets for S3 cross-region replication, one per content bucket.

--- a/terraform/physical/dr.tf
+++ b/terraform/physical/dr.tf
@@ -19,7 +19,8 @@ locals {
 
   # RDS automated-backup cross-region replication is only possible when the DB
   # uses a customer-managed key (either our created CMK or an operator-pinned one).
-  dr_rds_enabled = var.enable_dr && (local.rds_use_dr_cmk || data.aws_kms_key.rds.key_manager == "CUSTOMER")
+  # Aurora DR uses Global Database (Plan B), not automated-backup replication.
+  dr_rds_enabled = var.db_engine == "rds" && var.enable_dr && (local.rds_use_dr_cmk || data.aws_kms_key.rds.key_manager == "CUSTOMER")
 }
 
 # Defense-in-depth guardrail. The real selection + blocklist enforcement happens
@@ -109,7 +110,7 @@ resource "aws_db_instance_automated_backups_replication" "primary" {
   source_db_instance_arn = local.dr_source_db_arn
   kms_key_id             = aws_kms_key.dr_rds[0].arn
 
-  depends_on = [module.primary_database, module.aurora]
+  depends_on = [module.primary_database]
 }
 
 # Destination buckets for S3 cross-region replication, one per content bucket.

--- a/terraform/physical/main.tf
+++ b/terraform/physical/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.5.0"
+  required_version = ">= 1.11.1"
 
   required_providers {
     aws = {

--- a/terraform/physical/main.tf
+++ b/terraform/physical/main.tf
@@ -84,7 +84,15 @@ locals {
   // If true we will use an empty RDS instance and setup replication via DMS.
   // If false we will use an RDS Read Replica and let RDS manage the replication for us.
   dms_enabled = var.enable_bi ? (var.bi_dms_enabled || var.bi_public_access) : false
-  bi_db       = var.enable_bi ? local.dms_enabled ? module.dms_replica_database[0] : module.rds_replica_database[0] : null
+
+  # BI source DB module (rds/dms paths only); null on the aurora private-BI path.
+  bi_db = var.enable_bi ? (local.dms_enabled ? module.dms_replica_database[0] : (var.db_engine == "rds" ? module.rds_replica_database[0] : null)) : null
+
+  # BI connection facts. aurora private BI = cluster reader endpoint + master creds.
+  bi_host = var.enable_bi ? (
+    local.dms_enabled ? module.dms_replica_database[0].db_instance_address :
+    (var.db_engine == "rds" ? module.rds_replica_database[0].db_instance_address : local.db_reader_endpoint)
+  ) : ""
 
   // Static map of all supported database instance types and their memory allocation, used for Memory Usage alarm.
   // (Neither RDS nor CloudWatch provides a metric or a queryable resource for instance memory size)

--- a/terraform/physical/monitoring.tf
+++ b/terraform/physical/monitoring.tf
@@ -175,6 +175,8 @@ module "rds_cpu_alarm" {
   source  = "terraform-aws-modules/cloudwatch/aws//modules/metric-alarm"
   version = "~> 5.0"
 
+  create_metric_alarm = var.db_engine == "rds"
+
   alarm_name        = "${local.identifier}-rds-cpu-usage"
   alarm_description = "CPU usage for RDS instance ${local.identifier}"
 
@@ -203,6 +205,8 @@ module "rds_cpu_alarm" {
 module "rds_free_memory_alarm" {
   source  = "terraform-aws-modules/cloudwatch/aws//modules/metric-alarm"
   version = "~> 5.0"
+
+  create_metric_alarm = var.db_engine == "rds"
 
   alarm_name        = "${local.identifier}-rds-free-memory"
   alarm_description = "Freeable Memory for RDS instance ${local.identifier}"
@@ -238,6 +242,8 @@ module "rds_swap_usage_alarm" {
   source  = "terraform-aws-modules/cloudwatch/aws//modules/metric-alarm"
   version = "~> 5.0"
 
+  create_metric_alarm = var.db_engine == "rds"
+
   alarm_name        = "${local.identifier}-rds-swap-usage"
   alarm_description = "Swap Usage for RDS instance ${local.identifier}"
 
@@ -264,6 +270,8 @@ module "rds_swap_usage_alarm" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "rds_storage_space_alarm" {
+  count = var.db_engine == "rds" ? 1 : 0
+
   alarm_name          = "${local.identifier}-rds-storage-space"
   alarm_description   = "Storage space usage for RDS instance ${local.identifier}"
   comparison_operator = "GreaterThanOrEqualToThreshold"
@@ -297,6 +305,8 @@ module "rds_connections_alarm" {
   source  = "terraform-aws-modules/cloudwatch/aws//modules/metric-alarm"
   version = "~> 5.0"
 
+  create_metric_alarm = var.db_engine == "rds"
+
   alarm_name        = "${local.identifier}-rds-connections"
   alarm_description = "Connection count for RDS instance ${local.identifier}"
 
@@ -326,6 +336,8 @@ module "rds_read_latency_alarm" {
   source  = "terraform-aws-modules/cloudwatch/aws//modules/metric-alarm"
   version = "~> 5.0"
 
+  create_metric_alarm = var.db_engine == "rds"
+
   alarm_name          = "${local.identifier}-rds-read-latency"
   alarm_description   = "Read latency for RDS instance ${local.identifier}"
   comparison_operator = "GreaterThanOrEqualToThreshold"
@@ -348,6 +360,8 @@ module "rds_read_latency_alarm" {
 module "rds_write_latency_alarm" {
   source  = "terraform-aws-modules/cloudwatch/aws//modules/metric-alarm"
   version = "~> 5.0"
+
+  create_metric_alarm = var.db_engine == "rds"
 
   alarm_name          = "${local.identifier}-rds-write-latency"
   alarm_description   = "Write latency for RDS instance ${local.identifier}"
@@ -531,4 +545,74 @@ resource "aws_cloudwatch_metric_alarm" "dr_s3_replication_failed" {
 
   alarm_actions = [module.sns.topic_arn]
   ok_actions    = [module.sns.topic_arn]
+}
+
+# --- Aurora CloudWatch alarms (count-gated on aurora engine) --- #
+
+resource "aws_cloudwatch_metric_alarm" "aurora_cpu" {
+  count               = var.db_engine == "aurora" ? 1 : 0
+  alarm_name          = "${local.identifier}-aurora-cpu"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 3
+  metric_name         = "CPUUtilization"
+  namespace           = "AWS/RDS"
+  period              = 300
+  statistic           = "Average"
+  threshold           = 85
+  alarm_description   = "Aurora cluster CPU high"
+  dimensions          = { DBClusterIdentifier = local.identifier }
+  alarm_actions       = [module.sns.topic_arn]
+  ok_actions          = [module.sns.topic_arn]
+  tags                = local.tags
+}
+
+resource "aws_cloudwatch_metric_alarm" "aurora_memory" {
+  count               = var.db_engine == "aurora" ? 1 : 0
+  alarm_name          = "${local.identifier}-aurora-freeable-memory"
+  comparison_operator = "LessThanThreshold"
+  evaluation_periods  = 3
+  metric_name         = "FreeableMemory"
+  namespace           = "AWS/RDS"
+  period              = 300
+  statistic           = "Average"
+  threshold           = 536870912 # 512 MiB
+  alarm_description   = "Aurora cluster freeable memory low"
+  dimensions          = { DBClusterIdentifier = local.identifier }
+  alarm_actions       = [module.sns.topic_arn]
+  ok_actions          = [module.sns.topic_arn]
+  tags                = local.tags
+}
+
+resource "aws_cloudwatch_metric_alarm" "aurora_connections" {
+  count               = var.db_engine == "aurora" ? 1 : 0
+  alarm_name          = "${local.identifier}-aurora-connections"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 3
+  metric_name         = "DatabaseConnections"
+  namespace           = "AWS/RDS"
+  period              = 300
+  statistic           = "Average"
+  threshold           = 1000
+  alarm_description   = "Aurora cluster connection count high"
+  dimensions          = { DBClusterIdentifier = local.identifier }
+  alarm_actions       = [module.sns.topic_arn]
+  ok_actions          = [module.sns.topic_arn]
+  tags                = local.tags
+}
+
+resource "aws_cloudwatch_metric_alarm" "aurora_acu" {
+  count               = var.db_engine == "aurora" ? 1 : 0
+  alarm_name          = "${local.identifier}-aurora-acu-ceiling"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 3
+  metric_name         = "ACUUtilization"
+  namespace           = "AWS/RDS"
+  period              = 300
+  statistic           = "Average"
+  threshold           = 90
+  alarm_description   = "Aurora Serverless v2 capacity near max ACU"
+  dimensions          = { DBClusterIdentifier = local.identifier }
+  alarm_actions       = [module.sns.topic_arn]
+  ok_actions          = [module.sns.topic_arn]
+  tags                = local.tags
 }

--- a/terraform/physical/rds.tf
+++ b/terraform/physical/rds.tf
@@ -90,6 +90,7 @@ module "bi_database_sg" {
 }
 
 resource "aws_db_parameter_group" "default" {
+  count = var.db_engine == "rds" ? 1 : 0
 
   name_prefix = local.identifier
   family      = "mysql${var.rds_engine_family}"
@@ -120,6 +121,8 @@ resource "aws_db_parameter_group" "default" {
 module "primary_database" {
   source  = "terraform-aws-modules/rds/aws"
   version = "5.6.0"
+
+  count = var.db_engine == "rds" ? 1 : 0
 
   identifier = local.identifier
 
@@ -167,7 +170,7 @@ module "primary_database" {
 
   # DB parameter group
   create_db_parameter_group = false
-  parameter_group_name      = aws_db_parameter_group.default.name
+  parameter_group_name      = aws_db_parameter_group.default[0].name
 
   create_db_option_group = false
 
@@ -191,12 +194,12 @@ resource "aws_secretsmanager_secret" "primary_database_credentials" {
 resource "aws_secretsmanager_secret_version" "primary_database_credentials" {
   secret_id = aws_secretsmanager_secret.primary_database_credentials.id
   secret_string = jsonencode({
-    dbInstanceIdentifier = module.primary_database.db_instance_id
-    resourceId           = module.primary_database.db_instance_resource_id
-    host                 = module.primary_database.db_instance_address
-    port                 = module.primary_database.db_instance_port
+    dbInstanceIdentifier = local.db_identifier
+    resourceId           = local.db_resource_id
+    host                 = local.db_host
+    port                 = local.db_port
     engine               = "mysql"
-    username             = module.primary_database.db_instance_username
-    password             = module.primary_database.db_instance_password
+    username             = local.db_username
+    password             = local.db_password
   })
 }

--- a/terraform/physical/variables.tf
+++ b/terraform/physical/variables.tf
@@ -385,4 +385,39 @@ variable "rds_adopt_dr_cmk" {
   default     = false
 }
 
+variable "db_engine" {
+  description = "Database engine for this stack: 'rds' (provisioned RDS MySQL) or 'aurora' (Aurora MySQL 8.4 Serverless v2). Default 'rds' so existing stacks never auto-migrate; new stacks set 'aurora'."
+  type        = string
+  default     = "rds"
+
+  validation {
+    condition     = contains(["rds", "aurora"], var.db_engine)
+    error_message = "db_engine must be 'rds' or 'aurora'."
+  }
+}
+
+variable "aurora_min_acu" {
+  description = "Aurora Serverless v2 minimum capacity (ACUs)."
+  type        = number
+  default     = 0.5
+}
+
+variable "aurora_max_acu" {
+  description = "Aurora Serverless v2 maximum capacity (ACUs)."
+  type        = number
+  default     = 16
+}
+
+variable "aurora_engine_version" {
+  description = "Aurora MySQL engine version. Fresh cluster: an 8.4 version. Snapshot-restore migration: an 8.0-compatible version first, then upgrade."
+  type        = string
+  default     = "8.4.7"
+}
+
+variable "aurora_snapshot_identifier" {
+  description = "Optional RDS DB snapshot ARN to restore the Aurora cluster from (migration path). Empty = fresh cluster."
+  type        = string
+  default     = ""
+}
+
 # --- END App Configuration --- #


### PR DESCRIPTION
Plan A of the Aurora migration: adds an **Aurora MySQL 8.4 Serverless v2** path to `terraform/physical` behind a `db_engine` toggle, single-region. The physical→logical contract (`primary_db_secret`) is unchanged, so logical/app/chart need zero changes.

## What's here
- **`db_engine` toggle** (`"rds"` | `"aurora"`, default **`"rds"`** so existing stacks never auto-migrate; new stacks set `"aurora"`).
- **`aurora.tf`** — `terraform-aws-modules/rds-aurora` **v10.2.0**, Serverless v2 (`db.serverless` + `serverlessv2_scaling_configuration`, ACU min/max vars), self-managed master password via `random_password` → `master_password_wo`, cluster+instance parameter groups (binlog at cluster level for DMS, verified placement), customer-managed KMS, `snapshot_identifier` migration input.
- **`db.tf`** — a `local.db_*` selector that unifies host/port/user/password/identifier across engines, so the secret + DMS endpoints + bastion are engine-agnostic and the secret JSON is byte-identical.
- RDS module/param-group **count-gated** to `db_engine="rds"`; all references updated; aurora path made apply-safe (private BI → Aurora reader endpoint; RDS-only BI replica and #138 RDS backup-replication gated off on aurora — Global DB is Plan B).
- **Aurora CloudWatch alarms** (CPU, freeable memory, connections, ACU-ceiling); RDS alarms gated to `db_engine="rds"`; dropped `FreeStorageSpace` (N/A on Aurora).

## Important: tooling
The `rds-aurora` v10 module uses `master_password_wo` (write-only, **requires Terraform/OpenTofu ≥ 1.11.1**) and aws provider ≥ 6.28 (already satisfied by `~> 6.0`). **`required_version` bumped to `>= 1.11.1`.** This layer must run on **OpenTofu 1.12.x** — each physical stack's Spacelift Terragrunt **Tool** must be switched from Terraform to **OpenTofu** when it adopts this release (DB migration can happen later). Validated locally with OpenTofu 1.12.2 (`tofu validate` clean; standalone validate uses a gitignored provider stub since prod providers are terragrunt-generated).

## Scope / next
- Single-region only. **Plan B** adds opt-in Aurora **Global Database** (replaces #138's RDS backup-replication on the aurora path). **Plan C** adds the per-customer snapshot-restore migration runbook + the upgrade-test-harness `db_engine` dimension.
- Operator validation: real `tofu plan`/`apply` with `db_engine="aurora"` in DDVtest (covered by the harness rehearsal).

No account numbers per convention.
