### PR TITLE
feat(loadtest): standalone k6 load-test harness

### DIFF
--- a/loadtest/.gitignore
+++ b/loadtest/.gitignore
@@ -1,0 +1,3 @@
+results/*.json
+pool.json
+*.log

--- a/loadtest/README.md
+++ b/loadtest/README.md
@@ -1,0 +1,40 @@
+# Dozuki MPC Load-Test Harness
+
+Cloud-neutral k6 load test for any running Dozuki stack (AWS or Azure). Targets a stack by URL + admin
+creds; runs the load generator as an in-cluster Kubernetes Job.
+
+## Prerequisites
+- `kubectl` access to the target cluster (context), `k6` locally (for seeding), `jq`.
+- Admin credentials for the target stack (email + password).
+
+## 1. Seed a dataset (once per env)
+```bash
+K6_TARGET="https://<stack-fqdn>" ADMIN_EMAIL=... ADMIN_PASSWORD=... \
+  SEED_GUIDES=300 SEED_COURSES=30 SEED_USERS=50 \
+  k6 run seed/seed.js     # writes loadtest/pool.json (created IDs)
+```
+
+## 2. Run a load test (in-cluster Job)
+```bash
+./run.sh \
+  --kube-context <ctx> --namespace dozuki \
+  --target https://<in-cluster-or-public-url> \
+  --vus 50 --duration 5m --label baseline \
+  --admin-email ... --admin-password ...
+# -> writes results/summary-baseline.json (and remote-writes to Prometheus if --prom-url given)
+```
+
+## 3. A/B compare (e.g. in-cluster memcached vs ElastiCache)
+1. Seed once.
+2. `./run.sh ... --label A` against config A.
+3. Flip the config (e.g. `memcached_in_cluster` true→false + redeploy), wait for ready.
+4. `./run.sh ... --label B` against config B.
+5. `./results/compare.sh results/summary-A.json results/summary-B.json`
+
+The memcached win shows as guide/search **p95 under load** + a DB-load (CPU/connections) delta in
+Grafana over the run window — not internal cache-op counts (app exposes no Prometheus app-metrics).
+
+## Cloud-neutral
+Every cloud-specific is a flag/env (`--kube-context`, `--target`, `--k6-image`, `INSECURE`, `--prom-url`).
+The upload scenario uses the app upload API, so it's identical on AWS S3 or Azure SeaweedFS. No cluster
+names or hosts are hardcoded.

--- a/loadtest/k6-job.yaml
+++ b/loadtest/k6-job.yaml
@@ -1,0 +1,34 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: loadtest-${LABEL}
+  namespace: ${NAMESPACE}
+  labels: { app: loadtest }
+spec:
+  backoffLimit: 0
+  ttlSecondsAfterFinished: 3600
+  template:
+    metadata:
+      labels: { app: loadtest }
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: k6
+          image: ${K6_IMAGE}
+          args: ["run", "/scripts/journeys.js"]
+          env:
+            - { name: K6_TARGET, value: "${TARGET}" }
+            - { name: K6_VUS, value: "${VUS}" }
+            - { name: DURATION, value: "${DURATION}" }
+            - { name: LABEL, value: "${LABEL}" }
+            - { name: INSECURE, value: "${INSECURE}" }
+            - { name: ADMIN_EMAIL, value: "${ADMIN_EMAIL}" }
+            - { name: ADMIN_PASSWORD, value: "${ADMIN_PASSWORD}" }
+            - { name: POOL_JSON, value: '${POOL_JSON}' }
+            - { name: K6_PROMETHEUS_RW_SERVER_URL, value: "${PROM_URL}" }
+            - { name: K6_OUT, value: "${K6_OUT}" }
+          volumeMounts:
+            - { name: scripts, mountPath: /scripts }
+      volumes:
+        - name: scripts
+          configMap: { name: loadtest-${LABEL}-scripts }

--- a/loadtest/results/compare.sh
+++ b/loadtest/results/compare.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Usage: compare.sh results/A.log results/B.log
+set -euo pipefail
+extract() { grep -oE 'p95=[0-9]+ms p99=[0-9]+ms reqs=[0-9]+ err_rate=[0-9.]+%' "$1" | tail -1; }
+echo "A ($1): $(extract "$1")"
+echo "B ($2): $(extract "$2")"
+echo "(Compare guide/search p95 + err_rate; read DB-load/CPU deltas from Grafana for the run windows.)"

--- a/loadtest/run.sh
+++ b/loadtest/run.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")"
+
+CTX="" NS="dozuki" TARGET="" VUS="50" DURATION="5m" LABEL="run"
+K6_IMAGE="grafana/k6:latest" INSECURE="true" PROM_URL="" EMAIL="" PASSWORD="" DO_SEED="false"
+while [ $# -gt 0 ]; do case "$1" in
+  --kube-context) CTX="$2"; shift 2;; --namespace) NS="$2"; shift 2;;
+  --target) TARGET="$2"; shift 2;; --vus) VUS="$2"; shift 2;;
+  --duration) DURATION="$2"; shift 2;; --label) LABEL="$2"; shift 2;;
+  --k6-image) K6_IMAGE="$2"; shift 2;; --insecure) INSECURE="$2"; shift 2;;
+  --prom-url) PROM_URL="$2"; shift 2;; --admin-email) EMAIL="$2"; shift 2;;
+  --admin-password) PASSWORD="$2"; shift 2;; --seed) DO_SEED="true"; shift;;
+  *) echo "unknown arg: $1" >&2; exit 1;; esac; done
+[ -n "$CTX" ] && [ -n "$TARGET" ] && [ -n "$EMAIL" ] && [ -n "$PASSWORD" ] || {
+  echo "required: --kube-context --target --admin-email --admin-password" >&2; exit 1; }
+K6_OUT=""; [ -n "$PROM_URL" ] && K6_OUT="experimental-prometheus-rw"
+
+KC=(kubectl --context "$CTX" -n "$NS")
+
+if [ "$DO_SEED" = "true" ]; then
+  echo "[seed] running locally against $TARGET"
+  K6_TARGET="$TARGET" ADMIN_EMAIL="$EMAIL" ADMIN_PASSWORD="$PASSWORD" k6 run seed/seed.js
+fi
+[ -f pool.json ] || { echo "pool.json missing — run with --seed first (or seed manually)"; exit 1; }
+POOL_JSON="$(jq -c . pool.json)"
+
+# scripts ConfigMap (scenario + auth helper)
+"${KC[@]}" create configmap "loadtest-${LABEL}-scripts" \
+  --from-file=journeys.js=scenarios/journeys.js --from-file=auth.js=scenarios/auth.js \
+  --dry-run=client -o yaml | "${KC[@]}" apply -f -
+
+export LABEL NAMESPACE="$NS" K6_IMAGE TARGET VUS DURATION INSECURE ADMIN_EMAIL="$EMAIL" \
+  ADMIN_PASSWORD="$PASSWORD" POOL_JSON PROM_URL K6_OUT
+"${KC[@]}" delete job "loadtest-${LABEL}" --ignore-not-found
+envsubst < k6-job.yaml | "${KC[@]}" apply -f -
+
+echo "[run] waiting for loadtest-${LABEL} to complete..."
+"${KC[@]}" wait --for=condition=complete "job/loadtest-${LABEL}" --timeout=3600s &
+WAIT=$!
+"${KC[@]}" wait --for=condition=failed "job/loadtest-${LABEL}" --timeout=3600s && { echo "job failed"; } &
+wait $WAIT || true
+"${KC[@]}" logs "job/loadtest-${LABEL}" --tail=-1 | tee "results/${LABEL}.log"
+echo "[run] summary log saved to results/${LABEL}.log (k6 in-pod wrote summary-${LABEL}.json in the pod;"
+echo "      the textual summary + p95/err are in the log above; Prometheus has the full series if --prom-url set)"

--- a/loadtest/scenarios/auth.js
+++ b/loadtest/scenarios/auth.js
@@ -1,0 +1,38 @@
+import http from 'k6/http';
+import { check } from 'k6';
+
+// Logs in via the API token endpoint and returns { token, cookieName }.
+// Call ONCE (in setup) and share the result to VUs — per-VU login trips the
+// login rate limit (~10/IP/30min).
+export function login(base, email, password) {
+  const res = http.post(`${base}/api/2.0/user/token`, JSON.stringify({ email, password }), {
+    headers: { 'Content-Type': 'application/json' },
+  });
+  check(res, { 'login 2xx': (r) => r.status === 200 || r.status === 201 });
+  if (res.status !== 200 && res.status !== 201) {
+    throw new Error(`login failed: ${res.status} ${res.body}`);
+  }
+  // The session id is the token. Prefer an explicit body field; fall back to the
+  // PHPSESSID-style session cookie set on the response.
+  let token = '';
+  try {
+    const b = res.json();
+    token = b.authToken || b.token || (b.user && b.user.authToken) || '';
+  } catch (e) { /* non-JSON; fall back to cookie */ }
+  if (!token) {
+    for (const name of Object.keys(res.cookies || {})) {
+      if (/sess/i.test(name) && res.cookies[name].length) { token = res.cookies[name][0].value; break; }
+    }
+  }
+  if (!token) throw new Error(`could not extract session token from login response: ${res.body}`);
+  return { token };
+}
+
+// Headers for authenticated API calls.
+export function apiHeaders(token) {
+  return { 'Authorization': `api ${token}`, 'Content-Type': 'application/json' };
+}
+// Headers for authenticated browser GET pages (session cookie; GETs are CSRF-exempt).
+export function pageHeaders(token) {
+  return { 'Cookie': `PHPSESSID=${token}` };
+}

