### PR TITLE
Sync live/tests harness to master (v6.1 release-PR hygiene)

### DIFF
--- a/live/tests/harness/run.go
+++ b/live/tests/harness/run.go
@@ -5,16 +5,33 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/Dozuki/CloudPrem-Infra/live/tests/validation"
 )
 
+// phaseMark records one step() marker (time + message) for the end-of-run summary.
+type phaseMark struct {
+	at  time.Time
+	msg string
+}
+
+// Per-run phase tracking, reset at the start of each RunUpgrade. The harness runs
+// configs sequentially, so a package-level recorder is sufficient (no concurrency).
+var (
+	phaseMarks []phaseMark
+	runStart   time.Time
+)
+
 // step prints a timestamped progress marker to stderr (captured by run.sh's tee) so
 // the log shows what the harness is doing during the otherwise-silent gaps between
-// terragrunt stages (validation waits, output reads, validators, teardown).
+// terragrunt stages (validation waits, output reads, validators, teardown). Each
+// marker is also recorded for the end-of-run HARNESS RUN SUMMARY banner.
 func step(format string, args ...interface{}) {
-	fmt.Fprintf(os.Stderr, "\n>> [harness %s] %s\n", time.Now().Format("15:04:05"), fmt.Sprintf(format, args...))
+	msg := fmt.Sprintf(format, args...)
+	phaseMarks = append(phaseMarks, phaseMark{at: time.Now(), msg: msg})
+	fmt.Fprintf(os.Stderr, "\n>> [harness %s] %s\n", time.Now().Format("15:04:05"), msg)
 }
 
 // RunParams configures one upgrade run.
@@ -47,6 +64,13 @@ func RunUpgrade(p RunParams) (err error) {
 	if !p.Matrix.VersionProfileExists(p.ToRef) {
 		return fmt.Errorf("no version profile for to_ref %q in matrix", p.ToRef)
 	}
+
+	// Track phases and print a final summary banner on the way out. Registered before
+	// the worktree/teardown defers so it runs LAST — the run's outcome, what ran (with
+	// per-phase durations), and artifact location at a glance, no log-grepping needed.
+	phaseMarks = nil
+	runStart = time.Now()
+	defer func() { printSummary(p, cfg, err) }()
 
 	ctx := context.Background()
 	base := filepath.Join(p.RepoDir, "live", "tests", "__worktrees__", p.RunID)
@@ -323,4 +347,59 @@ func readOutputs(tg TGOptions, region string) (validation.StackOutputs, error) {
 		DRBucketNames: drBucketNames,
 		DBIdentifier:  str(physical, "db_identifier"),
 	}, nil
+}
+
+// printSummary writes a final, human-readable banner so a run's outcome, what ran
+// (with per-phase durations), and where the artifacts live are visible at a glance —
+// no scrolling or grepping the full log. Printed last, on pass or fail.
+func printSummary(p RunParams, cfg Config, err error) {
+	result := "PASS ✓"
+	if err != nil {
+		result = "FAIL ✗: " + err.Error()
+	}
+	dr := "(disabled)"
+	if p.EnableDR {
+		dr = p.DRRegion + " (enabled)"
+	}
+	customer, _ := cfg.FeatureFlags["customer"].(string)
+
+	var b strings.Builder
+	line := func(format string, a ...interface{}) { fmt.Fprintf(&b, format+"\n", a...) }
+	line("")
+	line("========================= HARNESS RUN SUMMARY =========================")
+	line(" Result:    %s", result)
+	line(" Config:    %s  (customer=%s, env=%s)", cfg.Name, customer, cfg.Env)
+	line(" Upgrade:   %s  ->  %s", p.FromRef, p.ToRef)
+	line(" Region:    %s    DR: %s", p.Matrix.Defaults.Region, dr)
+	line(" Run ID:    %s", p.RunID)
+	if !runStart.IsZero() {
+		line(" Duration:  %s", time.Since(runStart).Round(time.Second))
+		if len(phaseMarks) > 0 {
+			line(" Phases:")
+			for i, m := range phaseMarks {
+				next := time.Now()
+				if i+1 < len(phaseMarks) {
+					next = phaseMarks[i+1].at
+				}
+				line("   +%-8s %-56s %s",
+					m.at.Sub(runStart).Round(time.Second),
+					truncate(m.msg, 56),
+					next.Sub(m.at).Round(time.Second))
+			}
+		}
+	}
+	line(" Artifacts: live/tests/.artifacts/%s/  (run log + diagnostics; bundled to S3 by run.sh)", p.RunID)
+	line("======================================================================")
+	fmt.Fprint(os.Stderr, b.String())
+}
+
+// truncate collapses s to its first line and caps it at n bytes for the summary table.
+func truncate(s string, n int) string {
+	if i := strings.IndexByte(s, '\n'); i >= 0 {
+		s = s[:i]
+	}
+	if r := []rune(s); len(r) > n {
+		return string(r[:n-1]) + "…"
+	}
+	return s
 }

