### PR TITLE
docs: rewrite README + refresh DEPLOYMENT for the current architecture

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -1,35 +1,39 @@
 # Deploying a Test Environment Stack
 
-This guide covers deploying a new CloudPrem environment stack from a Mac workstation for development and testing.
+This guide covers deploying a new CloudPrem environment stack on **AWS** from a Mac
+workstation for development and testing. For **Azure** deployments, use the
+self-contained deploy kit and its runbook in [`azure-config/README.md`](./azure-config/README.md).
 
 ## Prerequisites
 
 ### Required Tools
 
 ```bash
-# Version managers for Terraform and Terragrunt
-brew install tfenv tgenv
-
-# Install the required versions
-tfenv install 1.13.4
-tfenv use 1.13.4
-tgenv install 0.80.6
-tgenv use 0.80.6
+# OpenTofu drives both layers locally — the physical layer requires >= 1.11.1, and
+# OpenTofu runs the logical layer too. Terragrunt orchestrates them.
+brew install opentofu terragrunt
 
 # Everything else
 brew install awscli helm kubectl hashicorp/tap/vault
+
+# Point Terragrunt at OpenTofu (add this to your shell profile):
+export TERRAGRUNT_TFPATH=tofu
 ```
 
 | Tool | Version | Verify |
 |------|---------|--------|
-| tfenv | latest | `tfenv --version` |
-| tgenv | latest | `tgenv --version` |
-| Terraform | 1.13.x (via tfenv) | `terraform version` |
-| Terragrunt | 0.80.x (via tgenv) | `terragrunt --version` |
+| OpenTofu | >= 1.11.1 | `tofu version` |
+| Terragrunt | 0.99.x | `terragrunt --version` |
 | AWS CLI | 2.x | `aws --version` |
 | Helm | 3.x | `helm version` |
 | kubectl | 1.28+ | `kubectl version --client` |
 | Vault CLI | 1.15+ | `vault version` |
+
+> **Toolchain note:** Production deploys run on **Spacelift**, which pins the
+> *logical* layer to Terraform 1.5.7 (the last MPL-licensed release). The modules
+> themselves only require Terraform/OpenTofu **>= 1.11.1** (physical — for the Aurora
+> module and write-only attributes) and **>= 1.5.0** (logical), so a single OpenTofu
+> binary runs both layers locally.
 
 ### AWS SSO Profiles
 
@@ -110,8 +114,7 @@ Edit `env.hcl` for your environment:
 ```hcl
 locals {
   environment                   = "min"
-  enable_vault                  = true       # Vault secret management via ESO
-  enable_webhooks               = false      # MSK Kafka + Redis + Frontegg connectivity
+  enable_webhooks               = false      # MSK Kafka for webhooks
   enable_bi                     = false      # BI replica database + Grafana dashboards
   rds_multi_az                  = false      # Multi-AZ RDS (production only)
   highly_available_nat_gateway  = false      # NAT per AZ (production only)
@@ -128,10 +131,10 @@ locals {
 
 | Type | `enable_webhooks` | `enable_bi` | What it deploys |
 |------|:-:|:-:|---|
-| `min` | false | false | Core app + OpenSearch + monitoring |
-| `hooks` | **true** | false | min + MSK Kafka + Redis + MongoDB + Frontegg connectivity |
-| `bi` | false | **true** | min + BI replica DB + Grafana dashboards |
-| `full` | **true** | **true** | Everything |
+| `min` | false | false | Core application stack + monitoring |
+| `hooks` | **true** | false | Core + webhooks infrastructure (MSK Kafka) |
+| `bi` | false | **true** | Core + business-intelligence replica database |
+| `full` | **true** | **true** | All features (webhooks + BI); pair with multi-AZ + DR for production |
 
 ## Step 4: Configure Physical Inputs
 
@@ -139,8 +142,16 @@ Edit `physical/terragrunt.hcl` to add any required overrides:
 
 ```hcl
 inputs = {
-  # Required when enable_vault = true (get from vault-infrastructure deployment):
+  # Required — Vault is mandatory (get the PrivateLink service name from the
+  # central Vault deployment):
   vault_endpoint_service_name = "com.amazonaws.vpce.<region>.vpce-svc-xxxxxxxxxxxxxxxxx"
+
+  # Optional — names this stack and its subdomain. Resources are named
+  # "<customer>-<env>"; defaults to "dozuki-<env>" when unset.
+  # customer = "acme"
+
+  # Optional — "rds" (default, provisioned MySQL) or "aurora" (Serverless v2).
+  # db_engine = "aurora"
 }
 ```
 
@@ -164,9 +175,16 @@ eval "$(aws configure export-credentials --profile <profile> --format env)"
 TG_AWS_PROFILE='' AWS_PROFILE='' terragrunt run-all apply
 ```
 
