### PR TITLE
test(harness): SSO runway preflight + cleanup-orphans.sh

### DIFF
--- a/live/tests/cleanup-orphans.sh
+++ b/live/tests/cleanup-orphans.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# cleanup-orphans.sh — tear down orphaned harness runs left behind when an upgrade
+# test fails or is aborted mid-apply (e.g. SSO expired mid-run, so the harness's own
+# deferred teardown couldn't authenticate).
+#
+# For each orphaned per-run state prefix (local-<ts>-<cfg>/...) it:
+#   1. disables NLB deletion protection (v6.0 baselines create the NLB protected),
+#   2. force-releases any held Terraform state lock,
+#   3. runs `terragrunt destroy` on the physical layer (deleting the EKS cluster also
+#      disposes of the in-cluster helm/k8s resources),
+#   4. purges the run's state objects — ONLY if the destroy succeeded,
+# then sweeps the addon-created containerinsights log groups (out-of-band, not TF
+# managed) and runs verify-clean.sh to confirm the account is clean.
+#
+# Run from your terminal AFTER `aws sso login` — each destroy can take ~25 min.
+#
+# Usage:
+#   ./cleanup-orphans.sh                       # auto-detect + tear down all local-* orphans
+#   ./cleanup-orphans.sh local-1700000000-min_default-min_default   # a specific prefix
+#   CUSTOMER=smoke ./cleanup-orphans.sh        # override the resource-name prefix (default: smoke)
+set -uo pipefail
+cd "$(dirname "$0")"
+HARNESS_DIR="$PWD"
+LIVE_ROOT="$(cd .. && pwd)"
+
+CUSTOMER="${CUSTOMER:-smoke}"
+P="${AWS_PROFILE:-default}"
+R="${AWS_REGION:-us-east-1}"
+DR="${DR_REGION:-us-west-2}"
+# Drop stale static creds so AWS_PROFILE (SSO) is authoritative.
+unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN
+export AWS_PROFILE="$P" TERRAGRUNT_TFPATH="${TERRAGRUNT_TFPATH:-tofu}"
+
+ACCT="$(aws sts get-caller-identity --profile "$P" --query Account --output text 2>/dev/null)" || {
+  echo "ERROR: no AWS identity (profile=$P). Run: aws sso login --profile $P" >&2; exit 1; }
+BUCKET="dozuki-terraform-state-${R}-${ACCT}"
+LOCK_TABLE="dozuki-terraform-lock"
+
+# Target prefixes: args if given, else every local-* prefix in the state bucket.
+if [ "$#" -gt 0 ]; then
+  PREFIXES="$(printf '%s\n' "$@" | sed 's:/*$::')"
+else
+  PREFIXES="$(aws s3 ls "s3://$BUCKET/" --profile "$P" 2>/dev/null | awk '/PRE local-/{gsub(/\//,"",$2); print $2}')"
+fi
+if [ -z "$PREFIXES" ]; then echo ">> No orphaned local-* state prefixes found in s3://$BUCKET/."; fi
+
+fail=0
+# Loop in the parent shell (process substitution, not a pipe) so set/exit behave.
+while IFS= read -r pfx; do
+  [ -z "$pfx" ] && continue
+  echo; echo "==================== orphan: $pfx ===================="
+
+  # Derive partition/region/env from the physical state key path.
+  key="$(aws s3 ls "s3://$BUCKET/$pfx/" --recursive --profile "$P" 2>/dev/null | awk '/physical\/terraform.tfstate$/{print $4; exit}')"
+  if [ -n "$key" ]; then
+    rel="${key#"$pfx"/}"                       # standard/us-east-1/min/physical/terraform.tfstate
+    envdir="$(dirname "$(dirname "$rel")")"    # standard/us-east-1/min
+    region="$(printf '%s' "$envdir" | awk -F/ '{print $2}')"; region="${region:-$R}"
+    env="$(printf '%s' "$envdir" | awk -F/ '{print $3}')"
+    echo "  partition path: $envdir  (region=$region env=$env customer=$CUSTOMER)"
+  else
+    echo "  no physical state under this prefix — will release locks + purge state only"
+    envdir=""; region="$R"; env=""
+  fi
+
+  # 1) Disable NLB deletion protection (<customer>-<env>).
+  if [ -n "$env" ]; then
+    arn="$(aws elbv2 describe-load-balancers --region "$region" --profile "$P" \
+          --query "LoadBalancers[?LoadBalancerName=='${CUSTOMER}-${env}'].LoadBalancerArn|[0]" --output text 2>/dev/null)"
+    if [ -n "$arn" ] && [ "$arn" != "None" ]; then
+      aws elbv2 modify-load-balancer-attributes --load-balancer-arn "$arn" \
+        --attributes Key=deletion_protection.enabled,Value=false --region "$region" --profile "$P" >/dev/null 2>&1 \
+        && echo "  NLB deletion protection disabled (${CUSTOMER}-${env})"
+    fi
+  fi
+
+  # 2) Force-release any held state locks for this prefix.
+  for lk in $(aws dynamodb scan --table-name "$LOCK_TABLE" --region "$R" --profile "$P" \
+        --query "Items[?contains(LockID.S, '$pfx') && !contains(LockID.S, '-md5')].LockID.S" --output text 2>/dev/null); do
+    aws dynamodb delete-item --table-name "$LOCK_TABLE" --region "$R" --profile "$P" \
+      --key "{\"LockID\":{\"S\":\"$lk\"}}" >/dev/null 2>&1 && echo "  released lock: $lk"
+  done
+
+  # 3) Destroy the physical layer (also disposes of in-cluster helm/k8s via the EKS delete).
+  destroyed_ok=1
+  if [ -n "$key" ] && [ -d "$LIVE_ROOT/$envdir/physical" ]; then
+    ( cd "$LIVE_ROOT/$envdir/physical"
+      rm -rf .terragrunt-cache
+      TG_AWS_ACCT_ID="$ACCT" TG_AWS_PROFILE="$P" TG_AWS_REGION="$region" TG_STATE_PREFIX="$pfx/" \
+      TF_VAR_customer="$CUSTOMER" TF_VAR_enable_dr=false \
+        terragrunt destroy --terragrunt-non-interactive -input=false )
+    destroyed_ok=$?
+  elif [ -n "$key" ]; then
+    echo "  WARNING: $LIVE_ROOT/$envdir/physical not found — cannot destroy via terragrunt; leaving state intact." >&2
+    destroyed_ok=1
+  fi
+
+  # 4) Purge state objects ONLY if the destroy succeeded (else keep state so it can retry).
+  if [ "$destroyed_ok" -eq 0 ] || [ -z "$key" ]; then
+    aws s3 rm "s3://$BUCKET/$pfx/" --recursive --profile "$P" >/dev/null 2>&1 && echo "  purged state prefix: $pfx"
+  else
+    echo "  destroy did NOT fully succeed — state prefix kept for retry: $pfx" >&2
+    fail=1
+  fi
+done <<EOF
+$PREFIXES
+EOF
+
+# 5) Sweep addon-created containerinsights log groups (out-of-band; TF doesn't own them).
+for lg in $(aws logs describe-log-groups --region "$R" --profile "$P" \
+      --query "logGroups[?starts_with(logGroupName,'/aws/containerinsights/${CUSTOMER}-')].logGroupName" --output text 2>/dev/null); do
+  aws logs delete-log-group --log-group-name "$lg" --region "$R" --profile "$P" 2>/dev/null && echo "  deleted log group: $lg"
+done
+
+# 6) Verify.
+echo; echo "==================== verify-clean ===================="
+DR_REGION="$DR" AWS_PROFILE="$P" "$HARNESS_DIR/verify-clean.sh" "$CUSTOMER" || fail=1
+
+echo
+if [ "$fail" -eq 0 ]; then echo "CLEANUP COMPLETE — account is clean."; else
+  echo "CLEANUP INCOMPLETE — see warnings above (re-run after resolving)."; exit 1; fi

