### PR TITLE
Add managed metrics-server addon for Auto Mode (forward-port of #186 to master)

### DIFF
--- a/terraform/physical/README.md
+++ b/terraform/physical/README.md
@@ -66,6 +66,7 @@
 | [aws_dms_replication_subnet_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dms_replication_subnet_group) | resource |
 | [aws_dms_replication_task.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dms_replication_task) | resource |
 | [aws_eks_addon.cloudwatch_observability](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_addon) | resource |
+| [aws_eks_addon.metrics_server](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_addon) | resource |
 | [aws_eks_pod_identity_association.app_default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_pod_identity_association) | resource |
 | [aws_eks_pod_identity_association.app_migration_wait](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_pod_identity_association) | resource |
 | [aws_eks_pod_identity_association.cert_manager](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_pod_identity_association) | resource |

--- a/terraform/physical/eks.tf
+++ b/terraform/physical/eks.tf
@@ -455,3 +455,20 @@ resource "aws_eks_addon" "cloudwatch_observability" {
 
   tags = local.tags
 }
+
+# Managed metrics-server addon. Provides the Kubernetes Metrics API (metrics.k8s.io) that
+# HorizontalPodAutoscalers read for their CPU/memory targets. EKS Auto Mode does NOT bundle
+# metrics-server, so without this every HPA reads <unknown> and never scales — the app stays
+# pinned at minReplicas under load. No IAM is needed: metrics-server reads kubelet metrics via
+# the Kubernetes API, not the AWS API. addon_version is left unset so EKS selects the default
+# compatible with the cluster's Kubernetes version. As with the addon above, a cluster that
+# already has metrics-server installed out-of-band must have it removed once before first apply.
+resource "aws_eks_addon" "metrics_server" {
+  cluster_name = module.eks_cluster.cluster_name
+  addon_name   = "metrics-server"
+
+  resolve_conflicts_on_create = "OVERWRITE"
+  resolve_conflicts_on_update = "OVERWRITE"
+
+  tags = local.tags
+}


### PR DESCRIPTION
Forward-port of #186 (merged to v6.1-release) onto master, so the metrics-server fix lives on both branches.

EKS Auto Mode does not bundle metrics-server, so every HPA reads `<unknown>` and never scales. This adds the AWS-managed `metrics-server` EKS add-on (no IAM, no hostNetwork — Auto Mode's vpc-cni pod IPs are routable). Identical to #186.

Once this lands on master, the "Release v6.1" PR (#146) no longer diffs `eks.tf` — keeping the metrics-server fix on both branches while making #146 clean.