-### Vault-Enabled Stacks (`enable_vault = true`)
+> **Heads-up:** these exported `AWS_*` env vars expire (~1 hour) and **override**
+> `AWS_PROFILE` while set — once they expire, profile-based commands fail with
+> confusing auth errors even though your SSO session is valid. Run
+> `unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN` when you're done
+> with the workaround.
 
-The logical layer's Vault provider needs connectivity and authentication. Before running apply:
+### Vault Setup (required)
+
+Vault is mandatory: the logical layer authenticates to the central Vault and seeds
+this stack's secrets. Its provider needs connectivity and authentication before apply:
 
 **1. Start a tunnel to Vault** (keep this running in a separate terminal):
 
@@ -214,17 +232,19 @@ TG_AWS_PROFILE='' AWS_PROFILE='' terragrunt run-all apply
 Set up kubectl and check the deployment:
 
 ```bash
+# The cluster name is "<customer>-<env>" (or "dozuki-<env>" when customer is unset).
+CLUSTER=dozuki-<env>
 aws eks update-kubeconfig \
-  --name dozuki-<env> \
+  --name "$CLUSTER" \
   --region <region> \
   --profile <profile> \
-  --alias dozuki-<env>
+  --alias "$CLUSTER"
 
 # Check all pods are running
-kubectl --context dozuki-<env> get pods -n dozuki
+kubectl --context "$CLUSTER" get pods -n dozuki
 
 # Check Helm releases
-helm --kube-context dozuki-<env> list -A
+helm --kube-context "$CLUSTER" list -A
 
 # Check the app URL (from Terraform output)
 cd logical && terragrunt output dozuki_url
@@ -257,7 +277,10 @@ Or from the environment root:
 terragrunt run-all destroy
 ```
 
-**Warning:** If `protect_resources = true`, RDS and S3 resources will block deletion. Set it to `false` first and apply before destroying.
+**Warning:** If `protect_resources = true`, RDS, S3, and the NLB get deletion
+protection and will block `destroy` — and a protected NLB keeps ENIs that pin the
+internet gateway, hanging the whole VPC teardown. Set `protect_resources = false` and
+apply once *before* destroying.
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -1,79 +1,171 @@
-# Dozuki Cloudprem infrastructure
+# Dozuki CloudPrem Infrastructure
 
