### PR TITLE
chore(v6.1): chart_version 0.3.6 + 30m EKS cluster delete timeout

### DIFF
--- a/terraform/logical/variables.tf
+++ b/terraform/logical/variables.tf
@@ -360,7 +360,7 @@ variable "rustici_managed_password" {
 variable "chart_version" {
   description = "Dozuki chart version pulled from the registry (oci://<image_repository>/charts/dozuki)."
   type        = string
-  default     = "0.3.0"
+  default     = "0.3.6"
 }
 
 variable "ghcr_pull_username" {

--- a/terraform/physical/eks.tf
+++ b/terraform/physical/eks.tf
@@ -199,6 +199,14 @@ module "eks_cluster" {
 
   depends_on = [aws_iam_policy.cluster_access, aws_iam_policy.eks_worker]
 
+  # The default 15m cluster-delete timeout can be exceeded when the cluster still has
+  # load-balancer/ENI resources to clean up (e.g. an automated teardown after a failed
+  # logical destroy leaves Service-type LoadBalancers behind). Give it headroom so the
+  # teardown completes instead of timing out mid-DELETING and stranding the VPC.
+  timeouts = {
+    delete = "30m"
+  }
+
   name = local.identifier
   # Default null lets EKS Auto Mode manage version via upgrade_policy.
   # Set eks_k8s_version to pin a specific version if needed.


### PR DESCRIPTION
Two small v6.1-readiness changes, both surfaced by the upgrade harness.

## `chart_version` default 0.3.0 → 0.3.6 (logical)
Picks up the db-migrations Job immutable-patch fix ([Dozuki/helm#48](https://github.com/Dozuki/helm/pull/48), published as chart `0.3.6`). Without it, v6.0→v6.1 upgrades fail with `cannot patch "dozuki-db-migrations" ... spec.template: field is immutable`. (The harness matrix's `v6.1-release` profile is bumped to `0.3.6` separately on the harness branch.)

## EKS cluster `timeouts.delete = 30m` (physical)
The module default is 15m. On teardown after a failed logical destroy, the cluster can still have Service-type LoadBalancers / ENIs to clean up, and the delete waiter timed out mid-`DELETING` — the cluster finished async but Terraform aborted and stranded the VPC tail. 30m gives the automated teardown headroom to complete.

Both verified with `tofu fmt`.