### PR TITLE
fix(logical): set ghcr-pull imagePullSecret on dozuki-operator for azure

### DIFF
--- a/terraform/logical/kubernetes.tf
+++ b/terraform/logical/kubernetes.tf
@@ -518,8 +518,11 @@ resource "helm_release" "app" {
     { name = "connectivity.connectors-worker.redis.tls", value = "false" },
     ], var.cloud == "azure" ? [
     # --- Operator (azure: pull from GHCR mirror, not ECR) ---
+    # The operator subchart reads its OWN imagePullSecrets (it does not honor
+    # global.imagePullSecrets), so the GHCR pull secret must be set explicitly.
     { name = "dozuki-operator.image.repository", value = "${var.image_repository}/dozuki-operator" },
     { name = "dozuki-operator.image.tag", value = var.operator_image_tag },
+    { name = "dozuki-operator.imagePullSecrets[0].name", value = "ghcr-pull" },
   ] : [])
 
   set_sensitive = [


### PR DESCRIPTION
## Summary
Follow-up to the azure-port batch. The operator subchart reads its **own** `imagePullSecrets` value and does not honor `global.imagePullSecrets`, so on azure (where images are pulled from a private GHCR repo) the operator pod had no pull credentials and 401'd even after the image was pointed at the GHCR mirror. Set `dozuki-operator.imagePullSecrets[0].name=ghcr-pull` in the azure-only block.

Validated live: with this value the operator pulls `dozuki-operator:3.0.3` from GHCR and runs. AWS is unaffected (azure-only `concat` block).

## Test Plan
- [ ] AWS zero-diff (azure-only set entries; AWS render unchanged).
- [ ] Azure deploy: operator pod pulls from GHCR and reaches Running.