### PR TITLE
feat(logical): customer TLS via Vault ESO (forward-port from mcp-deploy-integration)

### DIFF
--- a/terraform/logical/kubernetes.tf
+++ b/terraform/logical/kubernetes.tf
@@ -505,7 +505,7 @@ resource "helm_release" "app" {
     # Manual TLS. Supplied certs: chart renders the typed tls-secret (externallyManaged
     # false). Generated self-signed: Terraform renders it (externallyManaged true).
     { name = "tls.enabled", value = local.tls_manual ? "true" : "false" },
-    { name = "tls.externallyManaged", value = local.tls_managed_tf ? "true" : "false" },
+    { name = "tls.externallyManaged", value = local.tls_externally_managed ? "true" : "false" },
     { name = "tls.cert", value = local.tls_supplied ? var.tls_cert : "" },
 
     # --- Webhooks ---

--- a/terraform/logical/tls.tf
+++ b/terraform/logical/tls.tf
@@ -14,11 +14,17 @@ locals {
   tls_supplied = var.tls_cert != "" && var.tls_key != ""
   # Generated self-signed cert (dev). Azure-only for now; follow-up to generalize.
   tls_selfsigned = var.cloud == "azure" && var.azure_tls_mode == "self-signed"
+  # Customer cert stored in Vault, synced into tls-secret by ESO (cert never in TF
+  # state). Like self-signed, it's "manual" TLS and the secret is owned externally.
+  tls_from_vault = var.customer_tls_externally_managed
   # Any manual TLS -> cert-manager/ACME (dns_validation) stays out of the way.
-  tls_manual = local.tls_supplied || local.tls_selfsigned
+  tls_manual = local.tls_supplied || local.tls_selfsigned || local.tls_from_vault
   # Terraform creates the tls-secret ONLY for the generated self-signed cert; supplied
   # certs go through the chart (consistent owner across the v6.0->v6.1 upgrade).
   tls_managed_tf = local.tls_selfsigned
+  # The chart must skip rendering tls-secret whenever something ELSE owns it — the
+  # TF self-signed secret OR the ESO-synced Vault secret.
+  tls_externally_managed = local.tls_managed_tf || local.tls_from_vault
 }
 
 resource "tls_private_key" "gateway" {
@@ -61,5 +67,55 @@ resource "kubernetes_secret_v1" "gateway_tls" {
   data = {
     "tls.crt" = tls_self_signed_cert.gateway[0].cert_pem
     "tls.key" = tls_private_key.gateway[0].private_key_pem
+  }
+}
+
+# Customer-provided TLS: sync the cert+key from Vault (secret/<tenant>/<env>/tls,
+# keys cert/key) into the tls-secret K8s Secret via ESO. The cert/key are seeded in
+# Vault out-of-band, so they never enter Terraform state. The chart skips rendering
+# tls-secret (tls.externallyManaged) and drops the cert-manager Gateway annotation,
+# leaving ESO as the sole owner. References the chart-created SecretStore
+# vault-<stack_label>; depends on the app release so that SecretStore exists first.
+resource "kubernetes_manifest" "tls_external_secret" {
+  count = local.tls_from_vault ? 1 : 0
+
+  depends_on = [helm_release.external_secrets, helm_release.app]
+
+  manifest = {
+    apiVersion = "external-secrets.io/v1"
+    kind       = "ExternalSecret"
+    metadata = {
+      name      = "tls-secret"
+      namespace = kubernetes_namespace_v1.app.metadata[0].name
+    }
+    spec = {
+      refreshInterval = "5m"
+      secretStoreRef = {
+        name = "vault-${local.vault_stack_label}"
+        kind = "SecretStore"
+      }
+      target = {
+        name           = "tls-secret"
+        creationPolicy = "Owner"
+        deletionPolicy = "Retain"
+        template = {
+          type = "kubernetes.io/tls"
+          data = {
+            "tls.crt" = "{{ .cert }}"
+            "tls.key" = "{{ .key }}"
+          }
+        }
+      }
+      data = [
+        {
+          secretKey = "cert"
+          remoteRef = { key = "${local.vault_env_prefix}/tls", property = "cert" }
+        },
+        {
+          secretKey = "key"
+          remoteRef = { key = "${local.vault_env_prefix}/tls", property = "key" }
+        },
+      ]
+    }
   }
 }

--- a/terraform/logical/variables.tf
+++ b/terraform/logical/variables.tf
@@ -388,6 +388,19 @@ variable "tls_key" {
   default     = ""
 }
 
+variable "customer_tls_externally_managed" {
+  description = <<-EOT
+    Customer-provided TLS where the cert+key live in VAULT (not in tls_cert/tls_key).
+    When true, an ExternalSecret syncs cert/key from Vault secret/<tenant>/<env>/tls
+    (keys: cert, key) into the tls-secret K8s Secret, and the chart's
+    tls.externallyManaged is set so it skips rendering tls-secret and drops the
+    cert-manager Gateway annotation. Cert/key are seeded into Vault out-of-band and
+    never enter Terraform state. Mutually exclusive with tls_cert/tls_key.
+  EOT
+  type        = bool
+  default     = false
+}
+
 variable "operator_image_tag" {
   description = "dozuki-operator image tag to pull on azure (matches the bundled operator subchart appVersion)."
   type        = string


### PR DESCRIPTION
Forward-ports the v6.0 customer-TLS-via-Vault path (be7e390) into v6.1's TLS model. v6.1 had supplied-cert + self-signed but not the Vault-ESO path (cert in Vault, not TF state) that **3m-qa depends on**.

- New `customer_tls_externally_managed` var → `local.tls_from_vault`.
- Folded into `tls_manual` (cert-manager stays out) + a new `tls_externally_managed` local driving the chart's `tls.externallyManaged` (skip rendering tls-secret, drop cert-manager annotation).
- ExternalSecret syncs cert/key from Vault `secret/<tenant>/<env>/tls` into `tls-secret`, via the chart-created SecretStore `vault-<stack_label>` (names confirmed to match).

`kubernetes_manifest` only evaluates when the var is true (count gate), so other stacks are unaffected. `tofu validate` clean.