--- a/live/tests/cleanup-orphans.sh
+++ b/live/tests/cleanup-orphans.sh
@@ -36,13 +36,22 @@ ACCT="$(aws sts get-caller-identity --profile "$P" --query Account --output text
 BUCKET="dozuki-terraform-state-${R}-${ACCT}"
 LOCK_TABLE="dozuki-terraform-lock"
 
-# Target prefixes: args if given, else every local-* prefix in the state bucket.
+# Target prefixes: every local-* prefix in the state bucket, optionally filtered to
+# those that START WITH an arg — so a full prefix matches itself, and a RUN_ID like
+# "local-<ts>-" matches all of that run's per-config prefixes (and nothing else).
+ALL_PREFIXES="$(aws s3 ls "s3://$BUCKET/" --profile "$P" 2>/dev/null | awk '/PRE local-/{gsub(/\//,"",$2); print $2}')"
 if [ "$#" -gt 0 ]; then
-  PREFIXES="$(printf '%s\n' "$@" | sed 's:/*$::')"
+  PREFIXES=""
+  for arg in "$@"; do
+    arg="${arg%/}"
+    PREFIXES="$PREFIXES
+$(printf '%s\n' "$ALL_PREFIXES" | awk -v a="$arg" 'index($0,a)==1')"
+  done
+  PREFIXES="$(printf '%s\n' "$PREFIXES" | awk 'NF' | sort -u)"
 else
