### PR TITLE
fix(physical): auto-adopt pre-existing amazon-cloudwatch-observability EKS addon

### DIFF
--- a/terraform/physical/eks.tf
+++ b/terraform/physical/eks.tf
@@ -396,15 +396,45 @@ resource "aws_iam_role_policy_attachment" "cloudwatch_agent_xray" {
   policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/AWSXRayDaemonWriteAccess"
 }
 
+# EKS Auto Mode (and some cluster bootstraps) install the amazon-cloudwatch-observability
+# addon out-of-band. A plain CreateAddon then fails with 409 ResourceInUseException, and
+# resolve_conflicts_on_create=OVERWRITE only resolves field-level conflicts — it does NOT
+# adopt a pre-existing addon. To keep both fresh installs and v6.0->v6.1 upgrades hands-off,
+# delete any pre-existing copy with --preserve (the in-cluster cloudwatch-agent DaemonSet
+# stays up, so there's no observability gap) right before Terraform creates and manages it.
+# Runs once per cluster; a no-op when the addon isn't already present.
+resource "null_resource" "adopt_cloudwatch_observability_addon" {
+  triggers = {
+    cluster = module.eks_cluster.cluster_name
+  }
+
+  provisioner "local-exec" {
+    interpreter = ["/bin/bash", "-c"]
+    command     = <<-EOT
+      set -euo pipefail
+      region="${data.aws_region.current.id}"
+      cluster="${module.eks_cluster.cluster_name}"
+      addon="amazon-cloudwatch-observability"
+      if aws eks describe-addon --cluster-name "$cluster" --addon-name "$addon" --region "$region" >/dev/null 2>&1; then
+        echo "Adopting pre-existing $addon addon: deleting with --preserve so Terraform can manage it."
+        aws eks delete-addon --cluster-name "$cluster" --addon-name "$addon" --preserve --region "$region"
+        aws eks wait addon-deleted --cluster-name "$cluster" --addon-name "$addon" --region "$region"
+      fi
+    EOT
+  }
+}
+
 # Managed addon. The pod_identity_association wires the role to the cloudwatch-agent SA
 # in the amazon-cloudwatch namespace (EKS creates the association and annotates the SA).
 # addon_version is left unset so EKS selects the default compatible with the cluster's
-# Kubernetes version. OVERWRITE resolves field-level conflicts on managed resources;
-# it does NOT adopt a pre-existing addon — a cluster that already has this addon
-# installed out-of-band must have it removed (or imported) once before first apply.
+# Kubernetes version. The null_resource above clears any out-of-band copy first, so this
+# create succeeds and adopts the preserved in-cluster resources (OVERWRITE then keeps
+# field-level conflicts resolved on subsequent updates).
 resource "aws_eks_addon" "cloudwatch_observability" {
   cluster_name = module.eks_cluster.cluster_name
   addon_name   = "amazon-cloudwatch-observability"
+
+  depends_on = [null_resource.adopt_cloudwatch_observability_addon]
 
   pod_identity_association {
     role_arn        = aws_iam_role.cloudwatch_agent_pod_identity.arn


### PR DESCRIPTION
## Problem

The upgrade harness (`min_default`, v6.0→v6.1) fails the upgrade apply with:

```
Error: creating EKS Add-On (smoke-min:amazon-cloudwatch-observability): ...
StatusCode: 409, ResourceInUseException: Addon already exists.
```

EKS Auto Mode installs the `amazon-cloudwatch-observability` addon **out-of-band**. v6.0 never managed it (zero `aws_eks_addon` resources), so on the v6.0→v6.1 upgrade the new `aws_eks_addon` collides with the pre-existing addon. `resolve_conflicts_on_create = "OVERWRITE"` only resolves *field-level* conflicts — it does **not** adopt a pre-existing addon (the resource's own comment documented this as a required manual remove/import step). The same race can hit **fresh installs** too.

## Fix

A `null_resource` deletes any pre-existing addon with `--preserve` (the in-cluster `cloudwatch-agent` DaemonSet keeps running → **no observability gap**) immediately before Terraform creates and manages it:

- `describe-addon` guard → no-op when the addon isn't present
- `delete-addon --preserve` + `wait addon-deleted` so the subsequent create can't 409
- `triggers` on cluster name → runs once per cluster
- `aws_eks_addon` gets `depends_on` the adopt step

Matches the existing `null_resource` + aws-cli adopt pattern in `bi.tf`. Makes both upgrades and fresh installs hands-off, removing the documented manual step.

## Validation

`tofu fmt` clean; embedded script `bash -n` clean. Authoritative validation is the upgrade harness — once merged + synced to `v6.1-release`, the `min_default` run should pass the addon step.