### PR TITLE
fix(logical): memcached host FQDN in the Vault cache seed (the path the app actually reads)

### DIFF
--- a/terraform/logical/kubernetes.tf
+++ b/terraform/logical/kubernetes.tf
@@ -402,6 +402,12 @@ resource "aws_eks_addon" "cloudwatch_observability" {
 
 locals {
   memcached_in_cluster = var.cloud == "azure" || var.memcached_in_cluster
+  # The app's Hostname type rejects a bare single-label name ("Invalid hostname"), so
+  # in-cluster memcached must use the service FQDN. ElastiCache supplies a full host
+  # already. This single source feeds the chart value, the config-map values, AND the
+  # Vault-seeded cache secret (ESO-synced into memcached.json, which OVERRIDES the chart
+  # config map) — all three must agree or the app reads an empty/invalid host.
+  memcached_host = local.memcached_in_cluster ? "dozuki-memcached.${local.k8s_namespace_name}.svc.cluster.local" : var.memcached_cluster_address
 }
 
 resource "helm_release" "app" {
@@ -496,11 +502,10 @@ resource "helm_release" "app" {
     { name = "objectStorage.objectsBucket", value = var.s3_objects_bucket },
 
     # --- Memcached ---
-    # In-cluster memcached: use the service FQDN, not the bare name — the app's Hostname
-    # type rejects a single-label host ("Invalid hostname"), failing db-migrations and
-    # blocking the upgrade. (The bare name resolves via k8s DNS, but the app validates the
-    # string format.) ElastiCache supplies a full host already.
-    { name = "memcached.host", value = local.memcached_in_cluster ? "dozuki-memcached.${local.k8s_namespace_name}.svc.cluster.local" : var.memcached_cluster_address },
+    # Memcached host — see local.memcached_host (FQDN in-cluster). NOTE: this chart value
+    # is overridden by the ESO-synced memcached.json from Vault (vault.tf cache secret),
+    # so that path must use the same local too.
+    { name = "memcached.host", value = local.memcached_host },
 
     # --- Vault ---
     { name = "vault.enabled", value = var.cloud == "aws" ? "true" : "false" },

--- a/terraform/logical/main.tf
+++ b/terraform/logical/main.tf
@@ -154,7 +154,7 @@ locals {
     ingress_hostname       = { value = coalesce(var.ingress_hostname, var.dns_domain_name) }
     bi_enabled             = { value = var.enable_bi ? "true" : "false" }
     webhooks_enabled       = { value = var.enable_webhooks ? "true" : "false" }
-    memcached_host         = { value = var.memcached_cluster_address }
+    memcached_host         = { value = local.memcached_host }
     s3_kms_key             = { value = var.cloud == "aws" ? data.aws_kms_key.s3[0].arn : "" }
     s3_images_bucket       = { value = var.s3_images_bucket }
     s3_objects_bucket      = { value = var.s3_objects_bucket }

--- a/terraform/logical/vault.tf
+++ b/terraform/logical/vault.tf
@@ -186,8 +186,10 @@ resource "vault_kv_secret_v2" "cache" {
   name                = "${local.vault_env_prefix}/cache"
   delete_all_versions = !var.protect_resources
 
+  # ESO syncs this into the app's memcached.json (overriding the chart config map), so it
+  # must be the in-cluster FQDN, not the (empty when in-cluster) ElastiCache address.
   data_json = jsonencode({
-    host = var.memcached_cluster_address
+    host = local.memcached_host
   })
 }
 


### PR DESCRIPTION
Follow-up to #180, which fixed the *wrong (losing) side*.

The app's `memcached.json` is templated by External Secrets from the Vault secret `secret/<env>/cache` (`vault.tf`), and the ESO copy **overrides** the chart config map. That Vault seed used `var.memcached_cluster_address`, which is **empty** when memcached is in-cluster (#166 destroys ElastiCache) → the app read `hostname: ""` → `Invalid hostname` → db-migrations failed → upgrade hung. #180's chart-config-map fix never reached the app.

Fix: one `local.memcached_host` (in-cluster → `dozuki-memcached.<ns>.svc.cluster.local`, else the ElastiCache address) used in **all three** host-setting spots — the Vault cache secret (the one that wins), the config-map values, and the chart value — so they can't drift again.

Verified live: memcached pod schedules fine (Auto Mode), and the ESO-synced `memcached.json` had `hostname: ""` confirming the empty Vault seed. `tofu validate` clean.