### PR TITLE
fix(physical): clean teardown — NLB deletion protection + aws.dr provider

### DIFF
--- a/live/terragrunt.hcl
+++ b/live/terragrunt.hcl
@@ -12,7 +12,12 @@ locals {
   account_id   = get_env("TG_AWS_ACCT_ID", local.account_vars.locals.aws_account_id)
   aws_region   = get_env("TG_AWS_REGION", local.region_vars.locals.aws_region)
   aws_profile  = get_env("TG_AWS_PROFILE", local.account_vars.locals.aws_profile)
-  
+
+  # DR region for the generated aws.dr provider. physical/dr.tf references
+  # provider = aws.dr statically (even with enable_dr=false), so the provider must
+  # always exist or plan/destroy fails. Falls back to us-west-2 when DR is off.
+  dr_region = get_env("TG_AWS_DR_REGION", try(local.environment_vars.locals.dr_region, "us-west-2"))
+
   dns_role = local.aws_region == "us-gov-west-1" ? "arn:aws-us-gov:iam::446787640263:role/Route53AccessRole" : "arn:aws:iam::010601635461:role/Route53AccessRole"
 }
 
@@ -35,6 +40,12 @@ provider "aws" {
   assume_role {
     role_arn = "${local.dns_role}"
   }
+}
+provider "aws" {
+  alias               = "dr"
+  region              = "${local.dr_region}"
+  allowed_account_ids = ["${local.account_id}"]
+  profile             = "${local.aws_profile}"
 }
 EOF
 }

--- a/terraform/physical/nlb.tf
+++ b/terraform/physical/nlb.tf
@@ -52,6 +52,11 @@ module "nlb" {
   internal                         = !var.app_public_access
   enable_cross_zone_load_balancing = true
 
+  # The alb module (~> 10.0) defaults enable_deletion_protection=true (since
+  # v9.0.0). Follow protect_resources like rds/aurora/bi so non-protected stacks
+  # (e.g. the test harness) can be torn down without manually clearing it.
+  enable_deletion_protection = var.protect_resources
+
   vpc_id  = local.vpc_id
   subnets = local.public_subnet_ids
 


### PR DESCRIPTION
Two fixes surfaced by the v6.0→v6.1 upgrade test harness; both block clean teardown.

## NLB deletion protection (`terraform/physical/nlb.tf`)
`terraform-aws-modules/alb/aws` `~> 10.0` defaults `enable_deletion_protection = true` (since v9.0.0). `nlb.tf` never overrode it, so every NLB got deletion protection — Terraform couldn't delete it and the lingering NLB ENIs pinned the Internet Gateway, hanging destroys. Now set from `var.protect_resources`, consistent with `rds.tf`/`aurora.tf`/`bi.tf`.

## aws.dr provider (`live/terragrunt.hcl`)
`physical/dr.tf` references `provider = aws.dr` unconditionally (even with `enable_dr=false`), but the harness root stopped generating that provider, so `destroy`/`plan` failed with "provider configuration not present." The root now generates `aws.dr` (+ a `dr_region` local), matching `infra-live`.

Release-notes changelog updated separately in the v6.1 release PR (#146).