### PR TITLE
fix(logical): cloud-agnostic manual TLS (external cert/key on AWS too)

### DIFF
--- a/terraform/logical/kubernetes.tf
+++ b/terraform/logical/kubernetes.tf
@@ -446,7 +446,7 @@ resource "helm_release" "app" {
   set = concat([
     # --- General ---
     { name = "hostname", value = var.dns_domain_name },
-    { name = "dns_validation", value = var.cloud == "aws" && !local.is_us_gov && contains(["dozuki.cloud", "dozuki.com", "dozuki.app", "dozuki.guide"], replace(var.dns_domain_name, "/^[^.]+\\./", "")) ? "true" : "false" },
+    { name = "dns_validation", value = var.cloud == "aws" && !local.is_us_gov && !local.tls_managed_tf && contains(["dozuki.cloud", "dozuki.com", "dozuki.app", "dozuki.guide"], replace(var.dns_domain_name, "/^[^.]+\\./", "")) ? "true" : "false" },
     { name = "customer", value = coalesce(var.customer, "Dozuki") },
     { name = "environment", value = var.environment },
 
@@ -479,7 +479,7 @@ resource "helm_release" "app" {
     { name = "ingress.hosts[0].hostname", value = coalesce(var.ingress_hostname, var.dns_domain_name) },
     { name = "gateway.hosts[0].hostname", value = coalesce(var.ingress_hostname, var.dns_domain_name) },
     { name = "gateway.hosts[0].tlsSecretName", value = "tls-secret" },
-    { name = "tls.externallyManaged", value = (var.cloud == "azure" && var.azure_tls_mode != "letsencrypt") ? "true" : "false" },
+    { name = "tls.externallyManaged", value = local.tls_managed_tf ? "true" : "false" },
 
     # --- Webhooks ---
     { name = "webhooks.enabled", value = var.enable_webhooks ? "true" : "false" },

--- a/terraform/logical/tls.tf
+++ b/terraform/logical/tls.tf
@@ -1,11 +1,16 @@
-# Azure gateway TLS. On Azure the chart runs with tls.externallyManaged=true
-# (ACME cannot issue without public DNS), so Terraform supplies the tls-secret:
-# operator-provided cert (tls_cert/tls_key) when set, otherwise a generated
-# self-signed cert for dev smoke testing. AWS is unaffected (count = 0).
+# Gateway TLS managed by Terraform. When an operator supplies a cert/key
+# (tls_cert/tls_key) — on ANY cloud — Terraform creates the tls-secret directly and
+# the chart runs with tls.externallyManaged=true, so cert-manager/ACME stays out of
+# the way (no public-DNS / ACME dependency, which is essential for ephemeral test
+# clusters and air-gapped on-prem). Azure additionally supports a generated
+# self-signed cert for dev (azure_tls_mode=self-signed); making the self-signed
+# generation cloud-agnostic is a follow-up. AWS with no supplied cert is unaffected
+# (cert-manager/ACME as before).
 
 locals {
-  # letsencrypt mode: cert-manager owns tls-secret, so Terraform creates nothing.
-  tls_supplied   = var.cloud == "azure" && var.azure_tls_mode == "supplied" && var.tls_cert != "" && var.tls_key != ""
+  # Operator-supplied cert/key — cloud-agnostic.
+  tls_supplied = var.tls_cert != "" && var.tls_key != ""
+  # Generated self-signed cert (dev). Azure-only for now; follow-up to generalize.
   tls_selfsigned = var.cloud == "azure" && var.azure_tls_mode == "self-signed"
   tls_managed_tf = local.tls_supplied || local.tls_selfsigned
 }

--- a/terraform/logical/variables.tf
+++ b/terraform/logical/variables.tf
@@ -377,13 +377,13 @@ variable "ghcr_pull_token" {
 }
 
 variable "tls_cert" {
-  description = "Base64-encoded PEM TLS certificate for the gateway (azure). Empty = generate a self-signed cert for dev."
+  description = "Base64-encoded PEM TLS certificate (full chain) for the gateway. When set (any cloud), Terraform creates the tls-secret and the chart runs with tls.externallyManaged=true, bypassing cert-manager/ACME. Empty = cert-manager/ACME (AWS) or azure_tls_mode (azure)."
   type        = string
   default     = ""
 }
 
 variable "tls_key" {
-  description = "Base64-encoded PEM TLS private key matching tls_cert (azure). Empty = generate a self-signed cert for dev."
+  description = "Base64-encoded PEM TLS private key matching tls_cert. Required when tls_cert is set."
   type        = string
   default     = ""
 }


### PR DESCRIPTION
Manual TLS — supplying `tls_cert`/`tls_key` so Terraform creates `tls-secret` and the chart runs with `tls.externallyManaged=true` (bypassing cert-manager/ACME) — was gated to `cloud == azure`. The AWS path always used ACME, which is unreliable in ephemeral test clusters and impossible air-gapped (DNS-01 propagation, LE prod rate limits). This is the regression first introduced in #113 (manual-tls dropped) that #153/#158 only restored for Azure.

## Change
- `tls_supplied` = `tls_cert != "" && tls_key != ""` (drop the `cloud==azure`/`azure_tls_mode` gate).
- `tls.externallyManaged` driven by `local.tls_managed_tf` instead of `cloud==azure`.
- `dns_validation` additionally gated on `!local.tls_managed_tf` (no ACME when a cert is supplied).

Self-signed *generation* stays Azure-only for now (generalizing it is the agreed follow-up). **Azure behavior is unchanged** — supplied/self-signed/letsencrypt all resolve exactly as before; this only adds the AWS supplied-cert path.

Paired with a `v6.0.1` patch (same wiring backported) so the upgrade harness can self-sign on both refs.