-![Terraform](https://github.com/nclouds/doz-cloudprem-infrastructure/workflows/Terraform/badge.svg)
+Infrastructure-as-code for deploying the **Dozuki** application as a managed private
+cloud (MPC) — a self-contained, customer-isolated stack on **AWS** (commercial and
+GovCloud) or **Azure**. The project provisions the cloud infrastructure, the
+Kubernetes platform, and the application itself, and is driven by
+[Terragrunt](https://terragrunt.gruntwork.io/) over Terraform / OpenTofu.
 
-The Terraform project automates the creation of AWS resources as well as some base Kubernetes components required for the Cloudprem application infrastructure.
+## Architecture
 
-![dozuki](https://app.lucidchart.com/publicSegments/view/c01199f1-8171-415f-b3ca-09206a593da5/image.png)
+A deployment is split into two layers that apply in order. The split keeps the
+expensive, slow-changing cloud infrastructure independent of the fast-moving
+application/Kubernetes layer, and lets each layer use the toolchain it needs.
 
-## Deployment
-
-The infrastructure is managed and deployed using [Terragrunt](https://terragrunt.gruntwork.io/docs/#features). By using terragrunt we are able to deploy the infrastructure to multiple environments, lock and version the infrastructure and keep Terraform code and state configuration DRY.
-
-The terragrunt configurations for each environment can be found in the [live](./live) directory. The outer [terragrunt.hcl](./live/terragrunt.hcl) file contains configurations for the backend state and locks. The [terragrunt.hcl](./live/development) files under each environment directory contain the parameters for that specific environment and the location of the Terraform stack. *(Note: For the Cloudprem infrastructure development, local references to the modules are used, eg. `../..//terraform`. For the customers deployment a reference to a specific version of the stack should be declared, eg. `git::https://github.com/dozuki/cloudprem-infrastructure.git//cloudprem?ref=v0.0.1`)*
-
-To deploy the stack, perform the following steps:
-
-1. Initialize the backend and install the required providers and modules using terragrunt:
-
-    ```console
-    $ cd live/development
-    $ terragrun init
-    ```
-
-2. Review the parameters in the [terragrunt.hcl](./live/development/terragrunt.hcl) file and execute the plan/apply
-
-    ```console
-    $ terragrunt apply
-    ```
-
-To delete the infrastructure for the environment execute terragrunt destroy
-
-```console
-$ terragrunt destroy
 ```
+┌─────────────────────────────────────────────────────────────┐
+│  logical   (terraform/logical)          Terraform 1.5.x       │
+│  Kubernetes + Helm: cert-manager, metrics-server, External    │
+│  Secrets Operator, Envoy Gateway, and the Dozuki app chart.   │
+│  Seeds per-stack secrets into Vault.                          │
+├─────────────────────────────────────────────────────────────┤
+│  physical  (terraform/physical)         OpenTofu 1.11+        │
+│  AWS: VPC, EKS (Auto Mode), RDS MySQL / Aurora Serverless v2, │
+│  S3, ElastiCache, MSK, NLB, KMS, IAM, Route53, bastion,       │
+│  cross-region DR, and a PrivateLink endpoint to central Vault.│
+└─────────────────────────────────────────────────────────────┘
+```
+
+**Azure** deployments use a parallel `terraform/physical-azure` layer (AKS, Azure
+Database for MySQL, VNet, Key Vault, managed identity) plus the same `logical`
+layer, packaged with a self-contained deploy kit under [`azure-config/`](./azure-config).
+
+Secrets are managed centrally in **HashiCorp Vault** (reached over PrivateLink and
+surfaced into the cluster by the External Secrets Operator). The physical layer
+provisions the Vault endpoint; the logical layer authenticates (AWS + Kubernetes
+auth) and seeds each stack's secrets.
+
+## Repository layout
+
+```
+terraform/
+  physical/          AWS cloud infrastructure         (OpenTofu >= 1.11.1)
+  logical/           Kubernetes / Helm / app          (Terraform >= 1.5.0)
+  physical-azure/    Azure cloud infrastructure
+live/                Terragrunt deployment configs
+  terragrunt.hcl     Root: remote state, provider generation, input merge
+  common.hcl         Shared inputs + logical→physical dependency wiring
+  standard/          AWS commercial partition  (account.hcl → region → env)
+  gov/               AWS GovCloud partition
+  .skel/             Templates for scaffolding new partitions / environments
+  tests/             Upgrade + DR integration harness (Go / Terratest)
+azure-config/        Turnkey Azure deploy kit (image sync, charts, bootstrap)
+.github/workflows/   CI: validation, integration tests, releases
+DEPLOYMENT.md        Operator runbook for standing up / upgrading a stack
+```
+
+## The `live/` deployment model
+
+Terragrunt configuration is layered so values flow down a hierarchy and merge into
+each leaf module. The root [`live/terragrunt.hcl`](./live/terragrunt.hcl) generates
+the S3 remote-state backend (with DynamoDB locking) and the provider block — the
+primary `aws` provider plus the `aws.dns` (cross-account DNS) and `aws.dr`
+(disaster-recovery region) aliases.
+
+```
+live/standard/                       partition
+  account.hcl                        ← AWS account id + profile
+  us-east-1/
+    region.hcl                       ← region
+    full/
+      env.hcl                        ← feature flags for this environment
+      physical/terragrunt.hcl        ← sources terraform/physical
+      logical/terragrunt.hcl         ← sources terraform/logical
+```
+
+**Partitions:** `standard` (commercial AWS) and `gov` (AWS GovCloud).
+
+**Environments** are presets of the feature flags below:
+
+| Env                 | Purpose                                                        |
+|---------------------|---------------------------------------------------------------|
+| `min`               | Minimal single-AZ stack — dev / smoke testing                 |
+| `full`              | Production preset — multi-AZ, DR, webhooks, BI all on          |
+| `bi`                | Adds the business-intelligence database path                  |
+| `hooks`             | Adds the webhooks (Kafka) path                                 |
+| `workstation_setup` | Bootstrap/workstation tooling                                 |
+
+New partitions and environments are scaffolded from [`live/.skel/`](./live/.skel)
+via [`live/generate_live_env.sh`](./live/generate_live_env.sh).
+
+For the full step-by-step deploy and upgrade procedure, see **[DEPLOYMENT.md](./DEPLOYMENT.md)**.
+
+## Toolchain: the OpenTofu / Terraform split
+
+The two layers deliberately run on different binaries:
+
+- **`physical` → OpenTofu (`>= 1.11.1`).** It relies on write-only attributes
+  (e.g. `master_password_wo`) and the Aurora module, which require a newer core than
+  the logical layer is pinned to. Drive Terragrunt against it with
+  `TERRAGRUNT_TFPATH=tofu`.
+- **`logical` → Terraform (`1.5.7`).** Held at 1.5.7 for compatibility with the
+  production runner (Spacelift, MPL-licensed Terraform). Uses the Helm / Kubernetes
+  providers.
+
+CI enforces this per-layer (see [`.github/workflows/terraform.yml`](./.github/workflows/terraform.yml)),
+and the test harness selects the right binary per layer automatically.
+
+> **Production deployments** are executed by **Spacelift**, configured in the
+> separate `infra-live` repository (which wires each stack to the correct tool and
+> version). This repo holds the modules and the `live/` definitions; it is not the
+> Spacelift control plane.
+
+## Configuration
+
+Feature flags are set per-environment in `env.hcl` and flow through the root
+`terragrunt.hcl` `inputs` merge. The most common operator-facing toggles:
+
+| Variable                       | Layer    | Default | Purpose                                                        |
+|--------------------------------|----------|---------|----------------------------------------------------------------|
+| `customer`                     | physical | —       | Customer/stack name; drives resource naming and the subdomain  |
+| `protect_resources`            | both     | `true`  | Deletion protection on RDS, S3, Vault secrets                   |
+| `enable_dr`                    | physical | `true`  | Cross-region DR (RDS backup replication, S3 CRR)               |
+| `db_engine`                    | physical | `rds`   | `rds` (provisioned MySQL) or `aurora` (Aurora Serverless v2)    |
+| `rds_multi_az`                 | physical | `true`  | Multi-AZ RDS standby                                            |
+| `highly_available_nat_gateway` | physical | `true`  | One NAT gateway per AZ                                          |
+| `enable_webhooks`              | both     | `false` | Provision MSK (Kafka) for webhooks                             |
+| `enable_bi`                    | both     | `false` | Provision the business-intelligence database path             |
+| `image_tag` / `nextjs_tag`     | logical  | —       | Dozuki application image tags                                   |
+| `chart_version`                | logical  | —       | Dozuki Helm chart version (pulled from the OCI/ECR registry)   |
+| `image_repository`             | logical  | —       | Registry the app chart and images are pulled from              |
+
+## Testing
+
+[`live/tests/`](./live/tests) contains a Go/Terratest **upgrade harness**: it stands
+up a stack at a baseline release, validates it, upgrades to a target release,
+re-validates, and tears everything down — exercising the real upgrade path customers
+take. Scenarios are defined in `matrix.yaml` (`min_default`, `bi_ha`, `full`).
+
+- [`live/tests/verify-clean.sh`](./live/tests/verify-clean.sh) — read-only leak
+  detector that scans the cost-heavy / collision-prone services for harness residue;
+  use it as a post-run check or a gate before re-running.
+- The harness runs on demand against a dedicated test account — it stands up real
+  cloud resources — with a CI integration gate landing alongside the harness itself.
+
+## CI/CD
+
+| Workflow              | Trigger                     | Does                                                       |
+|-----------------------|-----------------------------|-----------------------------------------------------------|
+| `terraform.yml`       | push / PR                   | `fmt` + `tflint` per layer (OpenTofu for physical, Terraform for logical) |
+| `release.yml`         | push of a `v*` tag          | Publishes the AWS GitHub release from the curated notes    |
+| `release-azure.yml`   | Azure release tag           | Publishes the Azure deploy-kit release                     |
+
+## Releasing
+
+Releases are cut by tagging `vX.Y` (which fires `release.yml`). The working model is
+freeze a release branch, land any further fixes on `master`, re-sync them into the
+release branch, re-validate with the harness, then tag.
 
 ## Contributing
 
-To contribute to the project, make your changes to the Terraform code and deploy them to a local environment using the parameters in the [live/development](./live/development) directory by following the instructions in the [deploy](#deploy) section.
-
-### Pre-commit
-
-The project is configured with [pre-commit](https://pre-commit.com/) hooks to perform checks on the code and provide faster feedback. Consider using it on your development workflow.
-
-To enable the pre-commit hooks:
+Install the [pre-commit](https://pre-commit.com/) hooks (`terraform fmt`,
+`terraform-docs`, `tflint`) before committing:
 
 ```console
-$ pre-commit install
+pre-commit install
+pre-commit run -a       # run against all files
 ```
 
-The checks are going to be executed by default on every commit, if you want to perform the checks manually execute:
-
-```console
-$ pre-commit run -a
-```
-
-For more information about the pre-commit hooks configured check the [pre-commit configuration repository](https://github.com/nclouds/pre-commit-terraform)
-
-### CI / CD
-
-The repository is configured with two Github Workflows:
-
-1. Terraform: Performs validations using (terraform fmt, tflint and tfsec) for quality compliance. This CI pipeline is executed on every commit pushed github.
-2. Release: This workflow creates a github release of the Terraform project whenever a new tag of the form v* (i.e. v1.0, v20.15.10) is pushed to the repository. To control the Release notes and properties update the [release.yml](./.github/workflows/release.yml) file.
-
-#### Additional considerations
-
-By default only the user that creates the EKS cluster has permissions to access the cluster, for that reason if you create the Terraform stack with the pipeline and then try to update the stack manually you'll get an `Unauthorized` error when Terraform attempts to update or refresh the state of the kubernetes resources. To overcome that a role called *deployment_role* is created as part of the pipeline and used to deploy the infrastructure.
-
-To perform manual updates to the infrastructure after deploying it with the pipeline get the deployment role arn from the CloudFormation pipeline and assume the role:
-
-```console
-aws_credentials=$(aws sts assume-role --role-arn <deployment_role_arn> --role-session-name "Terraform")
-export AWS_ACCESS_KEY_ID=$(echo $aws_credentials|jq '.Credentials.AccessKeyId'|tr -d '"')
-export AWS_SECRET_ACCESS_KEY=$(echo $aws_credentials|jq '.Credentials.SecretAccessKey'|tr -d '"')
-export AWS_SESSION_TOKEN=$(echo $aws_credentials|jq '.Credentials.SessionToken'|tr -d '"')
-terragrunt apply
-```
-
-Note that the role session name is Terraform, you must use the exact same session name to perform updates.
+Make changes in `terraform/` (modules) and exercise them through a `min` environment
+under `live/` per [DEPLOYMENT.md](./DEPLOYMENT.md). Keep the `physical` layer
+OpenTofu-compatible and the `logical` layer Terraform 1.5.7-compatible.


### PR DESCRIPTION
## What

Documentation-only refresh. No code, no module or `live/` changes.

### README.md — full rewrite
The old README predated the entire current architecture: it referenced the wrong org, a `live/development` directory, and a `deployment_role` CI pipeline that no longer exist. The rewrite reflects the current tree:

- **Two-layer architecture** (physical/OpenTofu + logical/Terraform) with a diagram, plus **Azure** as a parallel `physical-azure` + `azure-config` path.
- **Repository layout**, the **`live/` Terragrunt model** (partition → account → region → env; `standard`/`gov`; env presets; `.skel` scaffolding).
- **The OpenTofu/Terraform version split** and *why* (physical needs ≥1.11.1 for the Aurora module + write-only attrs; logical pinned to 1.5.7 for the Spacelift runner). Notes that Spacelift config lives in the separate `infra-live` repo.
- **Toggle table**, **Vault** secret model, the **`live/tests` harness + `verify-clean.sh`**, the real **CI workflows**, releasing, and pre-commit.
- Account ID / ECR registry genericized (repo-visible doc).

### DEPLOYMENT.md — corrections
- **Toolchain:** OpenTofu ≥1.11.1 driving both layers locally (was a single Terraform 1.13.4); clarifies 1.5.7 is the Spacelift production pin for logical. Terragrunt 0.80.x → 0.99.x.
- **Removed the dead `enable_vault` toggle** — Vault is mandatory.
- **Fixed the EKS cluster name** to `<customer>-<env>` (defaulting to `dozuki-<env>`).
- **Removed the non-existent OpenSearch reference**; corrected per-env descriptions.
- Added the **exported-AWS-creds expiry footgun** and the **NLB deletion-protection → IGW teardown-hang** warning.
- Added an **Azure deploy-kit pointer** (`azure-config/README.md`).

All facts verified against `origin/master`.