### PR TITLE
harness: capability-based validation + teardown correctness + failure post-mortem

### DIFF
--- a/.github/workflows/upgrade-tests.yml
+++ b/.github/workflows/upgrade-tests.yml
@@ -1,0 +1,92 @@
+name: Upgrade Tests
+
+on:
+  workflow_dispatch:
+    inputs:
+      from_ref:
+        description: "baseline ref (default auto:latest-1)"
+        default: "auto:latest-1"
+      to_ref:
+        description: "target ref (default auto:latest)"
+        default: "auto:latest"
+      configs:
+        description: "comma-separated configs"
+        default: "min_default,bi_ha,full"
+      region:
+        description: "primary region"
+        default: "us-east-1"
+      dr_region:
+        description: "DR region"
+        default: "us-west-2"
+  pull_request:
+    types: [labeled, synchronize, reopened]
+
+permissions:
+  id-token: write
+  contents: read
+
+concurrency:
+  group: upgrade-tests-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  matrix:
+    # Run on manual dispatch always; on PRs only when the gate label is present.
+    if: github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'run-upgrade-tests')
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+    strategy:
+      fail-fast: false
+      matrix:
+        config: [min_default, bi_ha, full]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # full history + tags for worktree refs
+
+      - uses: opentofu/setup-opentofu@v1
+        with:
+          tofu_version: "1.11.8" # highest 1.11.x in Spacelift's bundled set; pairs with Terragrunt 0.99.4, satisfies physical's >= 1.11.1
+
+      - name: Install terragrunt
+        run: |
+          curl -fsSLo /usr/local/bin/terragrunt \
+            https://github.com/gruntwork-io/terragrunt/releases/download/v0.99.4/terragrunt_linux_amd64
+          chmod +x /usr/local/bin/terragrunt
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.22"
+
+      - name: Install helm + kubectl
+        run: |
+          curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+          curl -fsSLo /usr/local/bin/kubectl "https://dl.k8s.io/release/v1.31.0/bin/linux/amd64/kubectl"
+          chmod +x /usr/local/bin/kubectl
+
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.AWS_ROLE_ARN }}
+          aws-region: ${{ github.event.inputs.region || 'us-east-1' }}
+
+      - name: Run upgrade harness (${{ matrix.config }})
+        env:
+          RUN_INTEGRATION: "1"
+          TERRAGRUNT_TFPATH: tofu # physical layer requires OpenTofu (master_password_wo)
+          DDVTEST_ACCOUNT_ID: ${{ vars.DDVTEST_ACCOUNT_ID }}
+          RUN_ID: gha-${{ github.run_id }}
+          CONFIGS: ${{ matrix.config }}
+          FROM_REF: ${{ github.event.inputs.from_ref || 'auto:latest-1' }}
+          # On a PR, validate the PR head (the staged release); else the dispatch input.
+          TO_REF: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.event.inputs.to_ref || 'auto:latest' }}
+          DR_REGION: ${{ github.event.inputs.dr_region || 'us-west-2' }}
+          APP_NAMESPACE: dozuki
+        run: cd live/tests && go test ./scenarios/ -run TestUpgrade -v -timeout 350m
+
+      - name: Upload test logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: terratest-${{ matrix.config }}-${{ github.run_id }}
+          path: live/tests/**/test_output*/**
+          if-no-files-found: ignore

--- a/live/tests/cleanup-orphans.sh
+++ b/live/tests/cleanup-orphans.sh
@@ -21,6 +21,7 @@
 set -uo pipefail
 cd "$(dirname "$0")"
 HARNESS_DIR="$PWD"
+MARKERS_DIR="$HARNESS_DIR/__worktrees__/.markers"
 LIVE_ROOT="$(cd .. && pwd)"
 
 CUSTOMER="${CUSTOMER:-smoke}"
@@ -92,26 +93,72 @@ while IFS= read -r pfx; do
       --key "{\"LockID\":{\"S\":\"$lk\"}}" >/dev/null 2>&1 && echo "  released lock: $lk"
   done
 
-  # 3) Destroy the physical layer (also disposes of in-cluster helm/k8s via the EKS delete).
+  # 3) Destroy against the worktree whose code matches the deployed state (recorded
+  #    by the harness in a marker). The live tree is the current branch's code, which
+  #    does NOT match for cross-architecture upgrades — use it only as a last resort.
   destroyed_ok=1
-  if [ -n "$key" ] && [ -d "$LIVE_ROOT/$envdir/physical" ]; then
-    ( cd "$LIVE_ROOT/$envdir/physical"
-      rm -rf .terragrunt-cache
-      TG_AWS_ACCT_ID="$ACCT" TG_AWS_PROFILE="$P" TG_AWS_REGION="$region" TG_STATE_PREFIX="$pfx/" \
-      TF_VAR_customer="$CUSTOMER" TF_VAR_enable_dr=false \
-        terragrunt destroy --terragrunt-non-interactive -auto-approve -input=false )
-    destroyed_ok=$?
+  marker="$MARKERS_DIR/$(printf '%s' "$pfx" | tr '/' '_')"
+  tgt=""
+  if [ -f "$marker" ] && [ -d "$(cat "$marker")/physical" ]; then
+    tgt="$(cat "$marker")"
+    echo "  destroy target: worktree $tgt (from marker)"
+  elif [ -n "$key" ] && [ -d "$LIVE_ROOT/$envdir/physical" ]; then
+    tgt="$LIVE_ROOT/$envdir"
+    echo "  WARNING: no worktree marker for $pfx — falling back to LIVE tree $tgt (may not match deployed code)" >&2
+  fi
+  if [ -n "$tgt" ]; then
+    if [ "${DRY_RUN:-0}" = 1 ]; then
+      echo "  DRY_RUN: would destroy logical (best-effort) then physical in $tgt"; destroyed_ok=0
+    else
+      ( cd "$tgt/logical" 2>/dev/null && rm -rf .terragrunt-cache && \
+        TG_AWS_ACCT_ID="$ACCT" TG_AWS_PROFILE="$P" TG_AWS_REGION="$region" TG_STATE_PREFIX="$pfx/" \
+        TF_VAR_customer="$CUSTOMER" TF_VAR_enable_dr=false \
+          terragrunt destroy --terragrunt-non-interactive -auto-approve -input=false ) \
+        || echo "  logical destroy failed (continuing to physical so infra isn't stranded)" >&2
+      ( cd "$tgt/physical"
+        rm -rf .terragrunt-cache
+        TG_AWS_ACCT_ID="$ACCT" TG_AWS_PROFILE="$P" TG_AWS_REGION="$region" TG_STATE_PREFIX="$pfx/" \
+        TF_VAR_customer="$CUSTOMER" TF_VAR_enable_dr=false \
+          terragrunt destroy --terragrunt-non-interactive -auto-approve -input=false )
+      destroyed_ok=$?
+    fi
   elif [ -n "$key" ]; then
-    echo "  WARNING: $LIVE_ROOT/$envdir/physical not found — cannot destroy via terragrunt; leaving state intact." >&2
+    echo "  WARNING: no worktree marker and no live $LIVE_ROOT/$envdir/physical — cannot destroy via terragrunt; leaving state intact." >&2
     destroyed_ok=1
   fi
 
   # 4) Purge state objects ONLY if the destroy succeeded (else keep state so it can retry).
-  if [ "$destroyed_ok" -eq 0 ] || [ -z "$key" ]; then
+  if [ "${DRY_RUN:-0}" = 1 ]; then
+    echo "  DRY_RUN: would purge state prefix $pfx (only if the real destroy succeeded)"
+  elif [ "$destroyed_ok" -eq 0 ] || [ -z "$key" ]; then
     aws s3 rm "s3://$BUCKET/$pfx/" --recursive --profile "$P" >/dev/null 2>&1 && echo "  purged state prefix: $pfx"
   else
     echo "  destroy did NOT fully succeed — state prefix kept for retry: $pfx" >&2
     fail=1
+  fi
+
+  # 4b) Reclaim resources terraform does not own: the app's dynamic PVCs create EBS
+  #     volumes via the CSI driver (not in TF state), so destroy never removes them —
+  #     they orphan as `available`. Also sweep orphaned launch templates. Detached/
+  #     unused only; reports every deletion (no silent caps).
+  if [ -n "$env" ]; then
+    stack="${CUSTOMER}-${env}"
+    for vol in $(aws ec2 describe-volumes --region "$region" --profile "$P" \
+          --filters "Name=tag:Name,Values=${stack}-dynamic-pvc-*" "Name=status,Values=available" \
+          --query 'Volumes[].VolumeId' --output text 2>/dev/null | tr '\t' '\n'); do
+      [ -z "$vol" ] && continue
+      if [ "${DRY_RUN:-0}" = 1 ]; then echo "  DRY_RUN: would delete orphan volume $vol"; continue; fi
+      aws ec2 delete-volume --region "$region" --profile "$P" --volume-id "$vol" >/dev/null 2>&1 \
+        && echo "  reclaimed orphan EBS volume: $vol" || echo "  WARNING: could not delete volume $vol" >&2
+    done
+    for lt in $(aws ec2 describe-launch-templates --region "$region" --profile "$P" \
+          --filters "Name=launch-template-name,Values=${stack}-*" \
+          --query 'LaunchTemplates[].LaunchTemplateId' --output text 2>/dev/null | tr '\t' '\n'); do
+      [ -z "$lt" ] && continue
+      if [ "${DRY_RUN:-0}" = 1 ]; then echo "  DRY_RUN: would delete launch template $lt"; continue; fi
+      aws ec2 delete-launch-template --region "$region" --profile "$P" --launch-template-id "$lt" >/dev/null 2>&1 \
+        && echo "  reclaimed orphan launch template: $lt"
+    done
   fi
 done <<EOF
 $PREFIXES

--- a/live/tests/go.mod
+++ b/live/tests/go.mod
@@ -3,30 +3,29 @@ module github.com/Dozuki/CloudPrem-Infra/live/tests
 go 1.24
 
 require (
+	github.com/aws/aws-sdk-go-v2 v1.42.0
+	github.com/aws/aws-sdk-go-v2/config v1.32.25
+	github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.76.0
+	github.com/aws/aws-sdk-go-v2/service/databasemigrationservice v1.64.4
+	github.com/aws/aws-sdk-go-v2/service/eks v1.86.0
+	github.com/aws/aws-sdk-go-v2/service/rds v1.119.3
+	github.com/aws/aws-sdk-go-v2/service/s3 v1.104.0
 	gopkg.in/yaml.v3 v3.0.1
-	k8s.io/api v0.30.0
 	k8s.io/apimachinery v0.30.0
 	k8s.io/client-go v0.30.0
 )
 
 require (
-	github.com/aws/aws-sdk-go-v2 v1.42.0 // indirect
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.13 // indirect
-	github.com/aws/aws-sdk-go-v2/config v1.32.25 // indirect
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.24 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.29 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.29 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.29 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.30 // indirect
-	github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.76.0 // indirect
-	github.com/aws/aws-sdk-go-v2/service/databasemigrationservice v1.64.4 // indirect
-	github.com/aws/aws-sdk-go-v2/service/eks v1.86.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.12 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.9.22 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.29 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.29 // indirect
-	github.com/aws/aws-sdk-go-v2/service/rds v1.119.3 // indirect
-	github.com/aws/aws-sdk-go-v2/service/s3 v1.104.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/signin v1.2.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.31.3 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.36.6 // indirect
@@ -61,6 +60,7 @@ require (
 	google.golang.org/protobuf v1.33.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
+	k8s.io/api v0.30.0 // indirect
 	k8s.io/klog/v2 v2.120.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20240228011516-70dd3763d340 // indirect
 	k8s.io/utils v0.0.0-20230726121419-3b25d923346b // indirect

--- a/live/tests/harness/capabilities.go
+++ b/live/tests/harness/capabilities.go
@@ -1,0 +1,30 @@
+package harness
+
+import (
+	"github.com/Dozuki/CloudPrem-Infra/live/tests/validation"
+)
+
+// Capabilities describes what a deployed release supports, so validation runs only
+// the checks that apply. Infra flags are derived per ref from its Terraform outputs
+// (which readOutputs already extracts presence-tolerantly: a missing/renamed output
+// yields an empty value → the capability is absent). HasLogging is set by the caller
+// from the cluster (see validation.LoggingEnabled).
+type Capabilities struct {
+	HasDR           bool
+	HasDMS          bool
+	HasGuideBuckets bool
+	HasLogging      bool
+}
+
+// DetectCapabilities derives infra capabilities from already-read outputs.
+func DetectCapabilities(o validation.StackOutputs) Capabilities {
+	return Capabilities{
+		HasDR:           len(o.DRBucketNames) > 0,
+		HasDMS:          o.DMSTaskARN != "",
+		HasGuideBuckets: len(o.GuideBuckets) > 0,
+	}
+}
+
+// DefaultCriticalWorkloads is the fallback critical-set when matrix defaults omit it:
+// the app and nextjs deployments that back the served endpoint.
+func DefaultCriticalWorkloads() []string { return []string{"dozuki-app*", "*nextjs*"} }

--- a/live/tests/harness/capabilities_test.go
+++ b/live/tests/harness/capabilities_test.go
@@ -1,0 +1,28 @@
+package harness
+
+import (
+	"testing"
+
+	"github.com/Dozuki/CloudPrem-Infra/live/tests/validation"
+)
+
+func TestDetectCapabilities_presence(t *testing.T) {
+	full := validation.StackOutputs{
+		DMSTaskARN:    "arn:aws:dms:...:task/x",
+		GuideBuckets:  []string{"b1"},
+		DRBucketNames: []string{"dr1"},
+	}
+	got := DetectCapabilities(full)
+	if !got.HasDMS || !got.HasGuideBuckets || !got.HasDR {
+		t.Fatalf("full outputs: %+v, want all infra caps true", got)
+	}
+	// HasLogging is set by the caller from the cluster, not from outputs.
+	if got.HasLogging {
+		t.Fatalf("HasLogging should default false (set from cluster), got true")
+	}
+
+	empty := DetectCapabilities(validation.StackOutputs{})
+	if empty.HasDMS || empty.HasGuideBuckets || empty.HasDR {
+		t.Fatalf("empty outputs: %+v, want all infra caps false (missing → absent)", empty)
+	}
+}

--- a/live/tests/harness/config.go
+++ b/live/tests/harness/config.go
@@ -14,11 +14,12 @@ var harnessOnlyKeys = map[string]bool{
 }
 
 type Defaults struct {
-	FromRef  string `yaml:"from_ref"`
-	ToRef    string `yaml:"to_ref"`
-	Region   string `yaml:"region"`
-	DRRegion string `yaml:"dr_region"`
-	EnvPath  string `yaml:"env_path"`
+	FromRef           string   `yaml:"from_ref"`
+	ToRef             string   `yaml:"to_ref"`
+	Region            string   `yaml:"region"`
+	DRRegion          string   `yaml:"dr_region"`
+	EnvPath           string   `yaml:"env_path"`
+	CriticalWorkloads []string `yaml:"critical_workloads"`
 }
 
 type Config struct {

--- a/live/tests/harness/run.go
+++ b/live/tests/harness/run.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/Dozuki/CloudPrem-Infra/live/tests/validation"
@@ -36,18 +38,19 @@ func step(format string, args ...interface{}) {
 
 // RunParams configures one upgrade run.
 type RunParams struct {
-	RepoDir      string
-	Matrix       *Matrix
-	ConfigName   string
-	FromRef      string // resolved concrete ref
-	ToRef        string // resolved concrete ref
-	AccountID    string
-	Profile      string
-	RunID        string // unique per run; namespaces state
-	Namespace    string // app namespace, e.g. "dozuki"
-	DRRegion     string // DR region (e.g. "us-west-2"); set from matrix defaults
-	RestoreDrill bool   // run the RDS restore drill
-	EnableDR     bool   // DR validators enabled (enable_dr flag)
+	RepoDir           string
+	Matrix            *Matrix
+	ConfigName        string
+	FromRef           string // resolved concrete ref
+	ToRef             string // resolved concrete ref
+	AccountID         string
+	Profile           string
+	RunID             string   // unique per run; namespaces state
+	Namespace         string   // app namespace, e.g. "dozuki"
+	DRRegion          string   // DR region (e.g. "us-west-2"); set from matrix defaults
+	RestoreDrill      bool     // run the RDS restore drill
+	EnableDR          bool     // DR validators enabled (enable_dr flag)
+	CriticalWorkloads []string // critical workload name globs; empty → DefaultCriticalWorkloads()
 }
 
 // RunUpgrade executes apply(baseline) -> validate -> apply(target) -> validate
@@ -126,8 +129,9 @@ func RunUpgrade(p RunParams) (err error) {
 	}
 
 	// Write env.hcl into BOTH worktrees up front so the deferred destroy (which
-	// runs against toWT) always has a valid config to clean up with, even if the
-	// baseline apply fails before the target env.hcl would otherwise be written.
+	// runs against the applied worktree, appliedWT) always has a valid config to
+	// clean up with, even if the baseline apply fails before the target env.hcl
+	// would otherwise be written.
 	if werr := WriteEnvHCL(filepath.Join(fromWT.Dir, envSub), p.Matrix.MergedInputs(cfg, p.FromRef)); werr != nil {
 		return werr
 	}
@@ -135,18 +139,45 @@ func RunUpgrade(p RunParams) (err error) {
 		return werr
 	}
 
-	// Always attempt destroy (against the target/final code) without clobbering
-	// an earlier error. Registered last so it runs before the worktree removals.
-	defer func() {
-		// Capture artifacts BEFORE destroy (cluster) + before worktree removal (env.hcl).
-		// err (named return) reflects the run outcome here → full dump only on failure.
-		step("capturing diagnostics -> .artifacts/%s (full=%v)", p.RunID, err != nil)
-		captureDiagnostics(p, region, identifier, err != nil, tg(toWT), fromEnvHCL, toEnvHCL)
-		step("TEARDOWN: destroy (logical best-effort, then ALWAYS physical)")
-		if derr := tg(toWT).Destroy(); derr != nil && err == nil {
-			err = fmt.Errorf("destroy: %w", derr)
-		}
-	}()
+	// Track the worktree whose code matches what is deployed: baseline applies
+	// first, so default fromWT; flips to toWT only after the upgrade apply succeeds.
+	// The teardown destroys against THIS worktree (not always toWT) — essential for
+	// cross-architecture upgrades (e.g. v5.3->v6.1) where target code cannot destroy
+	// baseline state.
+	var appliedWT atomic.Pointer[Worktree]
+	appliedWT.Store(fromWT)
+	// Marker so the out-of-process cleanup-orphans backstop can destroy against the
+	// matching worktree too. Written for the baseline up front (a baseline-apply
+	// interrupt still leaves a correct from_ref marker).
+	_ = writeAppliedMarker(p.RepoDir, tg(fromWT).StatePrefix, tg(fromWT).WorkingDir)
+
+	var teardownOnce sync.Once
+	teardown := func(interrupted bool) {
+		teardownOnce.Do(func() {
+			wt := appliedWT.Load()
+			// An interrupted run is never "clean": full diagnostics, keep the marker
+			// for the cleanup backstop, and don't touch the named return err — the
+			// signal handler exits via os.Exit, and reading err here would race the
+			// still-running main goroutine.
+			failed := interrupted
+			if !interrupted {
+				failed = err != nil
+			}
+			step("capturing diagnostics -> .artifacts/%s (full=%v)", p.RunID, failed)
+			captureDiagnostics(p, region, identifier, failed, tg(wt), fromEnvHCL, toEnvHCL)
+			step("TEARDOWN: destroy against %s (logical best-effort, then ALWAYS physical)", wt.Ref)
+			derr := tg(wt).Destroy()
+			if !interrupted && derr != nil && err == nil {
+				err = fmt.Errorf("destroy: %w", derr)
+			}
+			if !failed {
+				removeAppliedMarker(p.RepoDir, tg(wt).StatePrefix)
+			}
+		})
+	}
+	defer teardown(false)
+	stopSig := installTeardownOnSignal(func() { teardown(true) }, os.Exit)
+	defer stopSig()
 
 	// ---- Baseline apply + validate ----
 	step("BASELINE apply: %s (terragrunt run-all apply — physical then logical)", p.FromRef)
@@ -154,7 +185,7 @@ func RunUpgrade(p RunParams) (err error) {
 		return fmt.Errorf("baseline apply: %w", aerr)
 	}
 	step("baseline applied — validating: cluster health (waits for pods Ready, up to 20m), endpoints, helm release")
-	baselineRev, _, verr := validateStack(tg(fromWT), p, region)
+	baselineRev, _, baseCaps, verr := validateStack(tg(fromWT), p, region)
 	if verr != nil {
 		return fmt.Errorf("baseline validation: %w", verr)
 	}
@@ -166,7 +197,7 @@ func RunUpgrade(p RunParams) (err error) {
 	if err != nil {
 		return fmt.Errorf("baseline readOutputs (sentinel): %w", err)
 	}
-	if len(baseOuts.GuideBuckets) > 0 {
+	if baseCaps.HasGuideBuckets {
 		if serr := validation.WriteSentinel(ctx, region, baseOuts.GuideBuckets[0], p.RunID); serr != nil {
 			return fmt.Errorf("continuity sentinel write: %w", serr)
 		}
@@ -180,8 +211,11 @@ func RunUpgrade(p RunParams) (err error) {
 	if aerr := tg(toWT).Apply(); aerr != nil {
 		return fmt.Errorf("upgrade apply: %w", aerr)
 	}
+	// Upgrade applied: target code now matches the deployed state.
+	appliedWT.Store(toWT)
+	_ = writeAppliedMarker(p.RepoDir, tg(toWT).StatePrefix, tg(toWT).WorkingDir)
 	step("upgrade applied — validating: cluster health (up to 20m), endpoints, helm release")
-	_, kc, verr := validateStack(tg(toWT), p, region)
+	_, kc, upCaps, verr := validateStack(tg(toWT), p, region)
 	if verr != nil {
 		return fmt.Errorf("upgrade validation: %w", verr)
 	}
@@ -191,32 +225,39 @@ func RunUpgrade(p RunParams) (err error) {
 		return fmt.Errorf("upgrade proof: %w", rerr)
 	}
 
-	// ---- Post-upgrade validators ----
-	step("upgrade proven ✓ — post-upgrade validators (control-plane logging, continuity sentinel, DMS, DR)")
+	// Post-upgrade validators — gated by detected capabilities; skips are logged.
+	step("upgrade proven ✓ — capability-gated post-upgrade validators")
 	outs, err := readOutputs(tg(toWT), region)
 	if err != nil {
 		return fmt.Errorf("post-upgrade readOutputs: %w", err)
 	}
+	upCaps.HasLogging = validation.LoggingEnabled(ctx, region, outs.ClusterName)
 
-	// Logging guard — always run.
-	if lerr := validation.AssertControlPlaneLogging(ctx, region, outs.ClusterName); lerr != nil {
-		return fmt.Errorf("logging guard: %w", lerr)
+	if upCaps.HasLogging {
+		if lerr := validation.AssertControlPlaneLogging(ctx, region, outs.ClusterName); lerr != nil {
+			return fmt.Errorf("logging guard: %w", lerr)
+		}
+	} else {
+		step("skipped: control-plane logging (not enabled on %s)", p.ToRef)
 	}
 
-	// Continuity sentinel — verify if a guide bucket was available pre-upgrade.
-	if len(outs.GuideBuckets) > 0 {
+	if upCaps.HasGuideBuckets {
 		if serr := validation.VerifySentinel(ctx, region, outs.GuideBuckets[0], p.RunID); serr != nil {
 			return fmt.Errorf("continuity sentinel verify: %w", serr)
 		}
+	} else {
+		step("skipped: continuity sentinel (no guide buckets in %s)", p.ToRef)
 	}
 
-	// DMS check — no-ops when DMSTaskARN is empty.
-	if derr := validation.AssertDMSRunning(ctx, region, outs.DMSTaskARN); derr != nil {
-		return fmt.Errorf("DMS running: %w", derr)
+	if upCaps.HasDMS {
+		if derr := validation.AssertDMSRunning(ctx, region, outs.DMSTaskARN); derr != nil {
+			return fmt.Errorf("DMS running: %w", derr)
+		}
+	} else {
+		step("skipped: DMS (no dms_task_arn in %s)", p.ToRef)
 	}
 
-	// DR validators — only when enable_dr is set for this config.
-	if p.EnableDR && len(outs.DRBucketNames) > 0 {
+	if p.EnableDR && upCaps.HasDR {
 		// Existence check: DR buckets versioned + replicated RDS backup present.
 		if derr := validation.AssertDRExistence(ctx, p.DRRegion, outs.DRBucketNames, outs.DBIdentifier); derr != nil {
 			return fmt.Errorf("DR existence: %w", derr)
@@ -227,11 +268,13 @@ func RunUpgrade(p RunParams) (err error) {
 		// from dr_s3_bucket_names is not guaranteed to align with guide bucket order),
 		// so we validate a single representative pair; the existence check covers all
 		// DR buckets above.
-		if len(outs.GuideBuckets) > 0 {
+		if upCaps.HasGuideBuckets {
 			if rerr := validation.AssertS3ReplicationFlow(ctx, region, p.DRRegion, outs.GuideBuckets[0], outs.DRBucketNames[0], p.RunID); rerr != nil {
 				return fmt.Errorf("DR S3 replication flow: %w", rerr)
 			}
 		}
+	} else if p.EnableDR {
+		step("skipped: DR (enable_dr set but no DR outputs in %s)", p.ToRef)
 	}
 
 	// Restore drill — only when requested (full config).
@@ -254,26 +297,36 @@ func generateLiveEnvs(worktreeDir string) error {
 }
 
 // validateStack runs the post-apply assertion suite and returns the helm
-// revision and the kubeconfig path it generated (reused by the upgrade proof).
-func validateStack(tg TGOptions, p RunParams, region string) (int, string, error) {
+// revision, the kubeconfig path it generated (reused by the upgrade proof),
+// and the detected Capabilities for use by later validation stages.
+func validateStack(tg TGOptions, p RunParams, region string) (int, string, Capabilities, error) {
 	outs, err := readOutputs(tg, region)
 	if err != nil {
-		return 0, "", err
+		return 0, "", Capabilities{}, err
 	}
+	caps := DetectCapabilities(outs)
 	if err := validation.CheckEndpoints(outs); err != nil {
-		return 0, "", err
+		return 0, "", caps, err
 	}
 	kubeDir := filepath.Dir(tg.WorkingDir)
 	kc, err := validation.Kubeconfig(outs.ClusterName, region, p.Profile, kubeDir)
 	if err != nil {
-		return 0, "", err
+		return 0, "", caps, err
 	}
-	if err := validation.CheckClusterHealth(kc, p.Namespace, 20*time.Minute); err != nil {
-		return 0, "", err
+	critical := p.CriticalWorkloads
+	if len(critical) == 0 {
+		critical = DefaultCriticalWorkloads()
+	}
+	advisory, err := validation.CheckClusterHealth(kc, p.Namespace, critical, 20*time.Minute)
+	if err != nil {
+		return 0, "", caps, err
+	}
+	for _, w := range advisory {
+		step("advisory: workload %s not Ready (non-critical — not failing the run)", w)
 	}
 	_ = validation.JobSucceeded(kc, p.Namespace, "db-migrations") // best-effort: job may be GC'd
 	rev, _ := validation.ReleaseRevision(kc, p.Namespace, "dozuki")
-	return rev, kc, nil
+	return rev, kc, caps, nil
 }
 
 // readOutputs pulls the outputs the validators need. Names reconciled against

--- a/live/tests/harness/teardown.go
+++ b/live/tests/harness/teardown.go
@@ -1,0 +1,72 @@
+package harness
+
+import (
+	"fmt"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"strings"
+	"syscall"
+)
+
+// markerDir holds per-run applied-ref markers, outside any single run's worktree
+// dir so it survives worktree removal.
+func markerDir(repoDir string) string {
+	return filepath.Join(repoDir, "live", "tests", "__worktrees__", ".markers")
+}
+
+// markerName flattens a state prefix (which ends in "/") into a flat filename.
+func markerName(statePrefix string) string {
+	return strings.ReplaceAll(strings.TrimSuffix(statePrefix, "/"), "/", "_")
+}
+
+// writeAppliedMarker records the env dir of the currently-applied worktree, keyed
+// by state prefix, so the out-of-process cleanup backstop can destroy against the
+// matching ref's code instead of the live tree.
+func writeAppliedMarker(repoDir, statePrefix, envDir string) error {
+	d := markerDir(repoDir)
+	if err := os.MkdirAll(d, 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(d, markerName(statePrefix)), []byte(envDir+"\n"), 0o644)
+}
+
+// readAppliedMarker returns the recorded env dir for a state prefix.
+func readAppliedMarker(repoDir, statePrefix string) (string, error) {
+	b, err := os.ReadFile(filepath.Join(markerDir(repoDir), markerName(statePrefix)))
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(b)), nil
+}
+
+// removeAppliedMarker deletes a run's marker (best-effort).
+func removeAppliedMarker(repoDir, statePrefix string) {
+	_ = os.Remove(filepath.Join(markerDir(repoDir), markerName(statePrefix)))
+}
+
+// watchSignals runs teardown() once on a signal, then exit(1). Returns when either
+// a signal arrives (after teardown+exit) or done is closed. Split from signal.Notify
+// wiring so it is unit-testable with a fake channel.
+func watchSignals(sigCh <-chan os.Signal, done <-chan struct{}, teardown func(), exit func(int)) {
+	select {
+	case <-sigCh:
+		fmt.Fprintf(os.Stderr, "\n>> [harness] interrupted — running teardown before exit\n")
+		teardown()
+		exit(1)
+	case <-done:
+	}
+}
+
+// installTeardownOnSignal wires SIGINT/SIGTERM to watchSignals. The returned stop()
+// unregisters the handler and ends the goroutine; call it via defer.
+func installTeardownOnSignal(teardown func(), exit func(int)) (stop func()) {
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
+	done := make(chan struct{})
+	go watchSignals(sigCh, done, teardown, exit)
+	return func() {
+		signal.Stop(sigCh)
+		close(done)
+	}
+}

--- a/live/tests/harness/teardown_test.go
+++ b/live/tests/harness/teardown_test.go
@@ -1,0 +1,69 @@
+package harness
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+)
+
+func TestMarkerName_flattensStatePrefix(t *testing.T) {
+	got := markerName("local-1-min_default-min_default/")
+	want := "local-1-min_default-min_default"
+	if got != want {
+		t.Fatalf("markerName = %q, want %q", got, want)
+	}
+	if got := markerName("a/b/c/"); got != "a_b_c" {
+		t.Fatalf("markerName nested = %q, want a_b_c", got)
+	}
+}
+
+func TestAppliedMarker_writeReadRemove(t *testing.T) {
+	repo := t.TempDir()
+	envDir := filepath.Join(repo, "live", "tests", "__worktrees__", "run1", "v5.3", "live", "standard", "us-east-1", "min")
+	const sp = "local-1-min_default-min_default/"
+
+	if _, err := readAppliedMarker(repo, sp); err == nil {
+		t.Fatal("expected error reading a missing marker")
+	}
+	if err := writeAppliedMarker(repo, sp, envDir); err != nil {
+		t.Fatalf("writeAppliedMarker: %v", err)
+	}
+	got, err := readAppliedMarker(repo, sp)
+	if err != nil {
+		t.Fatalf("readAppliedMarker: %v", err)
+	}
+	if got != envDir {
+		t.Fatalf("readAppliedMarker = %q, want %q", got, envDir)
+	}
+	removeAppliedMarker(repo, sp)
+	if _, err := readAppliedMarker(repo, sp); err == nil {
+		t.Fatal("expected error after remove")
+	}
+}
+
+func TestWatchSignals_runsTeardownThenExitOnSignal(t *testing.T) {
+	sigCh := make(chan os.Signal, 1)
+	done := make(chan struct{})
+	var torn, exited int
+	teardown := func() { torn++ }
+	exit := func(int) { exited++ }
+
+	sigCh <- syscall.SIGTERM // signal already pending
+	watchSignals(sigCh, done, teardown, exit)
+
+	if torn != 1 || exited != 1 {
+		t.Fatalf("on signal: torn=%d exited=%d, want 1/1", torn, exited)
+	}
+}
+
+func TestWatchSignals_noTeardownWhenDoneClosed(t *testing.T) {
+	sigCh := make(chan os.Signal, 1)
+	done := make(chan struct{})
+	var torn int
+	close(done) // normal-exit path
+	watchSignals(sigCh, done, func() { torn++ }, func(int) {})
+	if torn != 0 {
+		t.Fatalf("on done: torn=%d, want 0", torn)
+	}
+}

--- a/live/tests/matrix.yaml
+++ b/live/tests/matrix.yaml
@@ -20,10 +20,18 @@ versions:
     image_tag: "3625f3c7a3fe9bd3fb87b03a23a4cbb683d44ded.4"
     nextjs_tag: "2.23.0"
     image_repository: "069174876992.dkr.ecr.us-east-1.amazonaws.com"
+  v6.0.2:                                                              # v6.0.1 + KMS 7-day dev deletion window. Same app images.
+    image_tag: "3625f3c7a3fe9bd3fb87b03a23a4cbb683d44ded.4"
+    nextjs_tag: "2.23.0"
+    image_repository: "069174876992.dkr.ecr.us-east-1.amazonaws.com"
+  v6.0.3:                                                              # v6.0.2 + chart TLS-secret kubernetes.io/tls fix (serves HTTPS over Envoy Gateway). PREFERRED baseline. Same app images.
+    image_tag: "3625f3c7a3fe9bd3fb87b03a23a4cbb683d44ded.4"
+    nextjs_tag: "2.23.0"
+    image_repository: "069174876992.dkr.ecr.us-east-1.amazonaws.com"
   v6.1-release:
     image_tag: "3625f3c7a3fe9bd3fb87b03a23a4cbb683d44ded.4"
     nextjs_tag: "2.23.0"
-    chart_version: "0.3.6"
+    chart_version: "0.3.12"   # typed tls-secret (#54) + db-migrations upgrade-deadlock fix (#49); supplied TLS via chart
     image_repository: "069174876992.dkr.ecr.us-east-1.amazonaws.com"   # e.g. <acct>.dkr.ecr.us-east-1.amazonaws.com
 
 configs:

--- a/live/tests/postmortem.sh
+++ b/live/tests/postmortem.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# postmortem.sh RUN_ID RUN_LOG — opt-in (RUN_POSTMORTEM=1) LLM root-cause analysis of a
+# FAILED harness run. Non-gating. No-ops cleanly if the `claude` CLI isn't installed.
+set -uo pipefail
+RUN_ID="${1:?usage: postmortem.sh RUN_ID RUN_LOG}"
+RUN_LOG="${2:?usage: postmortem.sh RUN_ID RUN_LOG}"
+cd "$(dirname "$0")"
+
+if ! command -v claude >/dev/null 2>&1; then
+  echo ">> post-mortem: 'claude' CLI not found — skipping (pull the artifacts and run it manually)" >&2
+  exit 0
+fi
+
+ADIR="$PWD/.artifacts/$RUN_ID"
+mkdir -p "$ADIR"
+OUT="$ADIR/postmortem.txt"
+manifest="$( cd "$PWD/.artifacts" 2>/dev/null && ls -R "$RUN_ID" "$RUN_ID"-* 2>/dev/null | head -200 )"
+logtail="$( tail -300 "$RUN_LOG" 2>/dev/null )"
+prompt="You are debugging a FAILED CloudPrem upgrade-test harness run. From the artifact file manifest and the run-log tail below, identify the single most likely ROOT CAUSE and one concrete next step. Be concise (under 200 words).
+
+=== artifact manifest ===
+$manifest
+
+=== run log (tail) ===
+$logtail"
+
+echo ">> post-mortem: analyzing failure with claude (non-gating) ..." >&2
+if printf '%s' "$prompt" | claude -p >"$OUT" 2>/dev/null && [ -s "$OUT" ]; then
+  echo "================ POST-MORTEM (claude) ================" >&2
+  cat "$OUT" >&2
+  echo "=====================================================" >&2
+  echo ">> post-mortem saved to $OUT" >&2
+else
+  echo ">> post-mortem: claude invocation produced no output — skipping (non-fatal)" >&2
+fi
+exit 0

--- a/live/tests/run.sh
+++ b/live/tests/run.sh
@@ -143,16 +143,6 @@ cleanup() {
   fi
 
   echo ">> Full run log saved to: $RUN_LOG" >&2
-
-  # Top-level result banner — the one line to look for. Per-config detail (refs,
-  # phases, durations) is in the "HARNESS RUN SUMMARY" block printed by the Go harness.
-  if [ "${STARTED_RUN:-0}" = 1 ]; then
-    if [ "${TEST_RC:-1}" = 0 ]; then
-      echo ">> ================ RESULT: PASS ✓  (run ${RUN_ID}) ================" >&2
-    else
-      echo ">> ================ RESULT: FAIL ✗  (run ${RUN_ID}, exit ${TEST_RC:-?}) ================" >&2
-    fi
-  fi
 }
 trap cleanup EXIT
 
@@ -231,11 +221,10 @@ fi
 
 # From here on, the run can create cloud resources — arm the backstop cleanup (see trap).
 STARTED_RUN=1
-# Capture the test result so the EXIT trap can print a top-level PASS/FAIL banner and
-# the script exits with the test's status. (if/else keeps it safe under `set -e`.)
-if go test ./scenarios/ -run TestUpgrade -v -timeout 180m; then
-  TEST_RC=0
-else
-  TEST_RC=$?
+if go test ./scenarios/ -run TestUpgrade -v -timeout 180m; then TEST_RC=0; else TEST_RC=$?; fi
+
+if [ "$TEST_RC" -ne 0 ] && [ "${RUN_POSTMORTEM:-0}" = 1 ]; then
+  ./postmortem.sh "$RUN_ID" "$RUN_LOG" || true
 fi
+
 exit "$TEST_RC"

--- a/live/tests/validation/cluster.go
+++ b/live/tests/validation/cluster.go
@@ -5,10 +5,9 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"time"
 
-	appsv1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
@@ -35,67 +34,92 @@ func clientFor(kubeconfig string) (*kubernetes.Clientset, error) {
 	return kubernetes.NewForConfig(cfg)
 }
 
-// CheckClusterHealth asserts: every Deployment/StatefulSet in namespace has
-// ready==desired, no pod is in CrashLoopBackOff/Error, and (best-effort) the
-// db-migrations Job succeeded. Retries until ready or timeout.
-func CheckClusterHealth(kubeconfig, namespace string, timeout time.Duration) error {
+// matchesAny reports whether name matches any glob pattern (filepath.Match).
+func matchesAny(name string, patterns []string) bool {
+	for _, p := range patterns {
+		if ok, _ := filepath.Match(p, name); ok {
+			return true
+		}
+	}
+	return false
+}
+
+// CheckClusterHealth blocks (up to timeout) until every workload whose name matches
+// the critical set reports ready==desired, then returns the names of NON-critical
+// workloads that are not ready (advisory; never an error). A critical workload absent
+// from the cluster is an error.
+func CheckClusterHealth(kubeconfig, namespace string, critical []string, timeout time.Duration) ([]string, error) {
 	cs, err := clientFor(kubeconfig)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	ctx := context.Background()
 	started := time.Now()
 	deadline := started.Add(timeout)
 	for {
-		err := clusterReadyOnce(ctx, cs, namespace)
-		if err == nil {
-			fmt.Fprintf(os.Stderr, ">> [harness %s] cluster healthy — all workloads Ready (%s)\n", time.Now().Format("15:04:05"), time.Since(started).Round(time.Second))
-			return nil
+		advisory, matched, ready, err := evaluateWorkloads(ctx, cs, namespace, critical)
+		if err != nil {
+			return nil, err
+		}
+		if ready {
+			fmt.Fprintf(os.Stderr, ">> [harness %s] critical workloads Ready (%s)\n", time.Now().Format("15:04:05"), time.Since(started).Round(time.Second))
+			return advisory, nil
 		}
 		if time.Now().After(deadline) {
-			return fmt.Errorf("cluster not healthy within %s: %w", timeout, err)
+			if len(critical) > 0 && !matched {
+				return nil, fmt.Errorf("no workload matched the critical set %v within %s (expected the release to deploy one)", critical, timeout)
+			}
+			return nil, fmt.Errorf("critical workloads not ready within %s", timeout)
 		}
-		// Heartbeat so the (otherwise silent) up-to-20m wait shows progress.
-		fmt.Fprintf(os.Stderr, ">> [harness %s] waiting for cluster (%s elapsed): %v\n", time.Now().Format("15:04:05"), time.Since(started).Round(time.Second), err)
+		fmt.Fprintf(os.Stderr, ">> [harness %s] waiting for critical workloads (%s elapsed)\n", time.Now().Format("15:04:05"), time.Since(started).Round(time.Second))
 		time.Sleep(30 * time.Second)
 	}
 }
 
-func clusterReadyOnce(ctx context.Context, cs *kubernetes.Clientset, ns string) error {
+// evaluateWorkloads inspects current Deployments+StatefulSets and reports: the
+// not-ready non-critical (advisory) workloads, whether any critical pattern matched
+// a workload (matched), and whether the critical set is satisfied (ready). It only
+// errors on an API list failure — "no critical match" is surfaced by the caller at
+// timeout, so a not-yet-listed critical workload is waited for rather than failed.
+func evaluateWorkloads(ctx context.Context, cs kubernetes.Interface, ns string, critical []string) (advisory []string, matched bool, ready bool, err error) {
+	type wl struct {
+		name           string
+		ready, desired int32
+	}
+	var all []wl
 	deps, err := cs.AppsV1().Deployments(ns).List(ctx, metav1.ListOptions{})
 	if err != nil {
-		return err
+		return nil, false, false, err
 	}
 	for _, d := range deps.Items {
-		if !deploymentReady(d) {
-			return fmt.Errorf("deployment %s not ready (%d/%d)", d.Name, d.Status.ReadyReplicas, desired(d.Spec.Replicas))
-		}
+		all = append(all, wl{d.Name, d.Status.ReadyReplicas, desired(d.Spec.Replicas)})
 	}
 	sss, err := cs.AppsV1().StatefulSets(ns).List(ctx, metav1.ListOptions{})
 	if err != nil {
-		return err
+		return nil, false, false, err
 	}
 	for _, s := range sss.Items {
-		if s.Status.ReadyReplicas != desired(s.Spec.Replicas) {
-			return fmt.Errorf("statefulset %s not ready (%d/%d)", s.Name, s.Status.ReadyReplicas, desired(s.Spec.Replicas))
-		}
+		all = append(all, wl{s.Name, s.Status.ReadyReplicas, desired(s.Spec.Replicas)})
 	}
-	pods, err := cs.CoreV1().Pods(ns).List(ctx, metav1.ListOptions{})
-	if err != nil {
-		return err
-	}
-	for _, p := range pods.Items {
-		for _, st := range p.Status.ContainerStatuses {
-			if st.State.Waiting != nil && (st.State.Waiting.Reason == "CrashLoopBackOff" || st.State.Waiting.Reason == "Error") {
-				return fmt.Errorf("pod %s container %s in %s", p.Name, st.Name, st.State.Waiting.Reason)
-			}
-		}
-	}
-	return nil
-}
 
-func deploymentReady(d appsv1.Deployment) bool {
-	return d.Status.ReadyReplicas == desired(d.Spec.Replicas)
+	allCriticalReady := true
+	for _, w := range all {
+		isReady := w.ready == w.desired
+		if matchesAny(w.name, critical) {
+			matched = true
+			if !isReady {
+				allCriticalReady = false
+			}
+		} else if !isReady {
+			advisory = append(advisory, w.name)
+		}
+	}
+	if len(critical) == 0 {
+		ready = true // no critical gate configured
+	} else {
+		ready = matched && allCriticalReady
+	}
+	return advisory, matched, ready, nil
 }
 
 func desired(r *int32) int32 {
@@ -120,5 +144,3 @@ func JobSucceeded(kubeconfig, namespace, name string) error {
 	}
 	return nil
 }
-
-var _ = corev1.Pod{} // keep corev1 import if pod helpers are extended

--- a/live/tests/validation/logging.go
+++ b/live/tests/validation/logging.go
@@ -13,6 +13,30 @@ import (
 
 var wantLogTypes = map[string]bool{"api": true, "audit": true, "authenticator": true, "controllerManager": true, "scheduler": true}
 
+// LoggingEnabled reports whether the EKS cluster has any control-plane log types
+// enabled. Used to gate AssertControlPlaneLogging so older refs (no logging) skip
+// rather than fail. Best-effort: any error → false (treated as "capability absent").
+func LoggingEnabled(ctx context.Context, region, clusterName string) bool {
+	cfg, err := config.LoadDefaultConfig(ctx, config.WithRegion(region))
+	if err != nil {
+		return false
+	}
+	ek := eks.NewFromConfig(cfg)
+	cl, err := ek.DescribeCluster(ctx, &eks.DescribeClusterInput{Name: &clusterName})
+	if err != nil {
+		return false
+	}
+	if cl.Cluster == nil || cl.Cluster.Logging == nil {
+		return false
+	}
+	for _, lc := range cl.Cluster.Logging.ClusterLogging {
+		if lc.Enabled != nil && *lc.Enabled && len(lc.Types) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
 // AssertControlPlaneLogging verifies all 5 control-plane log types are enabled,
 // the log group exists at 90-day retention, and audit events are flowing.
 func AssertControlPlaneLogging(ctx context.Context, region, clusterName string) error {


### PR DESCRIPTION
## What

Lands the three net-new harness batches on top of master's current harness. This **replaces PR #185**, whose branch (`integration-testing`) was a long-lived divergent reimplementation of the whole harness and couldn't merge cleanly (add/add conflicts on every `live/tests/` file). This branch is cut fresh from master and adds **only** the work master doesn't already have.

## Batches

**Teardown correctness** (`harness/teardown.go` NEW, `run.go`, `cleanup-orphans.sh`)
- Destroy against the **deployed worktree** (track `appliedWT`; applied-ref marker so the `cleanup-orphans` backstop matches it; live-tree fallback) — essential for upgrades crossing incompatible architectures.
- **SIGINT/SIGTERM → teardown** (`sync.Once`, race-safe) so Ctrl-C runs the correct teardown instead of leaking a stack.
- Reclaim orphaned PVC EBS volumes + launch templates (CSI volumes aren't in TF state). `DRY_RUN` fully non-destructive (no state purge).

**Capability-based validation** (`harness/capabilities.go` NEW, `validation/cluster.go`, `validation/logging.go`, `config.go`, `run.go`)
- Three tiers: universal (app 200 + helm revision) → critical-workload health (name-glob set, advisory for the rest) → capability-gated infra checks (logged `skip:` when absent). Capabilities auto-detected per ref so an old/different ref degrades gracefully instead of hanging/false-failing.

**Opt-in failure post-mortem** (`postmortem.sh` NEW, `run.sh`)
- `RUN_POSTMORTEM=1` runs the local `claude` CLI over the artifact bundle + log tail on failure. Non-gating; no-ops if `claude` absent.

Plus: `matrix.yaml` v6.0.2/v6.0.3 baseline profiles (chart 0.3.12), and the `upgrade-tests.yml` CI workflow pinned to **OpenTofu 1.11.8** (Spacelift-compatible; pairs with Terragrunt 0.99.4).

## Testing
`go build/vet/test ./...` green, `gofmt -l` clean, `bash -n` clean (run from `live/tests/`). New Go is unit-tested (teardown marker/signal paths, capability detection). Built on master's harness — run-summary banner, artifact bundling, azure paths all preserved.

## Not included
- `terraform/physical/variables.tf`: master is ahead; integration-testing was behind, so master's version is kept unchanged.