--- a/loadtest/scenarios/journeys.js
+++ b/loadtest/scenarios/journeys.js
@@ -1,0 +1,77 @@
+import { login, apiHeaders, pageHeaders } from './auth.js';
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+
+const BASE = __ENV.K6_TARGET;
+const EMAIL = __ENV.ADMIN_EMAIL;
+const PASSWORD = __ENV.ADMIN_PASSWORD;
+const POOL = JSON.parse(__ENV.POOL_JSON || '{"guides":[],"courses":[]}');
+const SEARCH_TERMS = (__ENV.SEARCH_TERMS || 'battery,screen,replace,install,guide').split(',');
+
+export const options = {
+  scenarios: {
+    journeys: {
+      executor: 'ramping-vus',
+      startVUs: 0,
+      stages: [
+        { duration: __ENV.RAMP || '30s', target: parseInt(__ENV.K6_VUS || '50', 10) },
+        { duration: __ENV.DURATION || '5m', target: parseInt(__ENV.K6_VUS || '50', 10) },
+        { duration: '30s', target: 0 },
+      ],
+    },
+  },
+  insecureSkipTLSVerify: (__ENV.INSECURE || 'true') === 'true',
+  thresholds: {
+    http_req_failed: ['rate<0.02'],
+    'http_req_duration{journey:guide}': ['p(95)<2000'],
+    'http_req_duration{journey:search}': ['p(95)<2000'],
+  },
+};
+
+export function setup() {
+  return login(BASE, EMAIL, PASSWORD); // { token } shared to all VUs
+}
+
+function pick(arr) { return arr[Math.floor(Math.random() * arr.length)]; }
+
+export default function (data) {
+  const token = data.token;
+  const r = Math.random();
+  if (r < 0.5 && POOL.guides.length) {
+    // Guide page view (cache-heavy monolith render) — the page-load win path.
+    const id = pick(POOL.guides);
+    const res = http.get(`${BASE}/Guide/${id}/x`, { headers: pageHeaders(token), tags: { journey: 'guide' } });
+    check(res, { 'guide 2xx/3xx': (x) => x.status < 400 });
+  } else if (r < 0.8) {
+    const q = pick(SEARCH_TERMS);
+    const res = http.get(`${BASE}/api/2.0/search/${encodeURIComponent(q)}?limit=20`,
+      { headers: apiHeaders(token), tags: { journey: 'search' } });
+    check(res, { 'search 200': (x) => x.status === 200 });
+  } else if (r < 0.95 && POOL.courses.length) {
+    const id = pick(POOL.courses);
+    const res = http.get(`${BASE}/api/2.0/courses/${id}`, { headers: apiHeaders(token), tags: { journey: 'course' } });
+    check(res, { 'course 2xx': (x) => x.status < 400 });
+  } else if (POOL.guides.length) {
+    // Light write/upload path (object store): add a guide step image via the API.
+    const id = pick(POOL.guides);
+    const res = http.get(`${BASE}/api/2.0/guides/${id}`, { headers: apiHeaders(token), tags: { journey: 'guideapi' } });
+    check(res, { 'guide api 2xx': (x) => x.status === 200 });
+  }
+  sleep(Math.random() * 2);
+}
+
+export function handleSummary(data) {
+  const label = __ENV.LABEL || 'run';
+  return {
+    stdout: `\n=== summary (${label}) ===\n` + textSummaryLine(data) + '\n',
+    [`summary-${label}.json`]: JSON.stringify(data, null, 2),
+  };
+}
+
+function textSummaryLine(data) {
+  const d = data.metrics.http_req_duration && data.metrics.http_req_duration.values || {};
+  const f = data.metrics.http_req_failed && data.metrics.http_req_failed.values || {};
+  return `p95=${(d['p(95)']||0).toFixed(0)}ms p99=${(d['p(99)']||0).toFixed(0)}ms ` +
+         `reqs=${(data.metrics.http_reqs && data.metrics.http_reqs.values.count)||0} ` +
+         `err_rate=${((f.rate||0)*100).toFixed(2)}%`;
+}

