### PR TITLE
fix(logical): azure deploy fixes — external-dns flags/txtPrefix + S3 region

### DIFF
--- a/terraform/logical/external_dns.tf
+++ b/terraform/logical/external_dns.tf
@@ -20,9 +20,21 @@ resource "helm_release" "external_dns" {
   wait       = true
   timeout    = 300
 
+  # Use the chart's native value keys (it generates --registry/--policy/--source/
+  # --domain-filter/--txt-owner-id/--aws-zone-type itself). Do NOT also pass these
+  # via extraArgs — the chart already emits --registry by default, so duplicating
+  # any of them is a fatal "flag cannot be repeated".
   values = [yamlencode({
-    provider = { name = "aws" }
-    sources  = ["gateway-httproute"]
+    provider      = { name = "aws" }
+    sources       = ["gateway-httproute"]
+    domainFilters = ["dozuki.cloud"]
+    policy        = "sync"
+    registry      = "txt"
+    txtOwnerId    = "azure-mpc-${var.environment}"
+    # Prefix ownership TXT records so they never sit at the same name as a managed
+    # CNAME (a TXT and CNAME can't coexist at one name — Route53 rejects the batch).
+    txtPrefix = "edns-"
+    aws       = { zoneType = "public" }
 
     serviceAccount = {
       create = true
@@ -50,14 +62,6 @@ resource "helm_release" "external_dns" {
       { name = "AWS_ROLE_ARN", value = var.aws_external_dns_role_arn },
       { name = "AWS_WEB_IDENTITY_TOKEN_FILE", value = "/var/run/secrets/aws/token" },
       { name = "AWS_REGION", value = "us-east-1" },
-    ]
-
-    extraArgs = [
-      "--domain-filter=dozuki.cloud",
-      "--registry=txt",
-      "--txt-owner-id=azure-mpc-${var.environment}",
-      "--policy=sync",
-      "--aws-zone-type=public",
     ]
   })]
 }

--- a/terraform/logical/kubernetes.tf
+++ b/terraform/logical/kubernetes.tf
@@ -447,7 +447,7 @@ resource "helm_release" "app" {
     { name = "environment", value = var.environment },
 
     # --- AWS ---
-    { name = "aws.region", value = var.cloud == "aws" ? data.aws_region.current[0].id : "" },
+    { name = "aws.region", value = var.cloud == "aws" ? data.aws_region.current[0].id : "us-east-1" },
     { name = "aws.accountId", value = var.cloud == "aws" ? data.aws_caller_identity.current[0].account_id : "" },
     { name = "aws.enabled", value = var.cloud == "aws" ? "true" : "false" },
 

--- a/terraform/logical/main.tf
+++ b/terraform/logical/main.tf
@@ -149,7 +149,7 @@ locals {
     customer               = { value = coalesce(var.customer, "Dozuki") }
     environment            = { value = var.environment }
     aws_acct_id            = { value = var.cloud == "aws" ? data.aws_caller_identity.current[0].account_id : "" }
-    aws_region             = { value = var.cloud == "aws" ? data.aws_region.current[0].id : "" }
+    aws_region             = { value = var.cloud == "aws" ? data.aws_region.current[0].id : "us-east-1" }
     hostname               = { value = var.dns_domain_name }
     ingress_hostname       = { value = coalesce(var.ingress_hostname, var.dns_domain_name) }
     bi_enabled             = { value = var.enable_bi ? "true" : "false" }


### PR DESCRIPTION
## Summary
Azure-deploy fixes found while bringing the stack up live (all azure-gated; AWS unaffected):

1. **external-dns duplicate flags** — the chart already emits `--registry`/`--policy`/`--source`/`--domain-filter`/`--txt-owner-id` from its own values, so passing them via `extraArgs` was a fatal `flag 'registry' cannot be repeated`. Switched to the chart's native value keys; removed `extraArgs`.
2. **external-dns TXT/CNAME conflict** — added `txtPrefix = "edns-"` so ownership TXTs never collide with the managed CNAME (Route53 `InvalidChangeBatch`).
3. **S3 region empty on azure** — `aws.region` was set to `""` for azure, but the AWS PHP SDK rejects an empty region even for a SeaweedFS endpoint, so the app's S3 client failed to construct → **HTTP 500 on any page rendering a media/CDN URL and all image uploads failed**. Set a non-empty placeholder (`us-east-1`, which SeaweedFS ignores) for non-AWS clouds.

Validated live: external-dns publishes the dozuki.cloud CNAME and the app's S3 client builds (region error gone, uploads work).

## Test Plan
- [ ] AWS zero-diff (all changes azure-gated).
- [ ] Azure: external-dns args unique + CNAME published; `s3.json` region non-empty; image upload + media pages work.