--- a/live/tests/run.sh
+++ b/live/tests/run.sh
@@ -128,7 +128,11 @@ cleanup() {
     mkdir -p "$_adir"
     cp -f "$RUN_LOG" "$_adir/run.log" 2>/dev/null || true
     _bundle="$PWD/.artifacts/${RUN_ID}.tar.gz"
-    if tar -czf "$_bundle" -C "$PWD/.artifacts" "$RUN_ID" 2>/dev/null; then
+    # The harness writes per-config diagnostics to .artifacts/<RUN_ID>-<config>/ (its
+    # p.RunID includes the config name), so bundle those dirs too — not just the run-log
+    # dir — or the upload is just the log. Feed the dir list to tar via -T (robust to
+    # shell word-splitting).
+    if ( cd "$PWD/.artifacts" && ls -d "$RUN_ID" "$RUN_ID"-* 2>/dev/null | tar -czf "$_bundle" -T - ) 2>/dev/null; then
       _bucket="${ARTIFACTS_BUCKET:-dozuki-cloudprem-harness-artifacts-us-east-1-${DDVTEST_ACCOUNT_ID}}"
       if aws s3 cp "$_bundle" "s3://${_bucket}/${RUN_ID}.tar.gz" --profile "$AWS_PROFILE" >/dev/null 2>&1; then
         echo ">> Artifacts archived: s3://${_bucket}/${RUN_ID}.tar.gz" >&2
@@ -139,6 +143,16 @@ cleanup() {
   fi
 
   echo ">> Full run log saved to: $RUN_LOG" >&2
+
+  # Top-level result banner — the one line to look for. Per-config detail (refs,
+  # phases, durations) is in the "HARNESS RUN SUMMARY" block printed by the Go harness.
+  if [ "${STARTED_RUN:-0}" = 1 ]; then
+    if [ "${TEST_RC:-1}" = 0 ]; then
+      echo ">> ================ RESULT: PASS ✓  (run ${RUN_ID}) ================" >&2
+    else
+      echo ">> ================ RESULT: FAIL ✗  (run ${RUN_ID}, exit ${TEST_RC:-?}) ================" >&2
+    fi
+  fi
 }
 trap cleanup EXIT
 
@@ -217,4 +231,11 @@ fi
 
 # From here on, the run can create cloud resources — arm the backstop cleanup (see trap).
 STARTED_RUN=1
-go test ./scenarios/ -run TestUpgrade -v -timeout 180m
+# Capture the test result so the EXIT trap can print a top-level PASS/FAIL banner and
+# the script exits with the test's status. (if/else keeps it safe under `set -e`.)
+if go test ./scenarios/ -run TestUpgrade -v -timeout 180m; then
+  TEST_RC=0
+else
+  TEST_RC=$?
+fi
+exit "$TEST_RC"


### PR DESCRIPTION
Brings v6.1-release's test harness up to master (it was behind: missing #182 per-config diagnostics dirs and #183 run-summary banner; v6.1 only ever got live/tests via merges *from* master, never authored its own).

Purpose: make the **Release v6.1** PR (#146, v6.1-release → master) show **only** `.github/workflows/release.yml` (the v6.1 changelog). Without this, #146 would *regress* master's harness on merge. Combined with #187 (metrics-server → master), #146 reduces to just the release.yml changelog.