### PR TITLE
feat(physical): S3 Gateway VPC endpoint for created VPCs

### DIFF
--- a/terraform/physical/vpc-endpoints.tf
+++ b/terraform/physical/vpc-endpoints.tf
@@ -1,0 +1,19 @@
+# S3 Gateway VPC endpoint. Routes private-subnet (EKS node) S3 traffic directly
+# over the AWS backbone instead of through the NAT Gateway: removes NAT
+# data-processing charges for S3 and the shared-SNAT bottleneck under load.
+# Gateway endpoints are free. Only added to VPCs we create (create_vpc); on
+# customer-managed VPCs the customer adds their own S3 endpoint.
+resource "aws_vpc_endpoint" "s3" {
+  count             = local.create_vpc ? 1 : 0
+  vpc_id            = module.vpc[0].vpc_id
+  service_name      = "com.amazonaws.${data.aws_region.current.id}.s3"
+  vpc_endpoint_type = "Gateway"
+  route_table_ids   = module.vpc[0].private_route_table_ids
+
+  tags = merge(
+    {
+      "Name" = "${local.identifier}-s3"
+    },
+    local.tags
+  )
+}


### PR DESCRIPTION
## Summary
Adds an S3 **Gateway** VPC endpoint (free) to VPCs Dozuki creates (`count = local.create_vpc ? 1 : 0`), associated with the private route tables. Private-subnet EKS node → S3 traffic then routes directly over the AWS backbone instead of through the NAT Gateway — removing NAT data-processing charges for S3 and the shared-SNAT bottleneck under load. Cost/reliability win (not a latency change).

- Default endpoint policy (IAM still governs S3 access).
- Private route tables only (public subnets already reach S3 via the IGW).
- `count = 0` on customer-managed VPCs (`var.vpc_id` set) — they add their own; no change there.
- No effect on the Azure layer, the logical layer, or any existing resource (default aws provider, additive route in the created VPC's private RTs).

## Test Plan
- [ ] `terraform plan` on a created-VPC env shows exactly one new `aws_vpc_endpoint.s3[0]` (Gateway, S3, private RT IDs) and **no other changes**.
- [ ] Plan on an existing-VPC env shows zero changes.
- [ ] Post-apply: endpoint Available + associated with the private route tables; object ops succeed; NAT bytes for S3 drop.

(Standalone `terraform validate` shows the pre-existing `Provider configuration not present` errors for the Spacelift-injected aliased `aws.dr`/`aws.dns` providers; this change adds **0** new errors — verified by with/without diff.)