### PR TITLE
Add managed metrics-server addon for Auto Mode (fix blind HPAs)

### DIFF
--- a/terraform/physical/README.md
+++ b/terraform/physical/README.md
@@ -66,6 +66,7 @@
 | [aws_dms_replication_subnet_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dms_replication_subnet_group) | resource |
 | [aws_dms_replication_task.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dms_replication_task) | resource |
 | [aws_eks_addon.cloudwatch_observability](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_addon) | resource |
+| [aws_eks_addon.metrics_server](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_addon) | resource |
 | [aws_eks_pod_identity_association.app_default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_pod_identity_association) | resource |
 | [aws_eks_pod_identity_association.app_migration_wait](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_pod_identity_association) | resource |
 | [aws_eks_pod_identity_association.cert_manager](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_pod_identity_association) | resource |

--- a/terraform/physical/eks.tf
+++ b/terraform/physical/eks.tf
@@ -416,3 +416,20 @@ resource "aws_eks_addon" "cloudwatch_observability" {
 
   tags = local.tags
 }
+
+# Managed metrics-server addon. Provides the Kubernetes Metrics API (metrics.k8s.io) that
+# HorizontalPodAutoscalers read for their CPU/memory targets. EKS Auto Mode does NOT bundle
+# metrics-server, so without this every HPA reads <unknown> and never scales — the app stays
+# pinned at minReplicas under load. No IAM is needed: metrics-server reads kubelet metrics via
+# the Kubernetes API, not the AWS API. addon_version is left unset so EKS selects the default
+# compatible with the cluster's Kubernetes version. As with the addon above, a cluster that
+# already has metrics-server installed out-of-band must have it removed once before first apply.
+resource "aws_eks_addon" "metrics_server" {
+  cluster_name = module.eks_cluster.cluster_name
+  addon_name   = "metrics-server"
+
+  resolve_conflicts_on_create = "OVERWRITE"
+  resolve_conflicts_on_update = "OVERWRITE"
+
+  tags = local.tags
+}


### PR DESCRIPTION
## Summary
The standard EKS **Auto Mode** stack ships with **no metrics-server** — the `metrics.k8s.io` API is absent, so every HorizontalPodAutoscaler reads `<unknown>/80%` and **never scales**. The app stays pinned at `minReplicas` under load. Confirmed on the dev-min stack: all three HPAs (`app`, `nextjs`, `queueworker`) read `<unknown>` and `kubectl top` returns nothing.

EKS Auto Mode does **not** bundle metrics-server (the assumption that it does was incorrect). This adds it via the **AWS-managed `metrics-server` EKS add-on**.

## Why this approach
- **Managed add-on**, matching the existing `amazon-cloudwatch-observability` add-on pattern in `eks.tf` — AWS handles version compatibility and config.
- **No IAM** needed: metrics-server reads kubelet metrics through the Kubernetes API, not AWS.
- **No hostNetwork/`--kubelet-insecure-tls` hacks** — those were only needed on the self-managed Cilium overlay (off-VPC pod IPs). Auto Mode uses vpc-cni with routable pod IPs, so the standard add-on works as-is.
- `addon_version` left unset so EKS selects the version compatible with the cluster's Kubernetes version.

## Deploy note
dev-min (and standard stacks) have **no** existing metrics-server, so the add-on installs cleanly. A cluster that somehow already has metrics-server installed out-of-band would need it removed once before first apply (same caveat as the cloudwatch add-on).

## Test plan
- [ ] Apply via Spacelift to dev-min
- [ ] `kubectl get apiservice v1beta1.metrics.k8s.io` → Available=True
- [ ] `kubectl top nodes` returns data; HPAs show real CPU/memory % instead of `<unknown>`

## Follow-up
This fix should also be forward-ported to `master` so future releases keep it. The self-managed EKS path (PR #175) installs metrics-server differently (helm bootstrap with hostNetwork) because of the Cilium overlay — that one stays separate.