### PR TITLE
forward-port from mcp-deploy-integration: lambda determinism + dms-start deploy name

### DIFF
--- a/terraform/logical/bi.tf
+++ b/terraform/logical/bi.tf
@@ -17,7 +17,7 @@ resource "kubernetes_job_v1" "dms_start" {
           command = [
             "/bin/sh",
             "-c",
-            "kubectl wait deploy/app-deployment --for condition=available --timeout=1200s && aws dms start-replication-task --start-replication-task-type start-replication --replication-task-arn ${var.dms_task_arn} --region ${data.aws_region.current[0].id}"
+            "kubectl wait deploy/dozuki-app-deployment --for condition=available --timeout=1200s && aws dms start-replication-task --start-replication-task-type start-replication --replication-task-arn ${var.dms_task_arn} --region ${data.aws_region.current[0].id}"
           ]
         }
         restart_policy = "Never"

--- a/terraform/physical/main.tf
+++ b/terraform/physical/main.tf
@@ -19,8 +19,12 @@ terraform {
       version = "~> 3.0"
     }
     archive = {
-      source  = "hashicorp/archive"
-      version = "~> 2.0"
+      source = "hashicorp/archive"
+      # Pinned exactly: archive output bytes (and therefore the lambda
+      # source_code_hash) can change between provider versions even for
+      # identical source, which produces a perpetual phantom diff on the
+      # lambda functions below. Pin so the computed hash is stable.
+      version = "2.8.0"
     }
   }
 }

--- a/terraform/physical/monitoring.tf
+++ b/terraform/physical/monitoring.tf
@@ -409,18 +409,25 @@ resource "aws_cloudwatch_event_target" "dms_task_state_changed_target" {
 
 // -- Slack Notification Lambda
 
+# Content-based archive: zips the file's BYTES (not the on-disk file with its
+# metadata), so the zip is byte-identical on every machine/checkout, at plan and
+# apply. Paths anchored to path.module so they don't depend on the working dir.
 data "archive_file" "slack_sns_lambda" {
   count = var.slack_webhook_url != "" ? 1 : 0
 
   type        = "zip"
-  source_file = "util/sns_to_slack.py"
-  output_path = "sns_lambda_payload.zip"
+  output_path = "${path.module}/sns_lambda_payload.zip"
+
+  source {
+    content  = file("${path.module}/util/sns_to_slack.py")
+    filename = "sns_to_slack.py"
+  }
 }
 
 resource "aws_lambda_function" "sns_to_slack" {
   count = var.slack_webhook_url != "" ? 1 : 0
 
-  filename      = "sns_lambda_payload.zip"
+  filename      = data.archive_file.slack_sns_lambda[0].output_path
   function_name = "${local.identifier}-sns_to_slack"
   handler       = "sns_to_slack.lambda_handler"
   runtime       = "python3.8"
@@ -461,14 +468,18 @@ data "archive_file" "dms_restart_lambda" {
   count = local.dms_enabled ? 1 : 0
 
   type        = "zip"
-  source_file = "util/dms_restart.py"
-  output_path = "dms_restart_lambda_payload.zip"
+  output_path = "${path.module}/dms_restart_lambda_payload.zip"
+
+  source {
+    content  = file("${path.module}/util/dms_restart.py")
+    filename = "dms_restart.py"
+  }
 }
 
 resource "aws_lambda_function" "dms_restart" {
   count = local.dms_enabled ? 1 : 0
 
-  filename      = "dms_restart_lambda_payload.zip"
+  filename      = data.archive_file.dms_restart_lambda[0].output_path
   function_name = "${local.identifier}-dms_restart"
   handler       = "dms_restart.lambda_handler"
   runtime       = "python3.8"


### PR DESCRIPTION
Two deploy fixes from the v6.0 `mcp-deploy-integration` line that aren't on v6.1:
- **Deterministic lambda packaging** (orig bf81d09): `output_path`/`filename` used cwd-relative paths → phantom `source_code_hash` diffs. Pin to `${path.module}` + reference `data.archive_file.*.output_path`.
- **DMS-start deploy name** (part of #134): the kubectl wait targeted `deploy/app-deployment`, but the chart names it `dozuki-app-deployment` → wait never matched.

Audited the other mcp-deploy-integration commits: EKS audit logging, s3 AWS_REGION, HTTPS submodule already on master; chart-submodule bump + grafana-common-config are moot on v6.1 (OCI chart / chart owns the secret). Customer-TLS-via-Vault is handled separately (v6.1 has a different TLS model — needs a Vault-ESO extension, in progress).