### PR TITLE
feat(logical): expose gateway via Azure LoadBalancer with DNS label

### DIFF
--- a/terraform/logical/kubernetes.tf
+++ b/terraform/logical/kubernetes.tf
@@ -420,10 +420,18 @@ resource "helm_release" "app" {
   wait    = true
   timeout = 900
 
-  # GHCR pull secret for MPC images (Azure only). On AWS this is an empty
-  # list of values files — a no-op, no value overrides applied.
+  # Azure-only values: GHCR pull secret for MPC images, and expose the gateway
+  # via an Azure public LoadBalancer (no NLB on Azure). An azure-dns-label-name
+  # annotation gives the LB a stable <label>.<region>.cloudapp.azure.com FQDN.
+  # On AWS this is an empty list of values files — a no-op, no overrides applied.
   values = var.cloud == "azure" ? [yamlencode({
     global = { imagePullSecrets = [{ name = "ghcr-pull" }] }
+    gateway = {
+      service = {
+        type        = "LoadBalancer"
+        annotations = var.gateway_dns_label != "" ? { "service.beta.kubernetes.io/azure-dns-label-name" = var.gateway_dns_label } : {}
+      }
+    }
   })] : []
 
   # helm provider 3.x: set/set_sensitive are list-of-object attributes, not

--- a/terraform/logical/variables.tf
+++ b/terraform/logical/variables.tf
@@ -393,3 +393,9 @@ variable "operator_image_tag" {
   type        = string
   default     = "3.0.3"
 }
+
+variable "gateway_dns_label" {
+  description = "Azure DNS label for the gateway LoadBalancer (azure). Yields <label>.<region>.cloudapp.azure.com. Empty = LB public IP with no DNS label."
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
## Summary
Gives the Azure MPC stack a real external entrypoint (AWS fronts the gateway with an NLB; Azure had none, leaving the gateway ClusterIP-only). Requires the chart change that makes the envoy service type/annotations configurable.

- Azure-only: set `gateway.service.type=LoadBalancer` and, when `gateway_dns_label` is set, the `service.beta.kubernetes.io/azure-dns-label-name` annotation so the public LB gets a stable `<label>.<region>.cloudapp.azure.com` FQDN.
- New variable `gateway_dns_label` (default empty).

AWS is unaffected: the override lives in the existing `var.cloud == "azure"` values block; the AWS path applies no overrides.

## Test Plan
- [ ] AWS zero-diff (change is inside the azure-only values block).
- [ ] Azure deploy: gateway Service becomes type LoadBalancer with a public IP and the DNS label resolves.