### PR TITLE
fix(harness): cleanup-orphans destroy needs -auto-approve

### DIFF
--- a/live/tests/cleanup-orphans.sh
+++ b/live/tests/cleanup-orphans.sh
@@ -99,7 +99,7 @@ while IFS= read -r pfx; do
       rm -rf .terragrunt-cache
       TG_AWS_ACCT_ID="$ACCT" TG_AWS_PROFILE="$P" TG_AWS_REGION="$region" TG_STATE_PREFIX="$pfx/" \
       TF_VAR_customer="$CUSTOMER" TF_VAR_enable_dr=false \
-        terragrunt destroy --terragrunt-non-interactive -input=false )
+        terragrunt destroy --terragrunt-non-interactive -auto-approve -input=false )
     destroyed_ok=$?
   elif [ -n "$key" ]; then
     echo "  WARNING: $LIVE_ROOT/$envdir/physical not found — cannot destroy via terragrunt; leaving state intact." >&2


### PR DESCRIPTION
Without `-auto-approve`, `--terragrunt-non-interactive` alone still prompted the underlying `tofu destroy` for approval. In run.sh's EXIT trap (no TTY) that prompt got `error asking for approval: EOF`, so the auto-cleanup destroy bailed and left residue (observed after run local-1781800674). Adds `-auto-approve` to match the harness's own `destroyModule`. Validated end-to-end: cleanup-orphans then destroyed the residual NLB+VPC, purged state, disabled the Vault mount, and verify-clean passed.