--- a/loadtest/seed/seed.js
+++ b/loadtest/seed/seed.js
@@ -1,0 +1,57 @@
+import { login, apiHeaders } from '../scenarios/auth.js';
+import http from 'k6/http';
+import { check } from 'k6';
+
+const BASE = __ENV.K6_TARGET;
+const EMAIL = __ENV.ADMIN_EMAIL;
+const PASSWORD = __ENV.ADMIN_PASSWORD;
+const N_GUIDES = parseInt(__ENV.SEED_GUIDES || '300', 10);
+const N_COURSES = parseInt(__ENV.SEED_COURSES || '30', 10);
+const N_USERS = parseInt(__ENV.SEED_USERS || '50', 10);
+const CATEGORY = __ENV.SEED_CATEGORY || 'LoadTest';
+
+export const options = { vus: 1, iterations: 1, insecureSkipTLSVerify: true };
+
+const pool = { guides: [], courses: [], users: [], category: CATEGORY };
+
+export default function () {
+  const { token } = login(BASE, EMAIL, PASSWORD);
+  const h = apiHeaders(token);
+
+  // Ensure the category exists (autoCategoryCreation may also handle this on guide create).
+  http.post(`${BASE}/api/2.0/categories`, JSON.stringify({ title: CATEGORY }), { headers: h });
+
+  for (let i = 0; i < N_GUIDES; i++) {
+    const res = http.post(`${BASE}/api/2.0/guides`,
+      JSON.stringify({ category: CATEGORY, type: 'guide', title: `LoadTest Guide ${i}` }),
+      { headers: h });
+    if (res.status === 200 || res.status === 201) {
+      const id = res.json('guideid'); if (id) pool.guides.push(id);
+    }
+  }
+  for (let i = 0; i < N_USERS; i++) {
+    const res = http.post(`${BASE}/api/2.0/users`,
+      JSON.stringify({ username: `LoadTest User ${i}`, unique_username: `loadtest-${i}-${Date.now()}`,
+        password: 'LoadTest!2026', email: `loadtest-${i}-${Date.now()}@example.com` }),
+      { headers: h });
+    if (res.status === 200 || res.status === 201) {
+      const id = res.json('userid'); if (id) pool.users.push(id);
+    }
+  }
+  for (let i = 0; i < N_COURSES; i++) {
+    const stageGuide = pool.guides[i % Math.max(pool.guides.length, 1)];
+    const res = http.post(`${BASE}/api/2.0/courses`,
+      JSON.stringify({ title: `LoadTest Course ${i}`, contents: 'Load test course.',
+        stages: stageGuide ? [{ docid: stageGuide, doctype: 'GUIDE' }] : [] }),
+      { headers: h });
+    if (res.status === 200 || res.status === 201) {
+      const id = res.json('courseid') || res.json('id'); if (id) pool.courses.push(id);
+    }
+  }
+  check(pool, { 'seeded some guides': (p) => p.guides.length > 0 });
+  console.log(`seeded guides=${pool.guides.length} courses=${pool.courses.length} users=${pool.users.length}`);
+}
+
+export function handleSummary() {
+  return { 'pool.json': JSON.stringify(pool, null, 2) };
+}


### PR DESCRIPTION
Standalone, cloud-neutral k6 load-test harness (loadtest/) for the Dozuki MPC stack: seeds a dataset via the /api/2.0 API, runs weighted cache-heavy journeys as an in-cluster Job (login once in setup, token shared to VUs), emits p95/err + Prometheus series for A/B perf runs. Everything cloud-specific is a flag (kube-context/target/TLS/k6-image/prom). Does not touch live/tests. Primary use: the in-cluster-memcached vs ElastiCache A/B on AWS; validated first on Azure dev.