### PR TITLE
feat(logical): azure auto-DNS (external-dns) + Let's Encrypt TLS

### DIFF
--- a/terraform/logical/external_dns.tf
+++ b/terraform/logical/external_dns.tf
@@ -1,0 +1,67 @@
+# external-dns on AKS (azure only): assumes an AWS IAM role via AKS workload
+# identity (projected token, audience sts.amazonaws.com) and publishes the
+# dozuki.cloud record for the gateway into Route53. Enabled when an AWS role ARN
+# is provided. AWS is unaffected (count = 0).
+
+locals {
+  external_dns_enabled = var.cloud == "azure" && var.aws_external_dns_role_arn != ""
+  azure_region         = var.cloud == "azure" ? data.azurerm_kubernetes_cluster.main[0].location : ""
+  lb_fqdn              = var.gateway_dns_label != "" ? "${var.gateway_dns_label}.${local.azure_region}.cloudapp.azure.com" : ""
+}
+
+resource "helm_release" "external_dns" {
+  count = local.external_dns_enabled ? 1 : 0
+
+  name       = "external-dns"
+  namespace  = kubernetes_namespace_v1.app.metadata[0].name
+  repository = "https://kubernetes-sigs.github.io/external-dns/"
+  chart      = "external-dns"
+  version    = "1.15.2"
+  wait       = true
+  timeout    = 300
+
+  values = [yamlencode({
+    provider = { name = "aws" }
+    sources  = ["gateway-httproute"]
+
+    serviceAccount = {
+      create = true
+      name   = var.external_dns_sa_name
+    }
+
+    extraVolumes = [{
+      name = "aws-token"
+      projected = {
+        sources = [{
+          serviceAccountToken = {
+            audience          = "sts.amazonaws.com"
+            expirationSeconds = 3600
+            path              = "token"
+          }
+        }]
+      }
+    }]
+    extraVolumeMounts = [{
+      name      = "aws-token"
+      mountPath = "/var/run/secrets/aws"
+      readOnly  = true
+    }]
+    env = [
+      { name = "AWS_ROLE_ARN", value = var.aws_external_dns_role_arn },
+      { name = "AWS_WEB_IDENTITY_TOKEN_FILE", value = "/var/run/secrets/aws/token" },
+      { name = "AWS_REGION", value = "us-east-1" },
+    ]
+
+    extraArgs = [
+      "--domain-filter=dozuki.cloud",
+      "--registry=txt",
+      "--txt-owner-id=azure-mpc-${var.environment}",
+      "--policy=sync",
+      "--aws-zone-type=public",
+    ]
+  })]
+}
+# NOTE: no azure.workload.identity label is needed — this federates to AWS, not
+# Azure AD. The projected serviceAccountToken with audience sts.amazonaws.com is
+# a standard Kubernetes feature (TokenRequest), independent of the Azure
+# workload-identity webhook.