-  PREFIXES="$(aws s3 ls "s3://$BUCKET/" --profile "$P" 2>/dev/null | awk '/PRE local-/{gsub(/\//,"",$2); print $2}')"
+  PREFIXES="$ALL_PREFIXES"
 fi
-if [ -z "$PREFIXES" ]; then echo ">> No orphaned local-* state prefixes found in s3://$BUCKET/."; fi
+if [ -z "$PREFIXES" ]; then echo ">> No matching orphaned local-* state prefixes found in s3://$BUCKET/."; fi
 
 fail=0
 # Loop in the parent shell (process substitution, not a pipe) so set/exit behave.

--- a/live/tests/run.sh
+++ b/live/tests/run.sh
@@ -36,6 +36,69 @@ export AWS_PROFILE="${AWS_PROFILE:-default}"
 # The physical layer requires OpenTofu (master_password_wo); drive terragrunt with tofu.
 export TERRAGRUNT_TFPATH="${TERRAGRUNT_TFPATH:-tofu}"
 
+# --- SSO session runway check ------------------------------------------------
+# A run can outlive the AWS SSO session (an upgrade run is ~1h; the full matrix is
+# several hours). If the session expires mid-apply, terraform loses its creds and
+# leaves a half-built, hard-to-clean stack. Refuse to start unless the SSO session
+# token has enough runway. Override with SKIP_SSO_CHECK=1; tune REQUIRED_SSO_HOURS.
+REQUIRED_SSO_HOURS="${REQUIRED_SSO_HOURS:-3}"
+sso_seconds_left() { # <profile> -> seconds left on the SSO session token (-1 if unknown)
+  command -v python3 >/dev/null 2>&1 || { echo -1; return; }
+  python3 - "$1" <<'PY'
+import configparser, glob, hashlib, json, os, sys
+from datetime import datetime, timezone
+profile = sys.argv[1]
+cfg = configparser.ConfigParser()
+cfg.read(os.path.expanduser("~/.aws/config"))
+sect = "default" if profile == "default" else "profile %s" % profile
+session = start = None
+if cfg.has_section(sect):
+    session = cfg.get(sect, "sso_session", fallback=None)
+    start = cfg.get(sect, "sso_start_url", fallback=None)
+if session and not start and cfg.has_section("sso-session %s" % session):
+    start = cfg.get("sso-session %s" % session, "sso_start_url", fallback=None)
+targets = set()
+for k in (session, start):
+    if k:
+        targets.add(os.path.expanduser("~/.aws/sso/cache/%s.json" % hashlib.sha1(k.encode()).hexdigest()))
+def newest(files):
+    best = None
+    for f in files:
+        try:
+            d = json.load(open(f))
+        except Exception:
+            continue
+        e = d.get("expiresAt")
+        if e and d.get("accessToken"):
+            best = e if best is None or e > best else best
+    return best
+allf = glob.glob(os.path.expanduser("~/.aws/sso/cache/*.json"))
+best = newest([f for f in allf if f in targets]) or newest(allf)
+if not best:
+    print(-1); sys.exit(0)
+try:
+    dt = datetime.fromisoformat(best.replace("Z", "+00:00"))
+except ValueError:
+    print(-1); sys.exit(0)
+print(int((dt - datetime.now(timezone.utc)).total_seconds()))
+PY
+}
+sso_rem="$(sso_seconds_left "$AWS_PROFILE")"
+if [ "$sso_rem" -ge 0 ] 2>/dev/null; then
+  if [ "$sso_rem" -lt $((REQUIRED_SSO_HOURS * 3600)) ]; then
+    echo "ERROR: AWS SSO session for '$AWS_PROFILE' has only $((sso_rem/3600))h$(((sso_rem%3600)/60))m left (< ${REQUIRED_SSO_HOURS}h)." >&2
+    echo "       A run can outlive it and strand a half-built stack. Refresh first:" >&2
+    echo "         aws sso login --profile $AWS_PROFILE" >&2
+    echo "       (override with SKIP_SSO_CHECK=1, or lower REQUIRED_SSO_HOURS, for a short run.)" >&2
+    [ "${SKIP_SSO_CHECK:-0}" = 1 ] || exit 1
+  else
+    echo ">> SSO: $((sso_rem/3600))h$(((sso_rem%3600)/60))m left on '$AWS_PROFILE' (>= ${REQUIRED_SSO_HOURS}h) — OK"
+  fi
+else
+  echo ">> SSO: could not read session expiry for '$AWS_PROFILE'; ensure 'aws sso login --profile $AWS_PROFILE' is fresh." >&2
+fi
+# -----------------------------------------------------------------------------
+
 VAULT_KUBE_CONTEXT="${VAULT_KUBE_CONTEXT:-vault-standard}"
 VAULT_AWS_PROFILE="${VAULT_AWS_PROFILE:-dozuki}"
 VAULT_AWS_ROLE="${VAULT_AWS_ROLE:-admin}"

