### PR TITLE
fix: use data.aws_region.current.region (.id deprecated) — physical + logical

### DIFF
--- a/terraform/logical/bi.tf
+++ b/terraform/logical/bi.tf
@@ -17,7 +17,7 @@ resource "kubernetes_job_v1" "dms_start" {
           command = [
             "/bin/sh",
             "-c",
-            "kubectl wait deploy/app-deployment --for condition=available --timeout=1200s && aws dms start-replication-task --start-replication-task-type start-replication --replication-task-arn ${var.dms_task_arn} --region ${data.aws_region.current[0].id}"
+            "kubectl wait deploy/app-deployment --for condition=available --timeout=1200s && aws dms start-replication-task --start-replication-task-type start-replication --replication-task-arn ${var.dms_task_arn} --region ${data.aws_region.current[0].region}"
           ]
         }
         restart_policy = "Never"

--- a/terraform/logical/kubernetes.tf
+++ b/terraform/logical/kubernetes.tf
@@ -493,7 +493,7 @@ resource "helm_release" "app" {
     { name = "environment", value = var.environment },
 
     # --- AWS ---
-    { name = "aws.region", value = var.cloud == "aws" ? data.aws_region.current[0].id : "us-east-1" },
+    { name = "aws.region", value = var.cloud == "aws" ? data.aws_region.current[0].region : "us-east-1" },
     { name = "aws.accountId", value = var.cloud == "aws" ? data.aws_caller_identity.current[0].account_id : "" },
     { name = "aws.enabled", value = var.cloud == "aws" ? "true" : "false" },
 

--- a/terraform/logical/main.tf
+++ b/terraform/logical/main.tf
@@ -132,7 +132,7 @@ locals {
 
   k8s_exec_command = var.cloud == "aws" ? "aws" : "kubelogin"
   k8s_exec_args = var.cloud == "aws" ? [
-    "eks", "get-token", "--cluster-name", var.eks_cluster_id, "--region", data.aws_region.current[0].id
+    "eks", "get-token", "--cluster-name", var.eks_cluster_id, "--region", data.aws_region.current[0].region
     ] : concat(
     ["get-token", "--server-id", "6dae42f8-4368-4678-94ff-3960e28e3630", "--login", var.azure_kubelogin_login],
     var.azure_environment == "usgovernment" ? ["--environment", "AzureUSGovernmentCloud"] : []
@@ -162,7 +162,7 @@ locals {
     customer               = { value = coalesce(var.customer, "Dozuki") }
     environment            = { value = var.environment }
     aws_acct_id            = { value = var.cloud == "aws" ? data.aws_caller_identity.current[0].account_id : "" }
-    aws_region             = { value = var.cloud == "aws" ? data.aws_region.current[0].id : "us-east-1" }
+    aws_region             = { value = var.cloud == "aws" ? data.aws_region.current[0].region : "us-east-1" }
     hostname               = { value = var.dns_domain_name }
     ingress_hostname       = { value = coalesce(var.ingress_hostname, var.dns_domain_name) }
     bi_enabled             = { value = var.enable_bi ? "true" : "false" }

--- a/terraform/physical/bastion.tf
+++ b/terraform/physical/bastion.tf
@@ -49,7 +49,7 @@ resource "aws_ssm_association" "bastion_mysql_config" {
   parameters = {
     RDSEndpoint : local.db_host
     RDSCredentialSecret : aws_secretsmanager_secret.primary_database_credentials.id
-    Region : data.aws_region.current.id
+    Region : data.aws_region.current.region
   }
 
   targets {
@@ -73,7 +73,7 @@ resource "aws_ssm_association" "bastion_kubernetes_config" {
   parameters = {
     EKSClusterName : module.eks_cluster.cluster_name
     EKSClusterRole : module.cluster_access_role_assumable.arn
-    Region : data.aws_region.current.id
+    Region : data.aws_region.current.region
   }
 
   targets {
@@ -98,7 +98,7 @@ module "bastion" {
   name = "${local.identifier}-bastion"
 
   create_iam_instance_profile = true
-  iam_role_name               = "${local.identifier}-${data.aws_region.current.id}-bastion"
+  iam_role_name               = "${local.identifier}-${data.aws_region.current.region}-bastion"
   iam_role_path               = "/ec2/"
   iam_role_description        = "Bastion IAM Role"
   iam_role_tags = {

--- a/terraform/physical/bi.tf
+++ b/terraform/physical/bi.tf
@@ -158,7 +158,7 @@ resource "null_resource" "replication_control" {
     dms_task_arn        = aws_dms_replication_task.this[0].replication_task_arn,
     source_endpoint_arn = aws_dms_endpoint.source[0].endpoint_arn,
     target_endpoint_arn = aws_dms_endpoint.target[0].endpoint_arn,
-    aws_region          = data.aws_region.current.id,
+    aws_region          = data.aws_region.current.region,
     aws_profile         = var.aws_profile
   }
 

--- a/terraform/physical/dr.tf
+++ b/terraform/physical/dr.tf
@@ -9,7 +9,7 @@ locals {
   dr_enabled = var.enable_dr
 
   # Source RDS instance ARN (the rds module exposes no ARN output, so construct it).
-  dr_source_db_arn = "arn:${data.aws_partition.current.partition}:rds:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:db:${local.identifier}"
+  dr_source_db_arn = "arn:${data.aws_partition.current.partition}:rds:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:db:${local.identifier}"
 
   # Use a Terraform-created customer-managed key for RDS only when a new stack
   # opts in AND no explicit key was given. Resolves to the SAME ARN as before for
@@ -27,8 +27,8 @@ locals {
 # in the admin layer; this only catches a missing/echoed injection.
 check "dr_region_valid" {
   assert {
-    condition     = !var.enable_dr || (var.dr_region != "" && var.dr_region != data.aws_region.current.id)
-    error_message = "enable_dr is true but dr_region is empty or equals the primary region (${data.aws_region.current.id}). The admin layer must inject TG_AWS_DR_REGION, or set dr_region explicitly."
+    condition     = !var.enable_dr || (var.dr_region != "" && var.dr_region != data.aws_region.current.region)
+    error_message = "enable_dr is true but dr_region is empty or equals the primary region (${data.aws_region.current.region}). The admin layer must inject TG_AWS_DR_REGION, or set dr_region explicitly."
   }
 }
 
@@ -178,7 +178,7 @@ data "aws_iam_policy_document" "dr_s3_replication_assume" {
 
 resource "aws_iam_role" "dr_s3_replication" {
   count              = local.dr_enabled ? 1 : 0
-  name               = "${local.identifier}-${data.aws_region.current.id}-dr-s3-replication"
+  name               = "${local.identifier}-${data.aws_region.current.region}-dr-s3-replication"
   assume_role_policy = data.aws_iam_policy_document.dr_s3_replication_assume[0].json
   tags               = local.tags
 }
@@ -218,7 +218,7 @@ data "aws_iam_policy_document" "dr_s3_replication" {
 
 resource "aws_iam_policy" "dr_s3_replication" {
   count  = local.dr_enabled ? 1 : 0
-  name   = "${local.identifier}-${data.aws_region.current.id}-dr-s3-replication"
+  name   = "${local.identifier}-${data.aws_region.current.region}-dr-s3-replication"
   policy = data.aws_iam_policy_document.dr_s3_replication[0].json
 }
 

--- a/terraform/physical/eks.tf
+++ b/terraform/physical/eks.tf
@@ -11,7 +11,7 @@ module "cluster_access_role_assumable" {
 
   create = true
 
-  name            = "${local.identifier}-${data.aws_region.current.id}-cluster-access-assumable"
+  name            = "${local.identifier}-${data.aws_region.current.region}-cluster-access-assumable"
   use_name_prefix = false
 
   policies = {
@@ -40,13 +40,13 @@ data "aws_iam_policy_document" "cluster_access" {
     ]
 
     resources = [
-      "arn:${data.aws_partition.current.partition}:eks:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:cluster/${local.identifier}",
+      "arn:${data.aws_partition.current.partition}:eks:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:cluster/${local.identifier}",
     ]
   }
 }
 
 resource "aws_iam_policy" "cluster_access" {
-  name   = "${local.identifier}-${data.aws_region.current.id}-cluster-access"
+  name   = "${local.identifier}-${data.aws_region.current.region}-cluster-access"
   policy = data.aws_iam_policy_document.cluster_access.json
 }
 
@@ -154,14 +154,14 @@ data "aws_iam_policy_document" "eks_worker" {
 }
 
 resource "aws_iam_policy" "eks_worker" {
-  name   = "${local.identifier}-${data.aws_region.current.id}"
+  name   = "${local.identifier}-${data.aws_region.current.region}"
   policy = data.aws_iam_policy_document.eks_worker.json
 }
 
 # We need separate policies to maintain backwards compatibility with existing stacks. Modifying the existing policy
 # with new resources triggers a cluster breaking event.
 resource "aws_iam_policy" "eks_worker_kms" {
-  name   = "${local.identifier}-${data.aws_region.current.id}-kms"
+  name   = "${local.identifier}-${data.aws_region.current.region}-kms"
   policy = data.aws_iam_policy_document.eks_worker_kms.json
 }
 
@@ -174,7 +174,7 @@ resource "aws_kms_key" "eks" {
 }
 
 resource "aws_iam_policy" "assume_cross_account_role" {
-  name        = "${local.identifier}-${data.aws_region.current.id}-AssumeCrossAccountRole"
+  name        = "${local.identifier}-${data.aws_region.current.region}-AssumeCrossAccountRole"
   description = "Policy to assume the cross-account role for Route 53 hosted zone access"
 
   policy = jsonencode({
@@ -280,7 +280,7 @@ module "eks_cluster" {
 
 # Pod Identity: App workloads (S3, KMS, RDS, DMS, logs, ECR)
 resource "aws_iam_role" "app_pod_identity" {
-  name = "${local.identifier}-${data.aws_region.current.id}-app-pod-identity"
+  name = "${local.identifier}-${data.aws_region.current.region}-app-pod-identity"
 
   assume_role_policy = jsonencode({
     Version = "2012-10-17"
@@ -329,7 +329,7 @@ resource "aws_eks_pod_identity_association" "app_migration_wait" {
 
 # Pod Identity: cert-manager cross-account Route53
 resource "aws_iam_role" "cert_manager_pod_identity" {
-  name = "${local.identifier}-${data.aws_region.current.id}-cert-manager-pod-identity"
+  name = "${local.identifier}-${data.aws_region.current.region}-cert-manager-pod-identity"
 
   assume_role_policy = jsonencode({
     Version = "2012-10-17"
@@ -372,7 +372,7 @@ resource "aws_eks_pod_identity_association" "cert_manager" {
 # INSUFFICIENT_DATA. Both the metrics agent and fluent-bit run as the cloudwatch-agent
 # SA, so one association covers metrics and logs.
 resource "aws_iam_role" "cloudwatch_agent_pod_identity" {
-  name = "${local.identifier}-${data.aws_region.current.id}-cw-agent-pod-identity"
+  name = "${local.identifier}-${data.aws_region.current.region}-cw-agent-pod-identity"
 
   assume_role_policy = jsonencode({
     Version = "2012-10-17"
@@ -421,7 +421,7 @@ resource "null_resource" "adopt_cloudwatch_observability_addon" {
     interpreter = ["/bin/bash", "-c"]
     command     = <<-EOT
       set -euo pipefail
-      region="${data.aws_region.current.id}"
+      region="${data.aws_region.current.region}"
       cluster="${module.eks_cluster.cluster_name}"
       addon="amazon-cloudwatch-observability"
       if aws eks describe-addon --cluster-name "$cluster" --addon-name "$addon" --region "$region" >/dev/null 2>&1; then

--- a/terraform/physical/main.tf
+++ b/terraform/physical/main.tf
@@ -30,7 +30,7 @@ provider "kubernetes" {
   exec {
     api_version = "client.authentication.k8s.io/v1beta1"
     command     = "aws"
-    args        = ["eks", "get-token", "--cluster-name", module.eks_cluster.cluster_name, "--region", data.aws_region.current.id]
+    args        = ["eks", "get-token", "--cluster-name", module.eks_cluster.cluster_name, "--region", data.aws_region.current.region]
   }
 }
 
@@ -39,7 +39,7 @@ locals {
   customer_name = var.subdomain_override != "" ? var.subdomain_override : var.customer == "" ? "dozuki" : var.customer
 
   # --EKS--
-  cluster_access_role_name = "${local.identifier}-${data.aws_region.current.id}-cluster-access"
+  cluster_access_role_name = "${local.identifier}-${data.aws_region.current.region}-cluster-access"
   create_eks_kms           = var.eks_kms_key_id == "" ? true : false
   eks_kms_key              = local.create_eks_kms ? aws_kms_key.eks[0].arn : data.aws_kms_key.eks[0].arn
 
@@ -58,7 +58,7 @@ locals {
   subdomain_parts = {
     "%CUSTOMER%"    = local.customer_name
     "%ENVIRONMENT%" = var.environment
-    "%REGION%"      = data.aws_region.current.id
+    "%REGION%"      = data.aws_region.current.region
     "%ACCOUNT%"     = data.aws_caller_identity.current.account_id
   }
   subdomain = join("-", [for part in var.subdomain_format : local.subdomain_parts[part] if local.subdomain_parts[part] != ""])

--- a/terraform/physical/modules/acm/main.tf
+++ b/terraform/physical/modules/acm/main.tf
@@ -9,10 +9,10 @@ terraform {
 locals {
   identifier = var.identifier == "" ? "dozuki-${var.environment}" : "${var.identifier}-dozuki-${var.environment}"
 
-  ssm_prefix = "/dozuki/${coalesce(var.identifier, "general")}/${var.environment}/${data.aws_region.current.id}"
+  ssm_prefix = "/dozuki/${coalesce(var.identifier, "general")}/${var.environment}/${data.aws_region.current.region}"
 
-  ssl_ca_cn   = var.ca_common_name == "" ? "${local.identifier}.${data.aws_region.current.id}.general.ca" : var.ca_common_name
-  ssl_cert_cn = var.cert_common_name == "" ? "${local.identifier}.${data.aws_region.current.id}.general.server" : var.cert_common_name
+  ssl_ca_cn   = var.ca_common_name == "" ? "${local.identifier}.${data.aws_region.current.region}.general.ca" : var.ca_common_name
+  ssl_cert_cn = var.cert_common_name == "" ? "${local.identifier}.${data.aws_region.current.region}.general.server" : var.cert_common_name
 
   # Tags for all resources. If you add a tag, it must never be blank.
   tags = {

--- a/terraform/physical/modules/vpn/config.tf
+++ b/terraform/physical/modules/vpn/config.tf
@@ -16,7 +16,7 @@ resource "tls_cert_request" "client" {
 
   private_key_pem = tls_private_key.client[count.index].private_key_pem
   subject {
-    common_name  = "${local.identifier}.${data.aws_region.current.id}.vpn.${var.vpn-client-list[count.index]}-client"
+    common_name  = "${local.identifier}.${data.aws_region.current.region}.vpn.${var.vpn-client-list[count.index]}-client"
     organization = local.identifier
   }
 }
@@ -59,7 +59,7 @@ resource "aws_s3_object" "vpn-config-file" {
 client
 dev tun
 proto udp
-remote ${aws_ec2_client_vpn_endpoint.vpn-client.id}.prod.clientvpn.${data.aws_region.current.id}.amazonaws.com 443
+remote ${aws_ec2_client_vpn_endpoint.vpn-client.id}.prod.clientvpn.${data.aws_region.current.region}.amazonaws.com 443
 remote-random-hostname
 resolv-retry infinite
 nobind

--- a/terraform/physical/modules/vpn/logs.tf
+++ b/terraform/physical/modules/vpn/logs.tf
@@ -12,7 +12,7 @@ data "aws_iam_policy_document" "vpn-logs-kms" {
   statement {
     effect = "Allow"
     principals {
-      identifiers = ["logs.${data.aws_region.current.id}.amazonaws.com"]
+      identifiers = ["logs.${data.aws_region.current.region}.amazonaws.com"]
       type        = "Service"
     }
     actions   = ["kms:*"]

--- a/terraform/physical/modules/vpn/main.tf
+++ b/terraform/physical/modules/vpn/main.tf
@@ -9,7 +9,7 @@ terraform {
 locals {
   identifier = var.identifier == "" ? "dozuki-${var.environment}" : "${var.identifier}-dozuki-${var.environment}"
 
-  ssm_prefix = "/dozuki/${coalesce(var.identifier, "general")}/${var.environment}/${data.aws_region.current.id}"
+  ssm_prefix = "/dozuki/${coalesce(var.identifier, "general")}/${var.environment}/${data.aws_region.current.region}"
 
   # Tags for all resources. If you add a tag, it must never be blank.
   tags = {

--- a/terraform/physical/modules/vpn/s3.tf
+++ b/terraform/physical/modules/vpn/s3.tf
@@ -8,7 +8,7 @@ resource "aws_s3_bucket_versioning" "vpn_config_versioning_block" {
 }
 #tfsec:ignore:aws-s3-enable-bucket-logging
 resource "aws_s3_bucket" "vpn-config-files" {
-  bucket        = "${local.identifier}-${data.aws_region.current.id}-vpn-credentials"
+  bucket        = "${local.identifier}-${data.aws_region.current.region}-vpn-credentials"
   force_destroy = true
 }
 
@@ -44,8 +44,8 @@ data "aws_iam_policy_document" "vpn-config-files" {
     actions = ["s3:*"]
     effect  = "Deny"
     resources = [
-      "arn:${data.aws_partition.current.partition}:s3:::${local.identifier}-${data.aws_region.current.id}-vpn-credentials",
-      "arn:${data.aws_partition.current.partition}:s3:::${local.identifier}-${data.aws_region.current.id}-vpn-credentials/*"
+      "arn:${data.aws_partition.current.partition}:s3:::${local.identifier}-${data.aws_region.current.region}-vpn-credentials",
+      "arn:${data.aws_partition.current.partition}:s3:::${local.identifier}-${data.aws_region.current.region}-vpn-credentials/*"
     ]
     condition {
       test     = "Bool"

--- a/terraform/physical/monitoring.tf
+++ b/terraform/physical/monitoring.tf
@@ -29,14 +29,14 @@ data "aws_iam_policy_document" "lambda_permissions" {
 resource "aws_iam_policy" "lambda_permissions" {
   count = var.slack_webhook_url != "" || local.dms_enabled ? 1 : 0
 
-  name   = "${local.identifier}-${data.aws_region.current.id}-lambda-alias"
+  name   = "${local.identifier}-${data.aws_region.current.region}-lambda-alias"
   policy = data.aws_iam_policy_document.lambda_permissions[0].json
 }
 
 resource "aws_iam_role" "lambda_execution" {
   count = var.slack_webhook_url != "" || local.dms_enabled ? 1 : 0
 
-  name               = "${local.identifier}-${data.aws_region.current.id}-lambda-execution"
+  name               = "${local.identifier}-${data.aws_region.current.region}-lambda-execution"
   assume_role_policy = data.aws_iam_policy_document.lambda_execution[0].json
 }
 resource "aws_iam_role_policy_attachment" "lambda_basic_execution" {

--- a/terraform/physical/s3.tf
+++ b/terraform/physical/s3.tf
@@ -112,7 +112,7 @@ resource "aws_kms_key" "s3" {
 resource "aws_kms_alias" "s3" {
   count = local.use_provided_s3_kms ? 0 : 1
 
-  name_prefix   = "alias/${local.identifier}/${data.aws_region.current.id}/s3/"
+  name_prefix   = "alias/${local.identifier}/${data.aws_region.current.region}/s3/"
   target_key_id = aws_kms_key.s3[0].id
 }
 
@@ -153,7 +153,7 @@ data "aws_iam_policy_document" "s3_replication_assume_role" {
 resource "aws_iam_role" "s3_replication" {
   count = local.use_existing_buckets ? 1 : 0
 
-  name               = "${local.identifier}-${data.aws_region.current.id}-s3-replication-role"
+  name               = "${local.identifier}-${data.aws_region.current.region}-s3-replication-role"
   assume_role_policy = data.aws_iam_policy_document.s3_replication_assume_role[0].json
 }
 
@@ -226,7 +226,7 @@ data "aws_iam_policy_document" "s3_replication" {
     condition {
       test     = "StringLike"
       variable = "kms:ViaService"
-      values   = ["s3.${data.aws_region.current.id}.${data.aws_partition.current.dns_suffix}"]
+      values   = ["s3.${data.aws_region.current.region}.${data.aws_partition.current.dns_suffix}"]
     }
 
     resources = [data.aws_kms_key.s3_migration[0].arn]
@@ -240,7 +240,7 @@ data "aws_iam_policy_document" "s3_replication" {
     condition {
       test     = "StringLike"
       variable = "kms:ViaService"
-      values   = ["s3.${data.aws_region.current.id}.${data.aws_partition.current.dns_suffix}"]
+      values   = ["s3.${data.aws_region.current.region}.${data.aws_partition.current.dns_suffix}"]
     }
 
     resources = [local.s3_kms_key_id]
@@ -250,7 +250,7 @@ data "aws_iam_policy_document" "s3_replication" {
 resource "aws_iam_policy" "s3_replication" {
   count = local.use_existing_buckets ? 1 : 0
 
-  name   = "${local.identifier}-${data.aws_region.current.id}-s3-replication-policy"
+  name   = "${local.identifier}-${data.aws_region.current.region}-s3-replication-policy"
   policy = data.aws_iam_policy_document.s3_replication[0].json
 }
 
@@ -303,7 +303,7 @@ resource "null_resource" "s3_replication_job_init" {
     # a default region; without this the aws CLI calls inside the script
     # fail with "An error occurred (NoRegion): You must specify a region."
     environment = {
-      AWS_REGION = data.aws_region.current.id
+      AWS_REGION = data.aws_region.current.region
     }
     command = "/usr/bin/env bash ./util/create-s3-batch.sh ${self.triggers["logging_bucket"]} ${self.triggers["source_bucket"]} ${self.triggers["replication_role"]} ${self.triggers["aws_account"]} ${self.triggers["aws_partition"]} ${self.triggers["aws_profile"]}"
   }
@@ -374,7 +374,7 @@ resource "aws_s3_bucket_ownership_controls" "logging_bucket" {
 #tfsec:ignore:aws-s3-enable-bucket-logging
 resource "aws_s3_bucket" "logging_bucket" {
 
-  bucket_prefix = "${local.identifier}-log-${data.aws_region.current.id}"
+  bucket_prefix = "${local.identifier}-log-${data.aws_region.current.region}"
   force_destroy = !var.protect_resources
 
   lifecycle {
@@ -409,7 +409,7 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "logging_bucket_en
 resource "aws_s3_bucket" "guide_buckets" {
   for_each = toset(local.create_s3_bucket_names)
 
-  bucket_prefix = "${local.identifier}-${each.key}-${data.aws_region.current.id}"
+  bucket_prefix = "${local.identifier}-${each.key}-${data.aws_region.current.region}"
   force_destroy = !var.protect_resources
 
   lifecycle {

--- a/terraform/physical/vault.tf
+++ b/terraform/physical/vault.tf
@@ -8,7 +8,7 @@ locals {
   # Extract the service region from the endpoint service name
   # (format: com.amazonaws.vpce.<region>.vpce-svc-xxx)
   vault_service_region  = element(split(".", var.vault_endpoint_service_name), 3)
-  vault_is_cross_region = local.vault_service_region != data.aws_region.current.id
+  vault_is_cross_region = local.vault_service_region != data.aws_region.current.region
 }
 
 # Look up endpoint service AZs for same-region deployments to filter subnets.

--- a/terraform/physical/vpc-endpoints.tf
+++ b/terraform/physical/vpc-endpoints.tf
@@ -6,7 +6,7 @@
 resource "aws_vpc_endpoint" "s3" {
   count             = local.create_vpc ? 1 : 0
   vpc_id            = module.vpc[0].vpc_id
-  service_name      = "com.amazonaws.${data.aws_region.current.id}.s3"
+  service_name      = "com.amazonaws.${data.aws_region.current.region}.s3"
   vpc_endpoint_type = "Gateway"
   route_table_ids   = module.vpc[0].private_route_table_ids
 


### PR DESCRIPTION
## What
Replace all **44** `data.aws_region.current.id` references with `.region` across the physical layer (bastion, bi, dr, eks, main, monitoring, s3, vault, vpc-endpoints + acm/vpn modules).

## Why
AWS provider 6.x deprecates **both** `.id` and `.name` on the `aws_region` data source in favor of `.region`. Every physical-stack plan currently emits ~70 `Warning: Deprecated attribute — The attribute "id" is deprecated` lines (e.g. `bastion.tf:52`). This clears them. (The codebase previously moved `.name → .id` for the v5→v6 provider bump; v6 now deprecates `.id` too.)

## Scope
- Physical only — the logical layer has **zero** `aws_region.current.id` references on master/v6.1-release.
- Pure attribute rename; no behavior change (`.region` returns the same value).

## Verify
`tofu init -backend=false && tofu validate` in `terraform/physical` — provider schema accepts `.region` (no 'Unsupported attribute' errors; the only validate errors are the pre-existing `aws.dns`/`aws.dr` alias configs that terragrunt injects at runtime). `tofu fmt` clean.

## Follow-up
Forward-merge master → `v6.1-release` so the active deploy line picks it up.