### PR TITLE
fix(logical): patch coredns-custom instead of creating it

### DIFF
--- a/terraform/logical/coredns_objects.tf
+++ b/terraform/logical/coredns_objects.tf
@@ -30,7 +30,12 @@ locals {
 # makes in-cluster lookups of the object host return the gateway ClusterIP;
 # fallthrough preserves all other resolution. Count is gated on the static azure
 # local (NOT the discovered IP) so it is known at plan time.
-resource "kubernetes_config_map_v1" "coredns_objects" {
+#
+# AKS pre-creates an empty `coredns-custom` ConfigMap (addon-manager EnsureExists),
+# so we PATCH its data rather than create the object (a create would 409). The
+# _data resource manages only this key via server-side apply; AKS keeps owning the
+# object and its labels.
+resource "kubernetes_config_map_v1_data" "coredns_objects" {
   count = local.coredns_objects_on ? 1 : 0
 
   metadata {
@@ -46,4 +51,7 @@ resource "kubernetes_config_map_v1" "coredns_objects" {
       }
     EOT
   }
+
+  field_manager = "dozuki-mpc-objects"
+  force         = true
 }


### PR DESCRIPTION
## Summary
The object-host CoreDNS split-horizon used `kubernetes_config_map_v1` to create `coredns-custom` in kube-system, but AKS pre-creates that ConfigMap (addon-manager EnsureExists) → `configmaps "coredns-custom" already exists` on apply. Switched to `kubernetes_config_map_v1_data` (server-side apply patch of just the `dozuki-objects.override` key), so AKS keeps owning the object and we only manage our key.

Validated live: the patch applies; after CoreDNS reloads the in-cluster `s3.<domain>` resolves to the Envoy Gateway ClusterIP and the app reaches SeaweedFS in-cluster (403 anon, TLS OK). Browser path unaffected (public LB). AWS no-op (azure-gated).

Note: CoreDNS picks up coredns-custom on its own schedule; a `kubectl -n kube-system rollout restart deploy/coredns` applies it immediately (the public-LB hairpin works as a fallback in the meantime).

## Test Plan
- [ ] AWS zero-diff (azure-gated).
- [ ] Azure: coredns-custom gets dozuki-objects.override with the gateway ClusterIP; in-cluster getent resolves to it.