### PR TITLE
fix(logical): render supplied manual-TLS via the chart (fix v6.0->v6.1 upgrade collision)

### DIFF
--- a/terraform/logical/kubernetes.tf
+++ b/terraform/logical/kubernetes.tf
@@ -446,7 +446,7 @@ resource "helm_release" "app" {
   set = concat([
     # --- General ---
     { name = "hostname", value = var.dns_domain_name },
-    { name = "dns_validation", value = var.cloud == "aws" && !local.is_us_gov && !local.tls_managed_tf && contains(["dozuki.cloud", "dozuki.com", "dozuki.app", "dozuki.guide"], replace(var.dns_domain_name, "/^[^.]+\\./", "")) ? "true" : "false" },
+    { name = "dns_validation", value = var.cloud == "aws" && !local.is_us_gov && !local.tls_manual && contains(["dozuki.cloud", "dozuki.com", "dozuki.app", "dozuki.guide"], replace(var.dns_domain_name, "/^[^.]+\\./", "")) ? "true" : "false" },
     { name = "customer", value = coalesce(var.customer, "Dozuki") },
     { name = "environment", value = var.environment },
 
@@ -479,7 +479,11 @@ resource "helm_release" "app" {
     { name = "ingress.hosts[0].hostname", value = coalesce(var.ingress_hostname, var.dns_domain_name) },
     { name = "gateway.hosts[0].hostname", value = coalesce(var.ingress_hostname, var.dns_domain_name) },
     { name = "gateway.hosts[0].tlsSecretName", value = "tls-secret" },
+    # Manual TLS. Supplied certs: chart renders the typed tls-secret (externallyManaged
+    # false). Generated self-signed: Terraform renders it (externallyManaged true).
+    { name = "tls.enabled", value = local.tls_manual ? "true" : "false" },
     { name = "tls.externallyManaged", value = local.tls_managed_tf ? "true" : "false" },
+    { name = "tls.cert", value = local.tls_supplied ? var.tls_cert : "" },
 
     # --- Webhooks ---
     { name = "webhooks.enabled", value = var.enable_webhooks ? "true" : "false" },
@@ -543,6 +547,7 @@ resource "helm_release" "app" {
 
   set_sensitive = [
     { name = "db.password", value = local.db_master_password },
+    { name = "tls.key", value = local.tls_supplied ? var.tls_key : "" },
     { name = "smtp.auth.password", value = var.smtp_password },
     { name = "objectStorage.credentials.accessKey", value = var.cloud == "azure" ? try(random_password.seaweedfs_access_key[0].result, "") : "" },
     { name = "objectStorage.credentials.secretKey", value = var.cloud == "azure" ? try(random_password.seaweedfs_secret_key[0].result, "") : "" },

--- a/terraform/logical/tls.tf
+++ b/terraform/logical/tls.tf
@@ -1,18 +1,24 @@
-# Gateway TLS managed by Terraform. When an operator supplies a cert/key
-# (tls_cert/tls_key) — on ANY cloud — Terraform creates the tls-secret directly and
-# the chart runs with tls.externallyManaged=true, so cert-manager/ACME stays out of
-# the way (no public-DNS / ACME dependency, which is essential for ephemeral test
-# clusters and air-gapped on-prem). Azure additionally supports a generated
-# self-signed cert for dev (azure_tls_mode=self-signed); making the self-signed
-# generation cloud-agnostic is a follow-up. AWS with no supplied cert is unaffected
-# (cert-manager/ACME as before).
+# Gateway TLS. Manual TLS (supplied cert/key on ANY cloud, or a generated self-signed
+# cert) keeps cert-manager/ACME out of the way (no public-DNS / ACME dependency —
+# essential for ephemeral test clusters and air-gapped on-prem).
+#
+# SUPPLIED certs are rendered by the chart (tls.enabled + tls.cert/key, typed
+# kubernetes.io/tls since chart 0.3.12), NOT by Terraform — so a v6.0 (chart-owned
+# tls-secret) -> v6.1 upgrade keeps the same owner and doesn't collide ("secrets
+# tls-secret already exists"). Terraform only creates the secret for the GENERATED
+# self-signed case (Azure dev), which is greenfield. AWS with no supplied cert is
+# unaffected (cert-manager/ACME as before).
 
 locals {
-  # Operator-supplied cert/key — cloud-agnostic.
+  # Operator-supplied cert/key — cloud-agnostic; rendered by the chart.
   tls_supplied = var.tls_cert != "" && var.tls_key != ""
   # Generated self-signed cert (dev). Azure-only for now; follow-up to generalize.
   tls_selfsigned = var.cloud == "azure" && var.azure_tls_mode == "self-signed"
-  tls_managed_tf = local.tls_supplied || local.tls_selfsigned
+  # Any manual TLS -> cert-manager/ACME (dns_validation) stays out of the way.
+  tls_manual = local.tls_supplied || local.tls_selfsigned
+  # Terraform creates the tls-secret ONLY for the generated self-signed cert; supplied
+  # certs go through the chart (consistent owner across the v6.0->v6.1 upgrade).
+  tls_managed_tf = local.tls_selfsigned
 }
 
 resource "tls_private_key" "gateway" {
@@ -51,8 +57,9 @@ resource "kubernetes_secret_v1" "gateway_tls" {
 
   type = "kubernetes.io/tls"
 
+  # Self-signed only (supplied certs are rendered by the chart). count == tls_selfsigned.
   data = {
-    "tls.crt" = local.tls_supplied ? base64decode(var.tls_cert) : tls_self_signed_cert.gateway[0].cert_pem
-    "tls.key" = local.tls_supplied ? base64decode(var.tls_key) : tls_private_key.gateway[0].private_key_pem
+    "tls.crt" = tls_self_signed_cert.gateway[0].cert_pem
+    "tls.key" = tls_private_key.gateway[0].private_key_pem
   }
 }

--- a/terraform/logical/variables.tf
+++ b/terraform/logical/variables.tf
@@ -360,7 +360,7 @@ variable "rustici_managed_password" {
 variable "chart_version" {
   description = "Dozuki chart version pulled from the registry (oci://<image_repository>/charts/dozuki)."
   type        = string
-  default     = "0.3.6"
+  default     = "0.3.12"
 }
 
 variable "ghcr_pull_username" {


### PR DESCRIPTION
**Fixes the upgrade-leg failure** the harness hit: `Error: secrets "tls-secret" already exists`.

v6.0 (manual TLS) creates `tls-secret` via the **Helm chart**; v6.1 (PR #169) created it via **Terraform** (`kubernetes_secret_v1`, `externallyManaged=true`). On upgrade, TF can't create a secret the chart already owns (and Helm's prune-on-upgrade would fight TF) → collision. Real bug for any v6.0-manual-TLS → v6.1.

### Fix
- **Supplied certs → chart** (`tls.enabled`+`tls.cert`/`tls.key`, `externallyManaged=false`). The chart renders a **typed `kubernetes.io/tls`** secret since chart **0.3.12** (helm #54), so ownership stays with the chart across the upgrade — no handoff, no collision.
- **Terraform secret path kept ONLY for generated self-signed** (Azure dev — greenfield, no chart secret to collide with).
- `dns_validation` now gates on `tls_manual` (supplied **or** self-signed).
- **`chart_version` default 0.3.6 → 0.3.12** (required for the typed secret). Drift is mostly beneficial: typed secret (#54) + db-migrations upgrade-deadlock fix (#49), plus object-storage/memcached-sizing/airgap/operator additions.

`tofu validate` clean. Pairs with a matrix `chart_version` bump on the harness branch. Needs chart 0.3.12 published to the ECR (CI in flight).