### PR TITLE
test(harness): cleanup-orphans disables the stack's central-Vault auth mount

### DIFF
--- a/live/tests/cleanup-orphans.sh
+++ b/live/tests/cleanup-orphans.sh
@@ -54,6 +54,7 @@ fi
 if [ -z "$PREFIXES" ]; then echo ">> No matching orphaned local-* state prefixes found in s3://$BUCKET/."; fi
 
 fail=0
+STACKS=""   # collected <customer>-<env> stacks, for central-Vault cleanup after teardown
 # Loop in the parent shell (process substitution, not a pipe) so set/exit behave.
 while IFS= read -r pfx; do
   [ -z "$pfx" ] && continue
@@ -66,6 +67,7 @@ while IFS= read -r pfx; do
     envdir="$(dirname "$(dirname "$rel")")"    # standard/us-east-1/min
     region="$(printf '%s' "$envdir" | awk -F/ '{print $2}')"; region="${region:-$R}"
     env="$(printf '%s' "$envdir" | awk -F/ '{print $3}')"
+    [ -n "$env" ] && STACKS="$STACKS ${CUSTOMER}-${env}"
     echo "  partition path: $envdir  (region=$region env=$env customer=$CUSTOMER)"
   else
     echo "  no physical state under this prefix — will release locks + purge state only"
