### PR TITLE
test(harness): capture run artifacts to S3 for post-mortem

### DIFF
--- a/live/tests/.gitignore
+++ b/live/tests/.gitignore
@@ -2,3 +2,4 @@
 *.tfplan
 __worktrees__/
 .logs/
+.artifacts/

--- a/live/tests/capture-cluster.sh
+++ b/live/tests/capture-cluster.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# capture-cluster.sh — dump live-cluster diagnostics for a harness run BEFORE the
+# deferred teardown destroys the cluster. Called by the Go harness (run.go) on failure;
+# the data (pod states, events, failed-pod logs, gateway listener status, rendered
+# configmaps) is gone once the EKS cluster is deleted, so it has to be grabbed here.
+#
+# Best-effort: every step swallows errors; this script never fails its caller. It does
+# NOT capture Secret *data* (only names+types) or raw TF state — no secrets land here.
+#
+# Usage: capture-cluster.sh <outdir> <cluster> <region> <aws_profile> [namespace] [release]
+set -uo pipefail
+OUT="${1:?outdir}"; CLUSTER="${2:?cluster}"; REGION="${3:?region}"; PROFILE="${4:?profile}"
+NS="${5:-dozuki}"; RELEASE="${6:-dozuki}"
+mkdir -p "$OUT"
+
+KCDIR="$(mktemp -d)"; KC="$KCDIR/config"
+trap 'rm -rf "$KCDIR"' EXIT
+
+if ! aws eks update-kubeconfig --name "$CLUSTER" --region "$REGION" --profile "$PROFILE" --kubeconfig "$KC" >/dev/null 2>&1; then
+  echo "EKS cluster '$CLUSTER' not reachable (already gone or never created) — no cluster dump." > "$OUT/cluster-unavailable.txt"
+  exit 0
+fi
+export KUBECONFIG="$KC"
+
+kubectl get pods -A -o wide                       > "$OUT/pods.txt"          2>&1
+kubectl get events -A --sort-by=.lastTimestamp    > "$OUT/events.txt"        2>&1
+kubectl get all,jobs,pvc -n "$NS" -o wide         > "$OUT/ns-resources.txt"  2>&1
+kubectl get gateway -A -o yaml                     > "$OUT/gateways.txt"      2>&1   # listener status (cert refs etc.)
+kubectl get secret -n "$NS"                        > "$OUT/secrets.txt"       2>&1   # NAMES + TYPES only (no data)
+kubectl describe pods -n "$NS"                     > "$OUT/describe-pods.txt" 2>&1
+kubectl get cm -n "$NS" -o yaml                    > "$OUT/configmaps.txt"    2>&1   # rendered app config (memcached.json etc.)
+
+# Per-pod logs (current + previous, all containers) for the app namespace.
+mkdir -p "$OUT/logs"
+for p in $(kubectl get pods -n "$NS" -o name 2>/dev/null); do
+  n="${p#pod/}"
+  kubectl logs "$p" -n "$NS" --all-containers --tail=400              > "$OUT/logs/$n.txt"      2>&1
+  kubectl logs "$p" -n "$NS" --all-containers --previous --tail=400   > "$OUT/logs/$n.prev.txt" 2>&1 || rm -f "$OUT/logs/$n.prev.txt"
+done
+
+# Helm release state (non-secret: revisions + status).
+{ helm history "$RELEASE" -n "$NS"; echo; helm status "$RELEASE" -n "$NS"; } > "$OUT/helm.txt" 2>&1 || true
+
+echo ">> capture-cluster: wrote $(find "$OUT" -type f | wc -l | tr -d ' ') files to $OUT"

