### PR TITLE
Enforce TLS on Azure MySQL (require_secure_transport ON)

### DIFF
--- a/terraform/physical-azure/mysql.tf
+++ b/terraform/physical-azure/mysql.tf
@@ -47,7 +47,10 @@ resource "azurerm_mysql_flexible_server_configuration" "require_secure_transport
   name                = "require_secure_transport"
   resource_group_name = azurerm_resource_group.this.name
   server_name         = azurerm_mysql_flexible_server.this.name
-  value               = "OFF"
+  # Enforce TLS by default. The app mounts the Azure MySQL CA (vendor/azure-mysql-global.pem,
+  # wired via local.ca_cert_pem_file -> db.rdsCaCert) and sets CAFile on every connection in
+  # db.json, so it already connects over TLS — a plaintext fallback is unnecessary and a risk.
+  value = var.mysql_require_secure_transport ? "ON" : "OFF"
 }
 
 resource "azurerm_management_lock" "mysql" {

--- a/terraform/physical-azure/variables.tf
+++ b/terraform/physical-azure/variables.tf
@@ -153,6 +153,12 @@ variable "mysql_geo_redundant_backup" {
   default     = true
 }
 
+variable "mysql_require_secure_transport" {
+  description = "Enforce TLS on the Azure MySQL Flexible Server (require_secure_transport). Default true (Azure's secure default). The app mounts the Azure MySQL CA (vendor/azure-mysql-global.pem) and sets CAFile on every DB connection, so ON does not break it. Set false only for a temporary migration where a client cannot yet use TLS."
+  type        = bool
+  default     = true
+}
+
 variable "aks_api_allowed_cidrs" {
   description = "Public IPs/CIDRs allowed to reach the AKS API server. Empty leaves the endpoint open (v1 default); the bootstrap passes the operator's egress IP."
   type        = list(string)


### PR DESCRIPTION
## Summary
Fixes a security-review **MEDIUM**: `terraform/physical-azure/mysql.tf` explicitly set `require_secure_transport = OFF` on the Azure MySQL Flexible Server, permitting **plaintext** DB connections.

## Why it's safe to flip ON
The app already connects over TLS to Azure MySQL — verified end-to-end:
- `terraform/logical/main.tf` sets `local.ca_cert_pem_file = vendor/azure-mysql-global.pem` for `cloud == "azure"`.
- `terraform/logical/kubernetes.tf` passes it to the chart as `db.rdsCaCert` (base64).
- The chart writes it to `/etc/dozuki/rds-ca.pem` and the app's `db.json` sets `"CAFile": "/etc/dozuki/rds-ca.pem"` on **all four** connections (generic/master/slave/sphinx), unconditionally.

So the server's `OFF` only permitted an unnecessary plaintext fallback. `ON` enforces what the app already does — same approach as the RDS/Aurora path.

## Change
- New `var.mysql_require_secure_transport` (bool, **default `true`** = Azure's secure default).
- The config resource now uses `var ... ? "ON" : "OFF"`. Set `false` only for a temporary migration where a client cannot yet present TLS.

## Test plan
- [ ] Apply to the Azure stack; confirm `SHOW VARIABLES LIKE 'require_secure_transport'` = `ON`
- [ ] App login / DB access still works (it presents the Azure CA, so it should)
- [ ] A plaintext (`--ssl-mode=DISABLED`) client connection is now rejected

## Note
Targeted at `master`. If the Azure stack deploys from `v6.1-release`, this should be cherry-picked there too (happy to open that PR).