@@ -121,7 +123,43 @@ for lg in $(aws logs describe-log-groups --region "$R" --profile "$P" \
   aws logs delete-log-group --log-group-name "$lg" --region "$R" --profile "$P" 2>/dev/null && echo "  deleted log group: $lg"
 done
 
-# 6) Verify.
+# 6) Central Vault cleanup: disable each stack's k8s auth mount + delete its policy.
+# The mount k8s/<customer>-<env> lives in the central Vault (account 0106), keyed by
+# stack name, and is NOT torn down with the AWS stack. A leftover mount makes the next
+# run's `vault_auth_backend` create fail ("path already in use"), so kubernetes_host
+# stays pointed at the old cluster -> ESO gets 403 -> pods can't mount their secret ->
+# helm hangs. Reuses an inherited VAULT_ADDR/VAULT_TOKEN (e.g. from run.sh's trap) or
+# brings up its own tunnel + AWS-auth login. Skip with SKIP_VAULT_CLEANUP=1.
+STACKS="$(printf '%s\n' $STACKS | awk 'NF' | sort -u)"
+if [ -n "$STACKS" ] && [ "${SKIP_VAULT_CLEANUP:-0}" != 1 ]; then
+  echo; echo "==================== central-Vault cleanup ===================="
+  VPF=""
+  if [ -z "${VAULT_ADDR:-}" ] || [ -z "${VAULT_TOKEN:-}" ]; then
+    VCTX="${VAULT_KUBE_CONTEXT:-vault-standard}"; VPROF="${VAULT_AWS_PROFILE:-dozuki}"; VROLE="${VAULT_AWS_ROLE:-admin}"
+    if command -v vault >/dev/null 2>&1 && command -v kubectl >/dev/null 2>&1 && command -v python3 >/dev/null 2>&1 \
+       && aws sts get-caller-identity --profile "$VPROF" >/dev/null 2>&1; then
+      kubectl --context "$VCTX" port-forward -n vault svc/vault-active 8204:8200 >/tmp/cleanup-vpf.log 2>&1 &
+      VPF=$!; sleep 4
+      export VAULT_ADDR="http://127.0.0.1:8204"
+      VAULT_TOKEN="$( eval "$(aws --profile "$VPROF" configure export-credentials --format env 2>/dev/null)"; \
+        vault login -method=aws role="$VROLE" -format=json 2>/dev/null | python3 -c 'import sys,json;print(json.load(sys.stdin)["auth"]["client_token"])' 2>/dev/null )"
+      export VAULT_TOKEN
+    fi
+  fi
+  if [ -n "${VAULT_TOKEN:-}" ]; then
+    for stack in $STACKS; do
+      vault auth disable "k8s/$stack" >/dev/null 2>&1 && echo "  vault: disabled auth mount k8s/$stack"
+      vault policy delete "$stack" >/dev/null 2>&1 || true
+    done
+  else
+    echo "  WARNING: no Vault access — skipped central-Vault mount cleanup for: $STACKS" >&2
+    echo "           (a leftover k8s/<stack> mount will break the next run; disable it manually or set SKIP_VAULT_CLEANUP=1)" >&2
+    fail=1
+  fi
+  [ -n "$VPF" ] && kill "$VPF" 2>/dev/null || true
+fi
+
+# 7) Verify.
 echo; echo "==================== verify-clean ===================="
 DR_REGION="$DR" AWS_PROFILE="$P" "$HARNESS_DIR/verify-clean.sh" "$CUSTOMER" || fail=1
 

--- a/live/tests/run.sh
+++ b/live/tests/run.sh
@@ -105,17 +105,18 @@ VAULT_AWS_ROLE="${VAULT_AWS_ROLE:-admin}"
 VAULT_PF_PID=""
 
 cleanup() {
-  [ -n "$VAULT_PF_PID" ] && kill "$VAULT_PF_PID" 2>/dev/null || true
   # Backstop teardown: once the run has started, always sweep THIS run's resources +
   # state on exit — scoped to $RUN_ID so it never touches another run's stack — even
   # if the harness's own deferred destroy didn't run or finish (e.g. the test was
-  # interrupted/killed). It's a no-op once the run already cleaned itself, and it also
-  # purges the leftover state objects the in-test destroy leaves behind. Opt out with
-  # SKIP_AUTO_CLEANUP=1 to inspect a failed run's resources.
+  # interrupted/killed). It's a no-op once the run already cleaned itself, also purges
+  # the leftover state objects the in-test destroy leaves, and disables the stack's
+  # central-Vault auth mount. Runs BEFORE the tunnel is torn down so it can reuse this
+  # session's VAULT_ADDR/VAULT_TOKEN for that Vault cleanup. Opt out: SKIP_AUTO_CLEANUP=1.
   if [ "${STARTED_RUN:-0}" = 1 ] && [ "${SKIP_AUTO_CLEANUP:-0}" != 1 ]; then
     echo ">> Auto-cleanup: sweeping this run's resources + state (${RUN_ID}) ..." >&2
     ./cleanup-orphans.sh "${RUN_ID}-" || echo ">> Auto-cleanup reported issues — see verify-clean output above." >&2
   fi
+  [ -n "$VAULT_PF_PID" ] && kill "$VAULT_PF_PID" 2>/dev/null || true
   echo ">> Full run log saved to: $RUN_LOG" >&2
 }
 trap cleanup EXIT


### PR DESCRIPTION
Follow-up to #162 (that PR merged before this commit was added).

**Problem (observed on run local-1781796886):** the v6.0→v6.1 baseline hung because the central Vault auth mount `k8s/smoke-min` (account 0106) survived a prior run. With the harness's fresh per-run state, `vault_auth_backend` create fails `path is already in use`, so `vault_kubernetes_auth_backend_config` never runs and `kubernetes_host` stays pointed at the **old** cluster → ESO gets **403** → pods can't mount `dozuki-infra-credentials` → `helm wait` hangs.

**Fix:** `cleanup-orphans.sh` now disables `k8s/<customer>-<env>` (and deletes the stack policy) for each torn-down stack — reusing an inherited `VAULT_ADDR`/`VAULT_TOKEN` or bringing up its own tunnel + AWS-auth login (`SKIP_VAULT_CLEANUP=1` to skip). `run.sh`'s EXIT trap now runs cleanup-orphans **before** tearing down the Vault tunnel so it can reuse this session's Vault creds. bash-3.2 safe; `bash -n` clean.