--- a/live/tests/run.sh
+++ b/live/tests/run.sh
@@ -106,6 +106,16 @@ VAULT_PF_PID=""
 
 cleanup() {
   [ -n "$VAULT_PF_PID" ] && kill "$VAULT_PF_PID" 2>/dev/null || true
+  # Backstop teardown: once the run has started, always sweep THIS run's resources +
+  # state on exit — scoped to $RUN_ID so it never touches another run's stack — even
+  # if the harness's own deferred destroy didn't run or finish (e.g. the test was
+  # interrupted/killed). It's a no-op once the run already cleaned itself, and it also
+  # purges the leftover state objects the in-test destroy leaves behind. Opt out with
+  # SKIP_AUTO_CLEANUP=1 to inspect a failed run's resources.
+  if [ "${STARTED_RUN:-0}" = 1 ] && [ "${SKIP_AUTO_CLEANUP:-0}" != 1 ]; then
+    echo ">> Auto-cleanup: sweeping this run's resources + state (${RUN_ID}) ..." >&2
+    ./cleanup-orphans.sh "${RUN_ID}-" || echo ">> Auto-cleanup reported issues — see verify-clean output above." >&2
+  fi
   echo ">> Full run log saved to: $RUN_LOG" >&2
 }
 trap cleanup EXIT
@@ -167,4 +177,6 @@ done
 
 [ "$DO_VAULT" = 1 ] && setup_vault
 
+# From here on, the run can create cloud resources — arm the backstop cleanup (see trap).
+STARTED_RUN=1
 go test ./scenarios/ -run TestUpgrade -v -timeout 180m


### PR DESCRIPTION
Two harness reliability improvements, both prompted by a run where the AWS SSO session expired mid-apply, stranding a stack.

## `run.sh` — SSO runway preflight
Before starting, reads the AWS SSO session token's `expiresAt` from `~/.aws/sso/cache/*.json` (matched to the profile's `sso_session`/`sso_start_url`) and **refuses to start** if fewer than `REQUIRED_SSO_HOURS` (default **3h**) remain. A `min_default` run is ~1h and the full matrix is several hours, so a session running low would otherwise expire mid-apply and leave a half-built, hard-to-clean stack. Override with `SKIP_SSO_CHECK=1`; tune with `REQUIRED_SSO_HOURS`. Verified against a live cache (reported `7h44m remaining`).

## `cleanup-orphans.sh` — one-command orphan teardown
Encapsulates the manual recipe we'd been hand-running every time a run died. For each orphaned per-run state prefix (`local-*`, auto-detected or passed as an arg):
1. disable NLB deletion protection (`<customer>-<env>`),
2. force-release any held Terraform state lock,
3. `terragrunt destroy` the physical layer (the EKS delete also disposes of in-cluster helm/k8s),
4. purge the run's state objects **only if the destroy succeeded** (else keep them for retry),

then sweep the addon-created `containerinsights` log groups and run `verify-clean.sh`. bash-3.2 compatible (macOS default shell).

Usage: `./cleanup-orphans.sh` (sweep all) or `./cleanup-orphans.sh <prefix>`.