### PR TITLE
feat: default AWS to in-cluster memcached (destroy ElastiCache)

### DIFF
--- a/terraform/logical/kubernetes.tf
+++ b/terraform/logical/kubernetes.tf
@@ -400,6 +400,10 @@ resource "aws_eks_addon" "cloudwatch_observability" {
   depends_on   = [helm_release.cert_manager]
 }
 
+locals {
+  memcached_in_cluster = var.cloud == "azure" || var.memcached_in_cluster
+}
+
 resource "helm_release" "app" {
   depends_on = [helm_release.cert_manager, helm_release.envoy_gateway, helm_release.external_secrets, kubernetes_service_account_v1.eso_vault_auth, kubernetes_secret_v1.ghcr_pull, aws_eks_addon.cloudwatch_observability, helm_release.seaweedfs, kubernetes_job_v1.seaweedfs_buckets, kubernetes_secret_v1.gateway_tls, helm_release.external_dns]
 
@@ -488,7 +492,7 @@ resource "helm_release" "app" {
     { name = "objectStorage.objectsBucket", value = var.s3_objects_bucket },
 
     # --- Memcached ---
-    { name = "memcached.host", value = var.cloud == "aws" ? var.memcached_cluster_address : "dozuki-memcached" },
+    { name = "memcached.host", value = local.memcached_in_cluster ? "dozuki-memcached" : var.memcached_cluster_address },
 
     # --- Vault ---
     { name = "vault.enabled", value = var.cloud == "aws" ? "true" : "false" },
@@ -504,7 +508,7 @@ resource "helm_release" "app" {
     { name = "monitoring.enabled", value = "true" },
 
     # --- In-cluster services (Azure) ---
-    { name = "memcached.enabled", value = var.cloud == "azure" ? "true" : "false" },
+    { name = "memcached.enabled", value = local.memcached_in_cluster ? "true" : "false" },
     { name = "objectStorage.endpoint", value = var.cloud == "azure" ? "https://s3.${var.dns_domain_name}" : "" },
     { name = "objectStorage.publicHost", value = var.cloud == "azure" ? "s3.${var.dns_domain_name}" : "" },
 

--- a/terraform/logical/variables.tf
+++ b/terraform/logical/variables.tf
@@ -434,3 +434,9 @@ variable "gateway_name" {
   type        = string
   default     = "dozuki-gateway"
 }
+
+variable "memcached_in_cluster" {
+  description = "Run memcached in-cluster instead of ElastiCache (AWS). Azure is always in-cluster. Must match the physical layer's value."
+  type        = bool
+  default     = true
+}

--- a/terraform/physical/elasticache.tf
+++ b/terraform/physical/elasticache.tf
@@ -1,4 +1,5 @@
 resource "aws_security_group" "elasticache" {
+  count = var.memcached_in_cluster ? 0 : 1
 
   name        = "${local.identifier}-elasticache"
   description = "Elasticache memcached SG. Allows access on the 11211 port"
@@ -17,31 +18,33 @@ resource "aws_security_group" "elasticache" {
 }
 
 resource "aws_security_group_rule" "egress" {
+  count             = var.memcached_in_cluster ? 0 : 1
   description       = "Allow all egress traffic"
   from_port         = 0
   to_port           = 0
   protocol          = "-1"
   cidr_blocks       = ["0.0.0.0/0"] #tfsec:ignore:aws-ec2-no-public-egress-sgr
-  security_group_id = aws_security_group.elasticache.id
+  security_group_id = aws_security_group.elasticache[0].id
   type              = "egress"
 }
 
 resource "aws_security_group_rule" "ingress_cidr_blocks" {
+  count             = var.memcached_in_cluster ? 0 : 1
   description       = "Allow inbound traffic from CIDR blocks"
   from_port         = 11211
   to_port           = 11211
   protocol          = "tcp"
   cidr_blocks       = [local.vpc_cidr]
-  security_group_id = aws_security_group.elasticache.id
+  security_group_id = aws_security_group.elasticache[0].id
   type              = "ingress"
 }
 
 resource "null_resource" "cluster_urls" {
-  count = var.elasticache_cluster_size
+  count = var.memcached_in_cluster ? 0 : var.elasticache_cluster_size
 
   triggers = {
     name = "${replace(
-      aws_elasticache_cluster.this.cluster_address,
+      aws_elasticache_cluster.this[0].cluster_address,
       ".cfg.",
       format(".%04d.", count.index + 1)
     )}:11211"
@@ -53,16 +56,19 @@ resource "null_resource" "cluster_urls" {
 }
 
 resource "aws_elasticache_subnet_group" "this" {
+  count      = var.memcached_in_cluster ? 0 : 1
   name       = local.identifier
   subnet_ids = local.private_subnet_ids
 }
 
 resource "aws_elasticache_parameter_group" "this" {
+  count  = var.memcached_in_cluster ? 0 : 1
   name   = local.identifier
   family = "memcached1.5"
 }
 
 resource "random_id" "elasticache" {
+  count       = var.memcached_in_cluster ? 0 : 1
   byte_length = 4
   keepers = {
     node_type      = var.elasticache_instance_type
@@ -71,20 +77,21 @@ resource "random_id" "elasticache" {
 }
 
 resource "aws_elasticache_cluster" "this" {
-  cluster_id = "${local.identifier}-${random_id.elasticache.hex}"
+  count      = var.memcached_in_cluster ? 0 : 1
+  cluster_id = "${local.identifier}-${random_id.elasticache[0].hex}"
 
   engine         = "memcached"
-  engine_version = random_id.elasticache.keepers.engine_version
+  engine_version = random_id.elasticache[0].keepers.engine_version
   port           = 11211
 
   node_type       = var.elasticache_instance_type
   num_cache_nodes = var.elasticache_cluster_size
 
   az_mode            = var.elasticache_cluster_size == 1 ? "single-az" : "cross-az"
-  subnet_group_name  = aws_elasticache_subnet_group.this.name
-  security_group_ids = [aws_security_group.elasticache.id]
+  subnet_group_name  = aws_elasticache_subnet_group.this[0].name
+  security_group_ids = [aws_security_group.elasticache[0].id]
 
-  parameter_group_name = aws_elasticache_parameter_group.this.name
+  parameter_group_name = aws_elasticache_parameter_group.this[0].name
 
   apply_immediately = true
 

--- a/terraform/physical/outputs.tf
+++ b/terraform/physical/outputs.tf
@@ -41,7 +41,7 @@ output "s3_replicate_buckets" {
   value = local.use_existing_buckets
 }
 output "memcached_cluster_address" {
-  value = aws_elasticache_cluster.this.cluster_address
+  value = try(aws_elasticache_cluster.this[0].cluster_address, "")
 }
 output "vpc_id" {
   description = "VPC ID"

--- a/terraform/physical/variables.tf
+++ b/terraform/physical/variables.tf
@@ -420,4 +420,10 @@ variable "aurora_snapshot_identifier" {
   default     = ""
 }
 
+variable "memcached_in_cluster" {
+  description = "Run memcached in-cluster (chart memcached deployment) instead of ElastiCache. When true (default), ElastiCache is not provisioned (and is destroyed if it exists)."
+  type        = bool
+  default     = true
+}
+
 # --- END App Configuration --- #


### PR DESCRIPTION
## Summary
Defaults memcached to in-cluster on AWS (perf: co-located cache vs cross-network ElastiCache) behind `memcached_in_cluster` (default true) in BOTH layers:
- physical: gates/destroys all of elasticache.tf when in-cluster; `memcached_cluster_address` output → "".
- logical: `local.memcached_in_cluster = cloud==azure || var.memcached_in_cluster` drives `memcached.enabled`/`host`.

Azure is always in-cluster (now 1GB via chart 0.3.9). Requires chart 0.3.9. Revert an env by setting `memcached_in_cluster=false` on BOTH its physical and logical stacks (recreates ElastiCache + repoints the app).

## DELIBERATE prod-wide change
Default true → the next Spacelift apply on each AWS env deploys the in-cluster memcached pod, repoints the app (cache cold-starts once, repopulating from DB — degraded not down), and DESTROYS ElastiCache. Physical/logical are separate stacks (no guaranteed order) → worst case a brief cache-miss window. Review the physical destroy plan and validate on ONE env before letting it propagate.

## Test Plan
- [ ] Physical plan (memcached_in_cluster=true) shows ElastiCache destroyed + output "".
- [ ] Logical AWS plan shows memcached.enabled=true + host=dozuki-memcached + the memcached Deployment/PDB; azure unchanged.
- [ ] One-env validation before fleet rollout.