### PR TITLE
feat(physical): optional Aurora copy-on-write clone path (fast ephemeral DBs)

### DIFF
--- a/terraform/physical/aurora.tf
+++ b/terraform/physical/aurora.tf
@@ -1,10 +1,27 @@
 # Aurora MySQL 8.4 Serverless v2 cluster (active when var.db_engine == "aurora").
 # Produces the same connection facts as the RDS path via local.db (db.tf).
 
+# No generated password when cloning: a copy-on-write clone inherits the source
+# cluster's master credentials (supplied to the app via var.aurora_clone_master_password).
 resource "random_password" "aurora" {
-  count   = local.db_is_aurora ? 1 : 0
+  count   = local.db_is_aurora && !local.db_is_clone ? 1 : 0
   length  = 40
   special = false
+}
+
+# Guards for the clone path (only evaluated when cloning).
+resource "terraform_data" "aurora_clone_guard" {
+  count = local.db_is_clone ? 1 : 0
+  lifecycle {
+    precondition {
+      condition     = var.aurora_snapshot_identifier == ""
+      error_message = "aurora_clone_source_cluster_id and aurora_snapshot_identifier are mutually exclusive — a cluster can restore from a snapshot OR clone a source, not both."
+    }
+    precondition {
+      condition     = var.aurora_clone_master_password != ""
+      error_message = "aurora_clone_master_password is required when aurora_clone_source_cluster_id is set: the clone inherits the source's master password, so the app's stored credentials must match it."
+    }
+  }
 }
 
 module "aurora" {
@@ -13,15 +30,17 @@ module "aurora" {
 
   count = local.db_is_aurora ? 1 : 0
 
-  name            = local.identifier
-  engine          = "aurora-mysql"
-  engine_mode     = "provisioned"
+  name        = local.identifier
+  engine      = "aurora-mysql"
+  engine_mode = "provisioned"
+  # On a clone, master_username/password and KMS key are inherited from the source
+  # cluster — setting them on a copy-on-write restore is rejected by AWS, so null them.
   engine_version  = var.aurora_engine_version
-  master_username = local.db_username
+  master_username = local.db_is_clone ? null : local.db_username
 
   manage_master_user_password = false
-  master_password_wo          = random_password.aurora[0].result
-  master_password_wo_version  = 1
+  master_password_wo          = one(random_password.aurora[*].result)
+  master_password_wo_version  = local.db_is_clone ? null : 1
 
   serverlessv2_scaling_configuration = {
     min_capacity = var.aurora_min_acu
@@ -37,9 +56,17 @@ module "aurora" {
   create_db_subnet_group = true
 
   storage_encrypted = true
-  kms_key_id        = local.rds_kms_key_arn
+  kms_key_id        = local.db_is_clone ? null : local.rds_kms_key_arn
 
-  snapshot_identifier = var.aurora_snapshot_identifier != "" ? var.aurora_snapshot_identifier : null
+  # Restore-from-snapshot and clone are mutually exclusive (guarded above).
+  snapshot_identifier = local.db_is_clone ? null : (var.aurora_snapshot_identifier != "" ? var.aurora_snapshot_identifier : null)
+
+  # Copy-on-write clone of a pre-seeded "golden" cluster — fast ephemeral DBs for tests.
+  restore_to_point_in_time = local.db_is_clone ? {
+    source_cluster_identifier  = var.aurora_clone_source_cluster_id
+    restore_type               = "copy-on-write"
+    use_latest_restorable_time = true
+  } : null
 
   cluster_parameter_group = {
     family = "aurora-mysql8.4"

--- a/terraform/physical/db.tf
+++ b/terraform/physical/db.tf
@@ -4,12 +4,15 @@
 # (rds.tf), DMS endpoints (bi.tf), and outputs.tf.
 locals {
   db_is_aurora = var.db_engine == "aurora"
+  # Clone path: an Aurora copy-on-write clone of a pre-seeded source cluster. The clone
+  # inherits the source's master password, so it comes from the var, not random_password.
+  db_is_clone = local.db_is_aurora && var.aurora_clone_source_cluster_id != ""
 
   db_host = local.db_is_aurora ? module.aurora[0].cluster_endpoint : module.primary_database[0].db_instance_address
   db_port = local.db_is_aurora ? module.aurora[0].cluster_port : module.primary_database[0].db_instance_port
 
   db_username = "dozuki"
-  db_password = local.db_is_aurora ? random_password.aurora[0].result : module.primary_database[0].db_instance_password
+  db_password = local.db_is_aurora ? (local.db_is_clone ? var.aurora_clone_master_password : one(random_password.aurora[*].result)) : module.primary_database[0].db_instance_password
 
   db_identifier  = local.db_is_aurora ? module.aurora[0].cluster_id : module.primary_database[0].db_instance_id
   db_resource_id = local.db_is_aurora ? module.aurora[0].cluster_resource_id : module.primary_database[0].db_instance_resource_id

--- a/terraform/physical/variables.tf
+++ b/terraform/physical/variables.tf
@@ -420,6 +420,19 @@ variable "aurora_snapshot_identifier" {
   default     = ""
 }
 
+variable "aurora_clone_source_cluster_id" {
+  description = "When set (and db_engine='aurora'), create the Aurora cluster as a fast copy-on-write CLONE of this source ('golden') cluster instead of provisioning from scratch — for ephemeral test/dev DBs. The clone inherits the source's data, schema, master credentials, and KMS key. Mutually exclusive with aurora_snapshot_identifier. Empty = normal create."
+  type        = string
+  default     = ""
+}
+
+variable "aurora_clone_master_password" {
+  description = "Master password of the clone source cluster. Required when aurora_clone_source_cluster_id is set: a copy-on-write clone inherits the source's password, so the app's stored credentials (Secrets Manager/Vault/Helm) must be seeded with it rather than a freshly generated one."
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
 variable "memcached_in_cluster" {
   description = "Run memcached in-cluster (chart memcached deployment) instead of ElastiCache. When true (default), ElastiCache is not provisioned (and is destroyed if it exists)."
   type        = bool


### PR DESCRIPTION
Opt-in path to create the Aurora cluster as a **copy-on-write clone** of a pre-seeded 'golden' source cluster instead of from scratch — for fast ephemeral test/dev DBs (~5-8 min vs ~12-15 min create+migrate+seed). The `rds-aurora` module already supports `restore_to_point_in_time`, so no fork/version bump.

**Fully backward compatible** — cloning is off unless `aurora_clone_source_cluster_id` is set; normal create and the snapshot-restore migration path are untouched.

### Changes
- **vars** (`variables.tf`): `aurora_clone_source_cluster_id`, `aurora_clone_master_password` (sensitive)
- **`aurora.tf`**: adds `restore_to_point_in_time { restore_type = "copy-on-write", use_latest_restorable_time = true }` when cloning; **nulls** `master_username`/`master_password_wo`/`kms_key_id` (a clone inherits these from the source — AWS rejects setting them); forces `snapshot_identifier` null (mutually exclusive); skips `random_password` generation when cloning
- **`db.tf`**: `db_password` comes from `aurora_clone_master_password` when cloning — the clone inherits the source's password, so the app's stored creds (Secrets Manager → Vault → Helm) must match it, not a freshly generated one (the key correctness gotcha)
- **guards**: `terraform_data` preconditions enforce snapshot/clone exclusivity + require the clone password

### Not in this PR (follow-ups to actually use it)
1. A **persistent seeded 'golden' Aurora cluster** (at the baseline schema) + upkeep
2. **Harness wiring** to pass the two vars in test mode (matrix/env.hcl)
3. Note: clone alone is ~5-8 min; pair with a warm pool of pre-made clones to hit 'minutes'

Validated with `tofu validate` (provider stub) — config valid, only the pre-existing `aws_region` deprecation warning.