### PR TITLE
chore: bootstrap release-please from v7.0 (fixes the bogus 7.1.0 release PR)

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "include-component-in-tag": false,
+  "last-release-sha": "3dc89748e74c0563ae96f3019e515c9eb1e80c1a",
   "packages": {
     ".": {
       "release-type": "simple",


### PR DESCRIPTION
**Fixes the mis-bootstrapped release PR #197.**

On its first run, release-please opened #197 "release 7.1.0" that re-lists every v7.0 commit (#145, #149, #166, #194, …) as unreleased. Root cause: the existing release tag is `v7.0` (2-component), but release-please expects semver `v7.0.0`, so it couldn't locate the 7.0.0 boundary and scanned all history.

This pins `last-release-sha` to the v7.0 commit (`3dc8974`) so release-please only considers commits **after** v7.0. The only commit since then is the `ci:` adoption (#196), which doesn't trigger a release — so once this merges, release-please re-runs and **#197 recomputes to empty and closes**.

Going forward, releases tag as `v<x.y.z>` (3-component semver). **Merge this; do NOT merge #197.**