### PR TITLE
fix(logical): in-cluster memcached host must be the service FQDN

### DIFF
--- a/terraform/logical/kubernetes.tf
+++ b/terraform/logical/kubernetes.tf
@@ -496,7 +496,11 @@ resource "helm_release" "app" {
     { name = "objectStorage.objectsBucket", value = var.s3_objects_bucket },
 
     # --- Memcached ---
-    { name = "memcached.host", value = local.memcached_in_cluster ? "dozuki-memcached" : var.memcached_cluster_address },
+    # In-cluster memcached: use the service FQDN, not the bare name — the app's Hostname
+    # type rejects a single-label host ("Invalid hostname"), failing db-migrations and
+    # blocking the upgrade. (The bare name resolves via k8s DNS, but the app validates the
+    # string format.) ElastiCache supplies a full host already.
+    { name = "memcached.host", value = local.memcached_in_cluster ? "dozuki-memcached.${local.k8s_namespace_name}.svc.cluster.local" : var.memcached_cluster_address },
 
     # --- Vault ---
     { name = "vault.enabled", value = var.cloud == "aws" ? "true" : "false" },


### PR DESCRIPTION
Fixes the upgrade-leg blocker the last run hit (after the TLS fix let it get to the migration step).

The db-migrations Job died with `IllegalArgumentException: Invalid hostname` building the memcached cluster config. With in-cluster memcached (#166) the app receives `memcached.host = "dozuki-memcached"` — the **bare k8s service name** — and the app's `Hostname` type rejects a single-label host. The baseline passed because ElastiCache hands it a full FQDN.

Fix: use the service **FQDN** `dozuki-memcached.<namespace>.svc.cluster.local`. ElastiCache path unchanged.

**Note (separate, possibly self-resolving):** chart 0.3.12 (#51) pins memcached to on-demand nodes (`karpenter.sh/capacity-type: on-demand`) + 1Gi requests; the last run showed `FailedScheduling` on `min`. EKS Auto Mode should provision a matching on-demand node, so this may clear once the run proceeds past the host error — and the new artifact capture will pinpoint it if it doesn't. `tofu validate` clean.