### PR TITLE
fix(physical): gate KMS deletion_window on protect_resources (30/7)

### DIFF
--- a/terraform/physical/bi.tf
+++ b/terraform/physical/bi.tf
@@ -60,8 +60,9 @@ resource "aws_dms_replication_subnet_group" "this" {
 resource "aws_kms_key" "bi" {
   count = var.enable_bi ? 1 : 0
 
-  description         = "BI KMS key for replication credentials"
-  enable_key_rotation = true
+  description             = "BI KMS key for replication credentials"
+  enable_key_rotation     = true
+  deletion_window_in_days = var.protect_resources ? 30 : 7
 }
 
 resource "aws_dms_replication_instance" "this" {

--- a/terraform/physical/dr.tf
+++ b/terraform/physical/dr.tf
@@ -49,9 +49,10 @@ check "dr_rds_replicable" {
 resource "aws_kms_key" "rds_cmk" {
   count = local.rds_use_dr_cmk ? 1 : 0
 
-  description         = "${local.identifier} RDS encryption (DR-replicable)"
-  enable_key_rotation = true
-  tags                = local.tags
+  description             = "${local.identifier} RDS encryption (DR-replicable)"
+  enable_key_rotation     = true
+  deletion_window_in_days = var.protect_resources ? 30 : 7
+  tags                    = local.tags
 }
 
 resource "aws_kms_alias" "rds_cmk" {
@@ -67,9 +68,10 @@ resource "aws_kms_key" "dr_rds" {
   count    = local.dr_rds_enabled ? 1 : 0
   provider = aws.dr
 
-  description         = "${local.identifier} DR replicated RDS backups"
-  enable_key_rotation = true
-  tags                = local.tags
+  description             = "${local.identifier} DR replicated RDS backups"
+  enable_key_rotation     = true
+  deletion_window_in_days = var.protect_resources ? 30 : 7
+  tags                    = local.tags
 }
 
 resource "aws_kms_alias" "dr_rds" {
@@ -85,9 +87,10 @@ resource "aws_kms_key" "dr_s3" {
   count    = local.dr_enabled ? 1 : 0
   provider = aws.dr
 
-  description         = "${local.identifier} DR replicated S3 content"
-  enable_key_rotation = true
-  tags                = local.tags
+  description             = "${local.identifier} DR replicated S3 content"
+  enable_key_rotation     = true
+  deletion_window_in_days = var.protect_resources ? 30 : 7
+  tags                    = local.tags
 }
 
 resource "aws_kms_alias" "dr_s3" {

--- a/terraform/physical/eks.tf
+++ b/terraform/physical/eks.tf
@@ -168,8 +168,9 @@ resource "aws_iam_policy" "eks_worker_kms" {
 resource "aws_kms_key" "eks" {
   count = local.create_eks_kms ? 1 : 0
 
-  description         = "EKS Secret Encryption Key"
-  enable_key_rotation = true
+  description             = "EKS Secret Encryption Key"
+  enable_key_rotation     = true
+  deletion_window_in_days = var.protect_resources ? 30 : 7
 }
 
 resource "aws_iam_policy" "assume_cross_account_role" {

--- a/terraform/physical/s3.tf
+++ b/terraform/physical/s3.tf
@@ -106,7 +106,7 @@ resource "aws_kms_key" "s3" {
   count = local.use_provided_s3_kms ? 0 : 1
 
   description             = "KMS key to encrypt S3 bucket contents"
-  deletion_window_in_days = 7
+  deletion_window_in_days = var.protect_resources ? 30 : 7
   policy                  = data.aws_iam_policy_document.s3_kms_key_policy.json
 }
 resource "aws_kms_alias" "s3" {


### PR DESCRIPTION
Customer CMKs (`eks`, `s3`, `bi`, `rds_cmk`, `dr_rds`, `dr_s3`) defaulted to a 30-day KMS deletion window (`s3` was a flat 7). So every dev/test create→destroy cycle left CMKs lingering ~30 days in `PendingDeletion` — billable + clutter; ~41 had piled up from the upgrade-harness runs.

Gate it to match the Secrets Manager recovery-window pattern: `deletion_window_in_days = var.protect_resources ? 30 : 7`. (7 is the KMS floor — unlike Secrets Manager, KMS rejects 0, so dev can't be instant.) Production (`protect_resources=true`) keeps 30.

Paired with a `v6.0.2` baseline patch so the upgrade harness's baseline keys also use the 7-day dev window.