### PR TITLE
test(harness): self-signed manual TLS + v6.0.1 baseline profile

### DIFF
--- a/live/tests/matrix.yaml
+++ b/live/tests/matrix.yaml
@@ -16,6 +16,10 @@ versions:
     image_tag: "3625f3c7a3fe9bd3fb87b03a23a4cbb683d44ded.4"
     nextjs_tag: "2.23.0"
     image_repository: "069174876992.dkr.ecr.us-east-1.amazonaws.com"   # required by v6.0 logical (no default)
+  v6.0.1:                                                              # v6.0 + manual-TLS restore (self-signing baseline); same app images as v6.0
+    image_tag: "3625f3c7a3fe9bd3fb87b03a23a4cbb683d44ded.4"
+    nextjs_tag: "2.23.0"
+    image_repository: "069174876992.dkr.ecr.us-east-1.amazonaws.com"
   v6.1-release:
     image_tag: "3625f3c7a3fe9bd3fb87b03a23a4cbb683d44ded.4"
     nextjs_tag: "2.23.0"

--- a/live/tests/run.sh
+++ b/live/tests/run.sh
@@ -163,7 +163,7 @@ setup_vault() {
   echo ">> Vault: token acquired."
 }
 
-REQUIRED_BINS="git tofu terragrunt helm aws go"
+REQUIRED_BINS="git tofu terragrunt helm aws go openssl"
 DO_VAULT=1
 if [ -n "${VAULT_TOKEN:-}" ] || [ "${SKIP_VAULT_TUNNEL:-0}" = 1 ]; then
   DO_VAULT=0
@@ -177,6 +177,22 @@ for bin in $REQUIRED_BINS; do
 done
 
 [ "$DO_VAULT" = 1 ] && setup_vault
+
+# Generate a throwaway self-signed cert and supply it as tls_cert/tls_key so the
+# logical layer renders tls-secret directly (manual TLS), bypassing cert-manager/ACME
+# — which can't issue reliably in an ephemeral test cluster (DNS-01 propagation, LE
+# prod rate limits). Applies to both refs' logical (baseline v6.0.1+ and the upgrade);
+# the physical layer ignores the unused TF_VARs. Override by presetting TF_VAR_tls_cert.
+if [ -z "${TF_VAR_tls_cert:-}" ]; then
+  _tlsdir="$(mktemp -d)"
+  openssl req -x509 -newkey rsa:2048 -nodes -days 365 \
+    -keyout "$_tlsdir/tls.key" -out "$_tlsdir/tls.crt" \
+    -subj "/O=Dozuki smoke test/CN=dozuki.cloud" \
+    -addext "subjectAltName=DNS:dozuki.cloud,DNS:*.dozuki.cloud" >/dev/null 2>&1
+  export TF_VAR_tls_cert="$(base64 < "$_tlsdir/tls.crt" | tr -d '\n')"
+  export TF_VAR_tls_key="$(base64 < "$_tlsdir/tls.key" | tr -d '\n')"
+  echo ">> TLS: generated self-signed cert -> manual TLS (no cert-manager/ACME)."
+fi
 
 # From here on, the run can create cloud resources — arm the backstop cleanup (see trap).
 STARTED_RUN=1


### PR DESCRIPTION
Wires the smoke test to use **manual TLS** (the cloud-agnostic path from #169 + the v6.0.1 patch) so it stops depending on cert-manager/Let's Encrypt — which can't issue reliably in the ephemeral test cluster (DNS-01 propagation, LE prod rate limits hit after repeated runs).

- `run.sh`: generates a throwaway self-signed cert (`openssl`) and exports `TF_VAR_tls_cert`/`TF_VAR_tls_key` → both refs' logical render `tls-secret` directly and disable cert-manager issuance. Physical ignores the unused vars. Override by presetting `TF_VAR_tls_cert`.
- `matrix.yaml`: adds a `v6.0.1` version profile (the self-signing baseline — v6.0 + the manual-TLS restore, tag `v6.0.1`).

Run with `FROM_REF=v6.0.1 TO_REF=v6.1-release`. Depends on #169 (cloud-agnostic TLS) being merged + synced to v6.1-release.