--- a/terraform/logical/kubernetes.tf
+++ b/terraform/logical/kubernetes.tf
@@ -401,7 +401,7 @@ resource "aws_eks_addon" "cloudwatch_observability" {
 }
 
 resource "helm_release" "app" {
-  depends_on = [helm_release.cert_manager, helm_release.envoy_gateway, helm_release.external_secrets, kubernetes_service_account_v1.eso_vault_auth, kubernetes_secret_v1.ghcr_pull, aws_eks_addon.cloudwatch_observability, helm_release.seaweedfs, kubernetes_job_v1.seaweedfs_buckets, kubernetes_secret_v1.gateway_tls]
+  depends_on = [helm_release.cert_manager, helm_release.envoy_gateway, helm_release.external_secrets, kubernetes_service_account_v1.eso_vault_auth, kubernetes_secret_v1.ghcr_pull, aws_eks_addon.cloudwatch_observability, helm_release.seaweedfs, kubernetes_job_v1.seaweedfs_buckets, kubernetes_secret_v1.gateway_tls, helm_release.external_dns]
 
   name      = "dozuki"
   namespace = kubernetes_namespace_v1.app.metadata[0].name
@@ -424,15 +424,18 @@ resource "helm_release" "app" {
   # via an Azure public LoadBalancer (no NLB on Azure). An azure-dns-label-name
   # annotation gives the LB a stable <label>.<region>.cloudapp.azure.com FQDN.
   # On AWS this is an empty list of values files — a no-op, no overrides applied.
-  values = var.cloud == "azure" ? [yamlencode({
+  values = var.cloud == "azure" ? [yamlencode(merge({
     global = { imagePullSecrets = [{ name = "ghcr-pull" }] }
     gateway = {
       service = {
         type        = "LoadBalancer"
         annotations = var.gateway_dns_label != "" ? { "service.beta.kubernetes.io/azure-dns-label-name" = var.gateway_dns_label } : {}
       }
+      dnsTarget = local.lb_fqdn
     }
-  })] : []
+    }, var.azure_acme_server != "" ? {
+    cert_manager = { acmeServer = var.azure_acme_server }
+  } : {}))] : []
 
   # helm provider 3.x: set/set_sensitive are list-of-object attributes, not
   # repeatable blocks. Section groupings preserved as comments.

--- a/terraform/logical/kubernetes.tf
+++ b/terraform/logical/kubernetes.tf
@@ -472,7 +472,7 @@ resource "helm_release" "app" {
     { name = "ingress.hosts[0].hostname", value = coalesce(var.ingress_hostname, var.dns_domain_name) },
     { name = "gateway.hosts[0].hostname", value = coalesce(var.ingress_hostname, var.dns_domain_name) },
     { name = "gateway.hosts[0].tlsSecretName", value = "tls-secret" },
-    { name = "tls.externallyManaged", value = var.cloud == "azure" ? "true" : "false" },
+    { name = "tls.externallyManaged", value = (var.cloud == "azure" && var.azure_tls_mode != "letsencrypt") ? "true" : "false" },
 
     # --- Webhooks ---
     { name = "webhooks.enabled", value = var.enable_webhooks ? "true" : "false" },

--- a/terraform/logical/tls.tf
+++ b/terraform/logical/tls.tf
@@ -4,8 +4,10 @@
 # self-signed cert for dev smoke testing. AWS is unaffected (count = 0).
 
 locals {
-  tls_supplied   = var.cloud == "azure" && var.tls_cert != "" && var.tls_key != ""
-  tls_selfsigned = var.cloud == "azure" && !local.tls_supplied
+  # letsencrypt mode: cert-manager owns tls-secret, so Terraform creates nothing.
+  tls_supplied   = var.cloud == "azure" && var.azure_tls_mode == "supplied" && var.tls_cert != "" && var.tls_key != ""
+  tls_selfsigned = var.cloud == "azure" && var.azure_tls_mode == "self-signed"
+  tls_managed_tf = local.tls_supplied || local.tls_selfsigned
 }
 
 resource "tls_private_key" "gateway" {
@@ -35,7 +37,7 @@ resource "tls_self_signed_cert" "gateway" {
 }
 
 resource "kubernetes_secret_v1" "gateway_tls" {
-  count = var.cloud == "azure" ? 1 : 0
+  count = local.tls_managed_tf ? 1 : 0
 
   metadata {
     name      = "tls-secret"

--- a/terraform/logical/variables.tf
+++ b/terraform/logical/variables.tf
@@ -422,3 +422,9 @@ variable "azure_acme_server" {
   type        = string
   default     = ""
 }
+
+variable "external_dns_sa_name" {
+  description = "external-dns service account name (must match the AWS role trust subject)."
+  type        = string
+  default     = "external-dns"
+}

--- a/terraform/logical/variables.tf
+++ b/terraform/logical/variables.tf
@@ -399,3 +399,26 @@ variable "gateway_dns_label" {
   type        = string
   default     = ""
 }
+
+variable "aws_external_dns_role_arn" {
+  description = "AWS IAM role ARN that external-dns assumes via AKS workload identity (azure). Empty = external-dns disabled."
+  type        = string
+  default     = ""
+}
+
+variable "azure_tls_mode" {
+  description = "Azure gateway TLS strategy: self-signed (dev), letsencrypt (cert-manager HTTP-01), or supplied (tls_cert/tls_key)."
+  type        = string
+  default     = "self-signed"
+
+  validation {
+    condition     = contains(["self-signed", "letsencrypt", "supplied"], var.azure_tls_mode)
+    error_message = "azure_tls_mode must be self-signed, letsencrypt, or supplied."
+  }
+}
+
+variable "azure_acme_server" {
+  description = "ACME directory URL for the cert-issuer when azure_tls_mode=letsencrypt. Empty = chart default (LE prod). Use the staging URL during bring-up."
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
Adds azure_tls_mode (self-signed/letsencrypt/supplied) plus external-dns on AKS that assumes an AWS role via workload identity (projected serviceAccountToken, audience sts.amazonaws.com) to publish the dozuki.cloud CNAME into Route53, and wires gateway.dnsTarget + cert_manager.acmeServer into the azure-only Helm values block.

AWS no-op: all new behavior is azure-gated (external-dns count=0 on AWS; values block only emitted when cloud==azure). Requires the infra-tf azure-mpc-dns role ARN + the gateway chart at deploy time. Gate merge on a terragrunt plan showing zero AWS changes.