--- a/live/tests/harness/diagnostics.go
+++ b/live/tests/harness/diagnostics.go
@@ -1,0 +1,81 @@
+package harness
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"time"
+)
+
+// ArtifactsDir is the per-run artifacts directory that run.sh bundles + uploads to S3.
+func ArtifactsDir(repoDir, runID string) string {
+	return filepath.Join(repoDir, "live", "tests", ".artifacts", runID)
+}
+
+// captureDiagnostics writes run artifacts (.artifacts/<RUN_ID>/) BEFORE the deferred
+// teardown destroys the cluster + removes the worktrees: always the TF inventory, the
+// run inputs (env.hcl), and the refs; on failure (full) also a live-cluster dump (pod
+// states, events, failed-pod logs, gateway status, rendered configmaps) — the data
+// that's gone once Destroy runs. Best-effort: never blocks or fails teardown.
+func captureDiagnostics(p RunParams, region, cluster string, full bool, toTG TGOptions, fromEnvHCL, toEnvHCL string) {
+	dir := ArtifactsDir(p.RepoDir, p.RunID)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		fmt.Fprintf(os.Stderr, ">> capture: mkdir %s: %v\n", dir, err)
+		return
+	}
+
+	outcome := "passed"
+	if full {
+		outcome = "FAILED"
+	}
+	_ = os.WriteFile(filepath.Join(dir, "refs.txt"), []byte(fmt.Sprintf(
+		"run_id=%s\nconfig=%s\nfrom_ref=%s\nto_ref=%s\noutcome=%s\ncaptured=%s\n",
+		p.RunID, p.ConfigName, p.FromRef, p.ToRef, outcome, time.Now().Format(time.RFC3339))), 0o644)
+
+	// Run inputs — copied before the worktrees are removed.
+	copyFileBestEffort(fromEnvHCL, filepath.Join(dir, "from-env.hcl"))
+	copyFileBestEffort(toEnvHCL, filepath.Join(dir, "to-env.hcl"))
+
+	// TF inventory — `state list` has no values; `output` renders sensitive as <sensitive>.
+	captureTG(toTG, "physical", dir)
+	captureTG(toTG, "logical", dir)
+
+	// Live-cluster dump — only on failure (the high-value, gone-after-teardown data).
+	if full && cluster != "" {
+		sh := filepath.Join(p.RepoDir, "live", "tests", "capture-cluster.sh")
+		cmd := exec.Command("bash", sh, filepath.Join(dir, "cluster"), cluster, region, p.Profile, p.Namespace)
+		cmd.Stdout = os.Stderr
+		cmd.Stderr = os.Stderr
+		_ = cmd.Run()
+	}
+	fmt.Fprintf(os.Stderr, "\n>> [harness %s] diagnostics captured -> %s\n", time.Now().Format("15:04:05"), dir)
+}
+
+// captureTG dumps `terragrunt state list` + `terragrunt output` for one module (no
+// secrets: state list has no values, output redacts sensitive). Best-effort.
+func captureTG(o TGOptions, module, dir string) {
+	md := filepath.Join(o.WorkingDir, module)
+	if _, err := os.Stat(md); err != nil {
+		return
+	}
+	for name, args := range map[string][]string{
+		"state-list": {"state", "list"},
+		"output":     {"output"},
+	} {
+		cmd := exec.Command("terragrunt", args...)
+		cmd.Dir = md
+		cmd.Env = o.env()
+		out, _ := cmd.CombinedOutput()
+		_ = os.WriteFile(filepath.Join(dir, fmt.Sprintf("tf-%s-%s.txt", module, name)), out, 0o644)
+	}
+}
+
+func copyFileBestEffort(src, dst string) {
+	b, err := os.ReadFile(src)
+	if err != nil {
+		return
+	}
+	_ = os.MkdirAll(filepath.Dir(dst), 0o755)
+	_ = os.WriteFile(dst, b, 0o644)
+}

--- a/live/tests/harness/run.go
+++ b/live/tests/harness/run.go
@@ -79,13 +79,14 @@ func RunUpgrade(p RunParams) (err error) {
 	}
 
 	envSub := filepath.Join(p.Matrix.Defaults.EnvPath, cfg.Env)
+	fromEnvHCL := filepath.Join(fromWT.Dir, envSub, "env.hcl")
+	toEnvHCL := filepath.Join(toWT.Dir, envSub, "env.hcl")
 
-	// NLB is named "<customer>-<env>" (terraform local.identifier). The teardown clears
-	// its deletion protection before the physical destroy so a v6.0.x baseline failure
-	// doesn't stall on the IGW (the protected NLB pins it).
-	nlbName := ""
+	// terraform local.identifier = "<customer>-<env>" — the name of both the NLB
+	// (teardown clears its deletion protection) and the EKS cluster (diagnostics dump).
+	identifier := ""
 	if customer, _ := cfg.FeatureFlags["customer"].(string); customer != "" {
-		nlbName = customer + "-" + cfg.Env
+		identifier = customer + "-" + cfg.Env
 	}
 
 	tg := func(wt *Worktree) TGOptions {
@@ -96,7 +97,7 @@ func RunUpgrade(p RunParams) (err error) {
 			Profile:      p.Profile,
 			BucketPrefix: "",
 			StatePrefix:  p.RunID + "-" + cfg.Name + "/",
-			NLBName:      nlbName,
+			NLBName:      identifier,
 		}
 	}
 
