### PR TITLE
feat(logical): serve azure objects from a public S3 host (image display)

### DIFF
--- a/terraform/logical/coredns_objects.tf
+++ b/terraform/logical/coredns_objects.tf
@@ -1,0 +1,49 @@
+# In-cluster split-horizon DNS for the public object host (azure only). Browsers
+# resolve s3.<domain> to the public LB (external-dns CNAME); in-cluster pods must
+# resolve it to the Envoy Gateway service so the app's own object ops terminate
+# TLS at the gateway (which fronts the plain-HTTP seaweedfs-s3:8333) instead of
+# hairpinning to the Azure LB (unsupported). The presign signature is bound to the
+# Host header (s3.<domain>), unchanged, so signatures stay valid.
+
+locals {
+  objects_public_host = var.cloud == "azure" && var.gateway_dns_label != "" ? "s3.${var.dns_domain_name}" : ""
+  coredns_objects_on  = local.objects_public_host != ""
+}
+
+# Discover the Envoy Gateway data-plane Service (hashed name). Created by the Envoy
+# Gateway controller once the Gateway exists; the app release (which creates the
+# Gateway) is the dependency, so by apply time the Service exists.
+data "kubernetes_resources" "envoy_gateway_svc" {
+  count          = local.coredns_objects_on ? 1 : 0
+  api_version    = "v1"
+  kind           = "Service"
+  namespace      = "envoy-gateway-system"
+  label_selector = "gateway.envoyproxy.io/owning-gateway-name=${var.gateway_name}"
+  depends_on     = [helm_release.app]
+}
+
+locals {
+  gateway_svc_cluster_ip = local.coredns_objects_on ? try(data.kubernetes_resources.envoy_gateway_svc[0].objects[0].spec.clusterIP, "") : ""
+}
+
+# AKS merges *.override keys into the default CoreDNS server block. A hosts entry
+# makes in-cluster lookups of the object host return the gateway ClusterIP;
+# fallthrough preserves all other resolution. Count is gated on the static azure
+# local (NOT the discovered IP) so it is known at plan time.
+resource "kubernetes_config_map_v1" "coredns_objects" {
+  count = local.coredns_objects_on ? 1 : 0
+
+  metadata {
+    name      = "coredns-custom"
+    namespace = "kube-system"
+  }
+
+  data = {
+    "dozuki-objects.override" = <<-EOT
+      hosts {
+        ${local.gateway_svc_cluster_ip} ${local.objects_public_host}
+        fallthrough
+      }
+    EOT
+  }
+}

--- a/terraform/logical/kubernetes.tf
+++ b/terraform/logical/kubernetes.tf
@@ -505,7 +505,8 @@ resource "helm_release" "app" {
 
     # --- In-cluster services (Azure) ---
     { name = "memcached.enabled", value = var.cloud == "azure" ? "true" : "false" },
-    { name = "objectStorage.endpoint", value = var.cloud == "azure" ? local.seaweedfs_s3_endpoint : "" },
+    { name = "objectStorage.endpoint", value = var.cloud == "azure" ? "https://s3.${var.dns_domain_name}" : "" },
+    { name = "objectStorage.publicHost", value = var.cloud == "azure" ? "s3.${var.dns_domain_name}" : "" },
 
     # --- Grafana ---
     { name = "grafana.enabled", value = var.enable_bi ? "true" : "false" },

--- a/terraform/logical/variables.tf
+++ b/terraform/logical/variables.tf
@@ -428,3 +428,9 @@ variable "external_dns_sa_name" {
   type        = string
   default     = "external-dns"
 }
+
+variable "gateway_name" {
+  description = "Envoy Gateway resource name (matches the chart gateway.name); used to discover its in-cluster data-plane Service for the object-host CoreDNS split-horizon."
+  type        = string
+  default     = "dozuki-gateway"
+}


### PR DESCRIPTION
Repoints the azure object endpoint to https://s3.<domain> + sets objectStorage.publicHost (chart 0.3.8 exposes it via the gateway), and adds a CoreDNS split-horizon (coredns-custom) so app pods reach the object host in-cluster via the Envoy Gateway (no Azure LB hairpin). AWS no-op (all azure-gated). Requires chart 0.3.8 at deploy time. Merge gate: terragrunt plan = zero AWS changes.