### PR TITLE
fix(harness): clear NLB deletion-protection before physical destroy

### DIFF
--- a/live/tests/harness/run.go
+++ b/live/tests/harness/run.go
@@ -80,6 +80,14 @@ func RunUpgrade(p RunParams) (err error) {
 
 	envSub := filepath.Join(p.Matrix.Defaults.EnvPath, cfg.Env)
 
+	// NLB is named "<customer>-<env>" (terraform local.identifier). The teardown clears
+	// its deletion protection before the physical destroy so a v6.0.x baseline failure
+	// doesn't stall on the IGW (the protected NLB pins it).
+	nlbName := ""
+	if customer, _ := cfg.FeatureFlags["customer"].(string); customer != "" {
+		nlbName = customer + "-" + cfg.Env
+	}
+
 	tg := func(wt *Worktree) TGOptions {
 		return TGOptions{
 			WorkingDir:   filepath.Join(wt.Dir, envSub),
@@ -88,6 +96,7 @@ func RunUpgrade(p RunParams) (err error) {
 			Profile:      p.Profile,
 			BucketPrefix: "",
 			StatePrefix:  p.RunID + "-" + cfg.Name + "/",
+			NLBName:      nlbName,
 		}
 	}
 

--- a/live/tests/harness/terragrunt.go
+++ b/live/tests/harness/terragrunt.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"strings"
 	"time"
 )
 
@@ -26,6 +27,7 @@ type TGOptions struct {
 	Profile      string
 	BucketPrefix string
 	StatePrefix  string
+	NLBName      string // "<customer>-<env>" (e.g. smoke-min); for pre-destroy protection clear
 }
 
 func (o TGOptions) env() []string {
@@ -106,7 +108,35 @@ func (o TGOptions) Destroy() error {
 	if err := o.destroyModule("logical"); err != nil {
 		fmt.Fprintf(os.Stderr, "\n>> teardown: logical destroy failed (continuing to physical so infra isn't stranded): %v\n", err)
 	}
+	o.clearNLBProtection()
 	return o.destroyModule("physical")
+}
+
+// clearNLBProtection disables deletion protection on the stack's NLB before the
+// physical destroy. v6.0.x baselines create the NLB protected (no protect_resources
+// wiring on the alb module's default), so a baseline-failure teardown would otherwise
+// stall ~15-20min on the internet gateway — the protected NLB's public addresses pin
+// it (DependencyViolation) — before the cleanup-orphans backstop disables it. This
+// makes the harness's own teardown self-sufficient. Best-effort + idempotent: a
+// missing NLB or already-cleared protection is a silent no-op.
+func (o TGOptions) clearNLBProtection() {
+	if o.NLBName == "" {
+		return
+	}
+	out, err := exec.Command("aws", "elbv2", "describe-load-balancers",
+		"--region", o.Region, "--profile", o.Profile,
+		"--query", fmt.Sprintf("LoadBalancers[?LoadBalancerName=='%s'].LoadBalancerArn|[0]", o.NLBName),
+		"--output", "text").Output()
+	arn := strings.TrimSpace(string(out))
+	if err != nil || arn == "" || arn == "None" {
+		return
+	}
+	if e := exec.Command("aws", "elbv2", "modify-load-balancer-attributes",
+		"--load-balancer-arn", arn,
+		"--attributes", "Key=deletion_protection.enabled,Value=false",
+		"--region", o.Region, "--profile", o.Profile).Run(); e == nil {
+		fmt.Fprintf(os.Stderr, "\n>> teardown: cleared NLB deletion-protection on %s (avoids IGW stall)\n", o.NLBName)
+	}
 }
 
 func (o TGOptions) Output(module, name string) (string, error) {


### PR DESCRIPTION
Closes the teardown-stall gap. On a **v6.0.x baseline failure**, the NLB was created protected (alb module default; `protect_resources` wiring is post-v6.0) and the upgrade never ran to flip it — so the physical destroy stalled ~15-20min retrying the IGW detach (the protected NLB's public addresses pin it, `DependencyViolation`) before `cleanup-orphans` (the trap backstop) disabled protection.

The harness's own `Destroy()` now clears deletion-protection on the stack NLB (`<customer>-<env>`) before the physical destroy — best-effort + idempotent (missing/already-clear = no-op). Pairs with #174 (Vault re-auth) to make a failed run tear down cleanly and fast without manual intervention.