@@ -113,6 +114,10 @@ func RunUpgrade(p RunParams) (err error) {
 	// Always attempt destroy (against the target/final code) without clobbering
 	// an earlier error. Registered last so it runs before the worktree removals.
 	defer func() {
+		// Capture artifacts BEFORE destroy (cluster) + before worktree removal (env.hcl).
+		// err (named return) reflects the run outcome here → full dump only on failure.
+		step("capturing diagnostics -> .artifacts/%s (full=%v)", p.RunID, err != nil)
+		captureDiagnostics(p, region, identifier, err != nil, tg(toWT), fromEnvHCL, toEnvHCL)
 		step("TEARDOWN: destroy (logical best-effort, then ALWAYS physical)")
 		if derr := tg(toWT).Destroy(); derr != nil && err == nil {
 			err = fmt.Errorf("destroy: %w", derr)

--- a/live/tests/run.sh
+++ b/live/tests/run.sh
@@ -117,6 +117,27 @@ cleanup() {
     ./cleanup-orphans.sh "${RUN_ID}-" || echo ">> Auto-cleanup reported issues — see verify-clean output above." >&2
   fi
   [ -n "$VAULT_PF_PID" ] && kill "$VAULT_PF_PID" 2>/dev/null || true
+
+  # Archive this run's artifacts to S3 for post-mortem. The harness writes diagnostics
+  # to .artifacts/$RUN_ID BEFORE teardown (TF inventory, env.hcl, and — on failure — a
+  # live-cluster dump: pods/events/failed-pod logs/gateway status/configmaps), which are
+  # gone once the cluster + worktrees are torn down. Bundle that + the run log and upload.
+  # Best-effort; opt out with SKIP_ARTIFACTS=1.
+  if [ "${STARTED_RUN:-0}" = 1 ] && [ "${SKIP_ARTIFACTS:-0}" != 1 ]; then
+    _adir="$PWD/.artifacts/$RUN_ID"
+    mkdir -p "$_adir"
+    cp -f "$RUN_LOG" "$_adir/run.log" 2>/dev/null || true
+    _bundle="$PWD/.artifacts/${RUN_ID}.tar.gz"
+    if tar -czf "$_bundle" -C "$PWD/.artifacts" "$RUN_ID" 2>/dev/null; then
+      _bucket="${ARTIFACTS_BUCKET:-dozuki-cloudprem-harness-artifacts-us-east-1-${DDVTEST_ACCOUNT_ID}}"
+      if aws s3 cp "$_bundle" "s3://${_bucket}/${RUN_ID}.tar.gz" --profile "$AWS_PROFILE" >/dev/null 2>&1; then
+        echo ">> Artifacts archived: s3://${_bucket}/${RUN_ID}.tar.gz" >&2
+      else
+        echo ">> Artifacts: S3 upload failed (perms/SSO?); local bundle kept at $_bundle" >&2
+      fi
+    fi
+  fi
+
   echo ">> Full run log saved to: $RUN_LOG" >&2
 }
 trap cleanup EXIT


### PR DESCRIPTION
Saves the forensics we keep losing when a run's cluster + worktrees are torn down (today: the db-migrations logs + rendered `memcached.json` were gone before I could look).

- **`harness/diagnostics.go`** — `captureDiagnostics()` in the teardown defer, *before* `Destroy` + worktree removal. Always: refs, run inputs (`env.hcl`), TF inventory (`terragrunt state list` + `output`). On failure: invokes `capture-cluster.sh`.
- **`capture-cluster.sh`** — live-cluster dump: pods, events, failed-pod logs (current+previous), **gateway listener status**, rendered configmaps (`memcached.json` etc.), helm history/status. Captures secret **names+types only** (no data); no raw TF state.
- **`run.sh`** — EXIT trap bundles `.artifacts/<RUN_ID>` + the run log → `<RUN_ID>.tar.gz` → `s3://dozuki-cloudprem-harness-artifacts-us-east-1-<acct>/`. Override `ARTIFACTS_BUCKET`; opt out `SKIP_ARTIFACTS=1`. Prints the S3 URI. Best-effort — never blocks teardown.

Bucket + IAM live (infra-tf #25). `go build/vet/test` + `bash -n` clean; capture-cluster.sh handles a missing cluster gracefully (exit 0).