### PR TITLE
test(harness): land fresh scenario on master + harden teardown against stranding

### DIFF
--- a/live/tests/.gitignore
+++ b/live/tests/.gitignore
@@ -3,3 +3,4 @@
 __worktrees__/
 .logs/
 .artifacts/
+.bin/

--- a/live/tests/cleanup-orphans.sh
+++ b/live/tests/cleanup-orphans.sh
@@ -86,11 +86,17 @@ while IFS= read -r pfx; do
     fi
   fi
 
-  # 2) Force-release any held state locks for this prefix.
+  # 2) Force-release held state locks AND clear the -md5 state digest for this prefix.
+  #    The digest item (LockID "<key>-md5") is the S3 backend's consistency check. An
+  #    interrupted apply leaves it out of sync with the S3 object, so a later destroy
+  #    aborts with "state data in S3 does not have the expected content" and strands
+  #    the infra. We are tearing down (state integrity is moot), so drop BOTH the lock
+  #    and the digest — terragrunt then reads the actual S3 state and writes a fresh
+  #    digest. (No -md5 filter here, unlike a normal lock-release.)
   for lk in $(aws dynamodb scan --table-name "$LOCK_TABLE" --region "$R" --profile "$P" \
-        --query "Items[?contains(LockID.S, '$pfx') && !contains(LockID.S, '-md5')].LockID.S" --output text 2>/dev/null); do
+        --query "Items[?contains(LockID.S, '$pfx')].LockID.S" --output text 2>/dev/null); do
     aws dynamodb delete-item --table-name "$LOCK_TABLE" --region "$R" --profile "$P" \
-      --key "{\"LockID\":{\"S\":\"$lk\"}}" >/dev/null 2>&1 && echo "  released lock: $lk"
+      --key "{\"LockID\":{\"S\":\"$lk\"}}" >/dev/null 2>&1 && echo "  cleared lock/digest: $lk"
   done
 
   # 3) Destroy against the worktree whose code matches the deployed state (recorded

--- a/live/tests/harness/refs.go
+++ b/live/tests/harness/refs.go
@@ -104,6 +104,21 @@ func (w *Worktree) Remove(repoDir string) error {
 	return run(repoDir, "git", "worktree", "remove", "--force", w.Dir)
 }
 
+// removeUnlessFailed removes the worktree only when the run succeeded
+// (*runErr == nil). On failure we KEEP it: the applied-worktree marker points at
+// this worktree, and the out-of-process cleanup-orphans backstop destroys against
+// the marked worktree. If we removed it here, the backstop would find a stale
+// marker and fall back to the LIVE tree (current branch's code/refs), which won't
+// match the deployed stack and strands the infra. Mirrors the marker's own
+// keep-on-failure rule. Stale kept worktrees are 'git worktree remove'-able after cleanup.
+func (w *Worktree) removeUnlessFailed(repoDir string, runErr *error) {
+	if runErr != nil && *runErr != nil {
+		fmt.Fprintf(os.Stderr, "\n>> keeping worktree %s (run failed) so the cleanup backstop can destroy against the deployed code; 'git worktree remove' it after cleanup\n", w.Dir)
+		return
+	}
+	_ = w.Remove(repoDir)
+}
+
 func (w *Worktree) HasSubmodule() bool {
 	_, err := os.Stat(filepath.Join(w.Dir, ".gitmodules"))
 	return err == nil

--- a/live/tests/harness/run.go
+++ b/live/tests/harness/run.go
@@ -89,12 +89,12 @@ func RunUpgrade(p RunParams) (err error) {
 	if err != nil {
 		return err
 	}
-	defer fromWT.Remove(p.RepoDir)
+	defer fromWT.removeUnlessFailed(p.RepoDir, &err)
 	toWT, err := AddWorktree(p.RepoDir, base, p.ToRef, false)
 	if err != nil {
 		return err
 	}
-	defer toWT.Remove(p.RepoDir)
+	defer toWT.removeUnlessFailed(p.RepoDir, &err)
 
 	// The concrete live/<partition>/<region>/<env> trees are gitignored (generated
 	// from live/.skel by generate_live_env.sh), so a fresh worktree doesn't contain
@@ -244,7 +244,7 @@ func RunFresh(p RunParams) (err error) {
 	if err != nil {
 		return err
 	}
-	defer wt.Remove(p.RepoDir)
+	defer wt.removeUnlessFailed(p.RepoDir, &err)
 
 	if gerr := generateLiveEnvs(wt.Dir); gerr != nil {
 		return fmt.Errorf("generate live envs for %s: %w", wt.Ref, gerr)

--- a/live/tests/harness/run.go
+++ b/live/tests/harness/run.go
@@ -151,32 +151,8 @@ func RunUpgrade(p RunParams) (err error) {
 	// interrupt still leaves a correct from_ref marker).
 	_ = writeAppliedMarker(p.RepoDir, tg(fromWT).StatePrefix, tg(fromWT).WorkingDir)
 
-	var teardownOnce sync.Once
-	teardown := func(interrupted bool) {
-		teardownOnce.Do(func() {
-			wt := appliedWT.Load()
-			// An interrupted run is never "clean": full diagnostics, keep the marker
-			// for the cleanup backstop, and don't touch the named return err — the
-			// signal handler exits via os.Exit, and reading err here would race the
-			// still-running main goroutine.
-			failed := interrupted
-			if !interrupted {
-				failed = err != nil
-			}
-			step("capturing diagnostics -> .artifacts/%s (full=%v)", p.RunID, failed)
-			captureDiagnostics(p, region, identifier, failed, tg(wt), fromEnvHCL, toEnvHCL)
-			step("TEARDOWN: destroy against %s (logical best-effort, then ALWAYS physical)", wt.Ref)
-			derr := tg(wt).Destroy()
-			if !interrupted && derr != nil && err == nil {
-				err = fmt.Errorf("destroy: %w", derr)
-			}
-			if !failed {
-				removeAppliedMarker(p.RepoDir, tg(wt).StatePrefix)
-			}
-		})
-	}
+	teardown, stopSig := setupTeardown(p, region, identifier, &appliedWT, tg, fromEnvHCL, toEnvHCL, &err)
 	defer teardown(false)
-	stopSig := installTeardownOnSignal(func() { teardown(true) }, os.Exit)
 	defer stopSig()
 
 	// ---- Baseline apply + validate ----
@@ -231,9 +207,146 @@ func RunUpgrade(p RunParams) (err error) {
 	if err != nil {
 		return fmt.Errorf("post-upgrade readOutputs: %w", err)
 	}
-	upCaps.HasLogging = validation.LoggingEnabled(ctx, region, outs.ClusterName)
+	if verr := runInfraValidators(ctx, p, region, upCaps, outs, true); verr != nil {
+		return verr
+	}
 
-	if upCaps.HasLogging {
+	step("ALL VALIDATIONS PASSED ✓ — %s -> %s upgrade verified; tearing down next", p.FromRef, p.ToRef)
+	return nil
+}
+
+// RunFresh executes apply -> validate -> capability-gated infra validators ->
+// destroy for a SINGLE ref (p.ToRef). No baseline, no continuity sentinel, and no
+// upgrade proof — it verifies a clean from-scratch deploy of one release (a class
+// of bug that an in-place upgrade can mask). Returns the first error; always
+// attempts destroy.
+func RunFresh(p RunParams) (err error) {
+	cfg, err := p.Matrix.Config(p.ConfigName)
+	if err != nil {
+		return err
+	}
+	if !p.Matrix.VersionProfileExists(p.ToRef) {
+		return fmt.Errorf("no version profile for to_ref %q in matrix", p.ToRef)
+	}
+
+	phaseMarks = nil
+	runStart = time.Now()
+	defer func() { printSummary(p, cfg, err) }()
+
+	ctx := context.Background()
+	base := filepath.Join(p.RepoDir, "live", "tests", "__worktrees__", p.RunID)
+	region := p.Matrix.Defaults.Region
+
+	FetchOrigin(p.RepoDir)
+
+	step("preparing worktree: %s (fresh deploy)", p.ToRef)
+	wt, err := AddWorktree(p.RepoDir, base, p.ToRef, true)
+	if err != nil {
+		return err
+	}
+	defer wt.Remove(p.RepoDir)
+
+	if gerr := generateLiveEnvs(wt.Dir); gerr != nil {
+		return fmt.Errorf("generate live envs for %s: %w", wt.Ref, gerr)
+	}
+
+	envSub := filepath.Join(p.Matrix.Defaults.EnvPath, cfg.Env)
+	envHCL := filepath.Join(wt.Dir, envSub, "env.hcl")
+
+	identifier := ""
+	if customer, _ := cfg.FeatureFlags["customer"].(string); customer != "" {
+		identifier = customer + "-" + cfg.Env
+	}
+
+	tg := func(w *Worktree) TGOptions {
+		return TGOptions{
+			WorkingDir:   filepath.Join(w.Dir, envSub),
+			AccountID:    p.AccountID,
+			Region:       region,
+			Profile:      p.Profile,
+			BucketPrefix: "",
+			StatePrefix:  p.RunID + "-" + cfg.Name + "/",
+			NLBName:      identifier,
+		}
+	}
+
+	if werr := WriteEnvHCL(filepath.Join(wt.Dir, envSub), p.Matrix.MergedInputs(cfg, p.ToRef)); werr != nil {
+		return werr
+	}
+
+	var appliedWT atomic.Pointer[Worktree]
+	appliedWT.Store(wt)
+	_ = writeAppliedMarker(p.RepoDir, tg(wt).StatePrefix, tg(wt).WorkingDir)
+	teardown, stopSig := setupTeardown(p, region, identifier, &appliedWT, tg, envHCL, "", &err)
+	defer teardown(false)
+	defer stopSig()
+
+	step("FRESH apply: %s (terragrunt run-all apply — physical then logical)", p.ToRef)
+	if aerr := tg(wt).Apply(); aerr != nil {
+		return fmt.Errorf("fresh apply: %w", aerr)
+	}
+	step("applied — validating: cluster health (waits for pods Ready, up to 20m), endpoints, helm release")
+	rev, _, caps, verr := validateStack(tg(wt), p, region)
+	if verr != nil {
+		return fmt.Errorf("fresh validation: %w", verr)
+	}
+	if rev < 1 {
+		return fmt.Errorf("helm release %q not deployed (revision %d)", "dozuki", rev)
+	}
+	step("fresh deploy validated ✓ (helm revision %d) — capability-gated infra validators", rev)
+
+	outs, err := readOutputs(tg(wt), region)
+	if err != nil {
+		return fmt.Errorf("fresh readOutputs: %w", err)
+	}
+	if ierr := runInfraValidators(ctx, p, region, caps, outs, false); ierr != nil {
+		return ierr
+	}
+
+	step("ALL VALIDATIONS PASSED ✓ — %s fresh deploy verified; tearing down next", p.ToRef)
+	return nil
+}
+
+// setupTeardown builds the sync.Once teardown closure (capture diagnostics, then
+// destroy against the APPLIED worktree) and installs the SIGINT/SIGTERM handler.
+// Shared by RunUpgrade and RunFresh. errp points at the caller's named return so a
+// destroy error can surface; it is read ONLY on the non-interrupted path — the
+// signal path exits via os.Exit while the main goroutine is still running, so
+// reading err there would race.
+func setupTeardown(p RunParams, region, identifier string, appliedWT *atomic.Pointer[Worktree], tg func(*Worktree) TGOptions, fromEnvHCL, toEnvHCL string, errp *error) (teardown func(bool), stop func()) {
+	var once sync.Once
+	teardown = func(interrupted bool) {
+		once.Do(func() {
+			wt := appliedWT.Load()
+			failed := interrupted
+			if !interrupted {
+				failed = *errp != nil
+			}
+			step("capturing diagnostics -> .artifacts/%s (full=%v)", p.RunID, failed)
+			captureDiagnostics(p, region, identifier, failed, tg(wt), fromEnvHCL, toEnvHCL)
+			step("TEARDOWN: destroy against %s (logical best-effort, then ALWAYS physical)", wt.Ref)
+			derr := tg(wt).Destroy()
+			if !interrupted && derr != nil && *errp == nil {
+				*errp = fmt.Errorf("destroy: %w", derr)
+			}
+			if !failed {
+				removeAppliedMarker(p.RepoDir, tg(wt).StatePrefix)
+			}
+		})
+	}
+	stop = installTeardownOnSignal(func() { teardown(true) }, os.Exit)
+	return teardown, stop
+}
+
+// runInfraValidators runs the capability-gated infra assertions shared by fresh and
+// upgrade runs: control-plane logging, DMS, DR (existence + a representative S3
+// replication-flow check), and the optional restore drill. Skips are logged, never
+// silent. It (re)probes logging from the live cluster, overriding caps.HasLogging.
+// verifyContinuity runs the continuity-sentinel verification (UPGRADE only — a fresh
+// deploy writes no baseline sentinel, so callers pass false).
+func runInfraValidators(ctx context.Context, p RunParams, region string, caps Capabilities, outs validation.StackOutputs, verifyContinuity bool) error {
+	caps.HasLogging = validation.LoggingEnabled(ctx, region, outs.ClusterName)
+	if caps.HasLogging {
 		if lerr := validation.AssertControlPlaneLogging(ctx, region, outs.ClusterName); lerr != nil {
 			return fmt.Errorf("logging guard: %w", lerr)
 		}
@@ -241,15 +354,17 @@ func RunUpgrade(p RunParams) (err error) {
 		step("skipped: control-plane logging (not enabled on %s)", p.ToRef)
 	}
 
-	if upCaps.HasGuideBuckets {
-		if serr := validation.VerifySentinel(ctx, region, outs.GuideBuckets[0], p.RunID); serr != nil {
-			return fmt.Errorf("continuity sentinel verify: %w", serr)
+	if verifyContinuity {
+		if caps.HasGuideBuckets {
+			if serr := validation.VerifySentinel(ctx, region, outs.GuideBuckets[0], p.RunID); serr != nil {
+				return fmt.Errorf("continuity sentinel verify: %w", serr)
+			}
+		} else {
+			step("skipped: continuity sentinel (no guide buckets in %s)", p.ToRef)
 		}
-	} else {
-		step("skipped: continuity sentinel (no guide buckets in %s)", p.ToRef)
 	}
 
-	if upCaps.HasDMS {
+	if caps.HasDMS {
 		if derr := validation.AssertDMSRunning(ctx, region, outs.DMSTaskARN); derr != nil {
 			return fmt.Errorf("DMS running: %w", derr)
 		}
@@ -257,7 +372,7 @@ func RunUpgrade(p RunParams) (err error) {
 		step("skipped: DMS (no dms_task_arn in %s)", p.ToRef)
 	}
 
-	if p.EnableDR && upCaps.HasDR {
+	if p.EnableDR && caps.HasDR {
 		// Existence check: DR buckets versioned + replicated RDS backup present.
 		if derr := validation.AssertDRExistence(ctx, p.DRRegion, outs.DRBucketNames, outs.DBIdentifier); derr != nil {
 			return fmt.Errorf("DR existence: %w", derr)
@@ -268,7 +383,7 @@ func RunUpgrade(p RunParams) (err error) {
 		// from dr_s3_bucket_names is not guaranteed to align with guide bucket order),
 		// so we validate a single representative pair; the existence check covers all
 		// DR buckets above.
-		if upCaps.HasGuideBuckets {
+		if caps.HasGuideBuckets {
 			if rerr := validation.AssertS3ReplicationFlow(ctx, region, p.DRRegion, outs.GuideBuckets[0], outs.DRBucketNames[0], p.RunID); rerr != nil {
 				return fmt.Errorf("DR S3 replication flow: %w", rerr)
 			}
@@ -284,8 +399,6 @@ func RunUpgrade(p RunParams) (err error) {
 			return fmt.Errorf("restore drill: %w", rderr)
 		}
 	}
-
-	step("ALL VALIDATIONS PASSED ✓ — %s -> %s upgrade verified; tearing down next", p.FromRef, p.ToRef)
 	return nil
 }
 
@@ -422,7 +535,11 @@ func printSummary(p RunParams, cfg Config, err error) {
 	line("========================= HARNESS RUN SUMMARY =========================")
 	line(" Result:    %s", result)
 	line(" Config:    %s  (customer=%s, env=%s)", cfg.Name, customer, cfg.Env)
-	line(" Upgrade:   %s  ->  %s", p.FromRef, p.ToRef)
+	if p.FromRef == "" {
+		line(" Deploy:    %s  (fresh)", p.ToRef)
+	} else {
+		line(" Upgrade:   %s  ->  %s", p.FromRef, p.ToRef)
+	}
 	line(" Region:    %s    DR: %s", p.Matrix.Defaults.Region, dr)
 	line(" Run ID:    %s", p.RunID)
 	if !runStart.IsZero() {

--- a/live/tests/harness/terragrunt.go
+++ b/live/tests/harness/terragrunt.go
@@ -105,11 +105,68 @@ func (o TGOptions) destroyModule(module string) error {
 // the logical destroy couldn't, and physical is the layer that actually costs
 // money and collides with the next run.
 func (o TGOptions) Destroy() error {
+	refreshVaultToken()
 	if err := o.destroyModule("logical"); err != nil {
 		fmt.Fprintf(os.Stderr, "\n>> teardown: logical destroy failed (continuing to physical so infra isn't stranded): %v\n", err)
 	}
 	o.clearNLBProtection()
 	return o.destroyModule("physical")
+}
+
+// refreshVaultToken best-effort re-logs-in to Vault before the teardown and updates
+// VAULT_TOKEN in the process env. A long run can outlast the AWS-auth token's TTL,
+// so the token run.sh logged in with is stale by teardown — the logical destroy then
+// 403s on every vault data source (lookup-self against VAULT_ADDR). run.sh's
+// port-forward is still up, so we re-login the same way it did. Best-effort: if the
+// vault/aws CLIs or VAULT_ADDR are absent, keep the inherited token — the logical
+// destroy is best-effort anyway and the cleanup-orphans backstop re-auths too.
+func refreshVaultToken() {
+	if os.Getenv("VAULT_ADDR") == "" {
+		return // no Vault tunnel in this run (e.g. azure / SKIP_VAULT_TUNNEL)
+	}
+	if _, err := exec.LookPath("vault"); err != nil {
+		return
+	}
+	profile := os.Getenv("VAULT_AWS_PROFILE")
+	if profile == "" {
+		profile = "dozuki"
+	}
+	role := os.Getenv("VAULT_AWS_ROLE")
+	if role == "" {
+		role = "admin"
+	}
+	// Export the profile's AWS creds, then run `vault login` with those creds in its
+	// env. No shell (`sh -c`): args are passed directly, so profile/role can't be
+	// interpreted as shell metacharacters (avoids command injection).
+	credsOut, err := exec.Command("aws", "--profile", profile, "configure",
+		"export-credentials", "--format", "env-no-export").Output()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, ">> teardown: Vault re-login skipped (aws creds for %q: %v) — using inherited token\n", profile, err)
+		return
+	}
+	loginEnv := os.Environ()
+	for _, line := range strings.Split(strings.TrimSpace(string(credsOut)), "\n") {
+		if strings.HasPrefix(line, "AWS_") {
+			loginEnv = append(loginEnv, line)
+		}
+	}
+	login := exec.Command("vault", "login", "-method=aws", "role="+role, "-format=json")
+	login.Env = loginEnv
+	out, err := login.Output()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, ">> teardown: Vault re-login skipped (%v) — using inherited token; backstop re-auths if needed\n", err)
+		return
+	}
+	var resp struct {
+		Auth struct {
+			ClientToken string `json:"client_token"`
+		} `json:"auth"`
+	}
+	if json.Unmarshal(out, &resp) != nil || resp.Auth.ClientToken == "" {
+		return
+	}
+	_ = os.Setenv("VAULT_TOKEN", resp.Auth.ClientToken)
+	fmt.Fprintf(os.Stderr, ">> teardown: refreshed Vault token (re-login via aws role=%s) so the logical destroy uses a live token\n", role)
 }
 
 // clearNLBProtection disables deletion protection on the stack's NLB before the

--- a/live/tests/matrix.yaml
+++ b/live/tests/matrix.yaml
@@ -40,6 +40,7 @@ configs:
     feature_flags:
       enable_webhooks: false
       enable_bi: false
+      db_engine: aurora              # Aurora Serverless v2 — the new-stack default; rds_* sizing flags are ignored on aurora
       rds_multi_az: false
       highly_available_nat_gateway: false
       protect_resources: false
@@ -64,9 +65,10 @@ configs:
     feature_flags:
       enable_webhooks: false
       enable_bi: true
+      db_engine: aurora
       rds_multi_az: true
       enable_dr: true
-      rds_adopt_dr_cmk: true     # required for RDS automated-backup replication on new stacks
+      rds_adopt_dr_cmk: true     # RDS-only (DR backup replication); ignored on aurora
       bi_dms_enabled: false
       alarm_email: "devops@dozuki.com"
   - name: full
@@ -74,6 +76,7 @@ configs:
     feature_flags:
       enable_webhooks: true
       enable_bi: true
+      db_engine: aurora
       rds_multi_az: true
       enable_dr: true
       rds_adopt_dr_cmk: true

--- a/live/tests/run.sh
+++ b/live/tests/run.sh
@@ -105,6 +105,10 @@ fi
 VAULT_KUBE_CONTEXT="${VAULT_KUBE_CONTEXT:-vault-standard}"
 VAULT_AWS_PROFILE="${VAULT_AWS_PROFILE:-dozuki}"
 VAULT_AWS_ROLE="${VAULT_AWS_ROLE:-admin}"
+# Exported so the Go harness's teardown can re-login to Vault with the same
+# profile/role if the inherited token expired during a long run (see
+# refreshVaultToken in harness/terragrunt.go).
+export VAULT_AWS_PROFILE VAULT_AWS_ROLE
 VAULT_PF_PID=""
 
 cleanup() {

--- a/live/tests/run.sh
+++ b/live/tests/run.sh
@@ -253,7 +253,17 @@ case "$SCENARIO" in
 esac
 echo ">> Running scenario(s): ${SCENARIO}  (go test -run '${_run}')" >&2
 
-if go test ./scenarios/ -run "$_run" -v -timeout 180m; then TEST_RC=0; else TEST_RC=$?; fi
+# Compile the test to a STABLE binary path, then run THAT binary — instead of
+# `go test`, which builds a throwaway scenarios.test at a fresh temp path every
+# run. Host firewalls (e.g. Little Snitch) treat each new temp path as a new
+# unknown process and re-prompt/deny it, silently blocking the in-process
+# endpoint-health HTTP checks when no one is there to approve. A fixed path lets
+# the allow-rule persist across runs (approve once). The binary is run from the
+# scenarios/ dir so its CWD matches `go test ./scenarios/` (relative paths intact).
+TEST_BIN="$PWD/.bin/scenarios.test"
+mkdir -p "$PWD/.bin"
+go test -c -o "$TEST_BIN" ./scenarios/
+if ( cd scenarios && "$TEST_BIN" -test.run "$_run" -test.v -test.timeout 180m ); then TEST_RC=0; else TEST_RC=$?; fi
 
 if [ "$TEST_RC" -ne 0 ] && [ "${RUN_POSTMORTEM:-0}" = 1 ]; then
   ./postmortem.sh "$RUN_ID" "$RUN_LOG" || true

--- a/live/tests/run.sh
+++ b/live/tests/run.sh
@@ -117,6 +117,7 @@ cleanup() {
     ./cleanup-orphans.sh "${RUN_ID}-" || echo ">> Auto-cleanup reported issues — see verify-clean output above." >&2
   fi
   [ -n "$VAULT_PF_PID" ] && kill "$VAULT_PF_PID" 2>/dev/null || true
+  [ -n "${AZ_SHIM_DIR:-}" ] && rm -rf "$AZ_SHIM_DIR" 2>/dev/null || true
 
   # Archive this run's artifacts to S3 for post-mortem. The harness writes diagnostics
   # to .artifacts/$RUN_ID BEFORE teardown (TF inventory, env.hcl, and — on failure — a
@@ -221,7 +222,38 @@ fi
 
 # From here on, the run can create cloud resources — arm the backstop cleanup (see trap).
 STARTED_RUN=1
-if go test ./scenarios/ -run TestUpgrade -v -timeout 180m; then TEST_RC=0; else TEST_RC=$?; fi
+
+# az-env-gap guard: simulate Spacelift's shared workers (no usable Azure CLI) by
+# shimming `az` to fail, so any AWS-path provider that depends on the Azure CLI breaks
+# the harness HERE instead of only at real deploy time (this is the gap that hid the
+# azurerm-on-AWS issue — the harness ran where `az` existed). On by default for AWS
+# runs; NO_AZ_SHIM=1 disables. Cleaned up by the EXIT trap.
+if [ "${NO_AZ_SHIM:-0}" != 1 ]; then
+  AZ_SHIM_DIR="$(mktemp -d)"
+  cat > "$AZ_SHIM_DIR/az" <<'AZEOF'
+#!/usr/bin/env bash
+echo ">> [harness] 'az' is intentionally shimmed to fail — simulating Spacelift workers (no Azure CLI). Set NO_AZ_SHIM=1 to disable." >&2
+exit 1
+AZEOF
+  chmod +x "$AZ_SHIM_DIR/az"
+  export PATH="$AZ_SHIM_DIR:$PATH"
+  echo ">> az-env-gap guard ACTIVE: 'az' shimmed to fail (NO_AZ_SHIM=1 to disable)." >&2
+else
+  echo ">> az-env-gap guard DISABLED (NO_AZ_SHIM=1) — 'az' uses the ambient PATH." >&2
+fi
+
+# Scenario selection: upgrade | fresh | both (default both). 'both' runs TestUpgrade
+# then TestFresh in one go-test process; a failure in EITHER makes go test exit non-zero.
+SCENARIO="${SCENARIO:-both}"
+case "$SCENARIO" in
+  upgrade) _run='TestUpgrade' ;;
+  fresh)   _run='TestFresh' ;;
+  both)    _run='TestUpgrade|TestFresh' ;;
+  *) echo ">> ERROR: invalid SCENARIO='$SCENARIO' (want upgrade|fresh|both)" >&2; exit 2 ;;
+esac
+echo ">> Running scenario(s): ${SCENARIO}  (go test -run '${_run}')" >&2
+
+if go test ./scenarios/ -run "$_run" -v -timeout 180m; then TEST_RC=0; else TEST_RC=$?; fi
 
 if [ "$TEST_RC" -ne 0 ] && [ "${RUN_POSTMORTEM:-0}" = 1 ]; then
   ./postmortem.sh "$RUN_ID" "$RUN_LOG" || true

--- a/live/tests/run.sh
+++ b/live/tests/run.sh
@@ -15,7 +15,10 @@
 set -euo pipefail
 cd "$(dirname "$0")"
 
-: "${DDVTEST_ACCOUNT_ID:?set DDVTEST_ACCOUNT_ID}"
+# The harness only ever targets the DDVtest account (076248559428) — used for
+# state/resource/artifacts-bucket names and passed to the tests as AccountID.
+# Default it so it needn't be passed every run; override for another test account.
+export DDVTEST_ACCOUNT_ID="${DDVTEST_ACCOUNT_ID:-076248559428}"
 export RUN_INTEGRATION=1
 export RUN_ID="${RUN_ID:-local-$(date +%s)}"
 

--- a/live/tests/scenarios/fresh_test.go
+++ b/live/tests/scenarios/fresh_test.go
@@ -1,0 +1,64 @@
+package scenarios
+
+import (
+	"os"
+	"testing"
+
+	"github.com/Dozuki/CloudPrem-Infra/live/tests/harness"
+)
+
+// TestFresh runs a fresh single-instance deploy + validate + teardown for the
+// configs in CONFIGS (comma-sep, default min_default) — no baseline/upgrade. It
+// catches create-from-scratch regressions that an in-place upgrade can mask.
+// Integration test: requires RUN_INTEGRATION=1, DDVtest creds, and Plan 1 applied.
+// Skipped otherwise so `go test ./...` stays green.
+func TestFresh(t *testing.T) {
+	if os.Getenv("RUN_INTEGRATION") != "1" {
+		t.Skip("set RUN_INTEGRATION=1 to run (needs DDVtest creds + applied foundation)")
+	}
+	repoDir := env("REPO_DIR", mustAbsRepoRoot(t))
+	accountID := mustEnv(t, "DDVTEST_ACCOUNT_ID")
+	profile := env("AWS_PROFILE", "ddvtest")
+	runID := mustEnv(t, "RUN_ID")
+	namespace := env("APP_NAMESPACE", "dozuki")
+
+	m, err := harness.LoadMatrix(repoDir + "/live/tests/matrix.yaml")
+	if err != nil {
+		t.Fatalf("load matrix: %v", err)
+	}
+	tags, err := harness.NewestTags(repoDir)
+	if err != nil {
+		t.Fatalf("tags: %v", err)
+	}
+	// Fresh deploys a single ref — the target. Reuse TO_REF (else matrix default).
+	toRef, err := harness.ResolveRef(env("TO_REF", m.Defaults.ToRef), tags)
+	if err != nil {
+		t.Fatalf("to_ref: %v", err)
+	}
+
+	for _, name := range splitConfigs(env("CONFIGS", "min_default")) {
+		name := name
+		t.Run(name, func(t *testing.T) {
+			cfg, err := m.Config(name)
+			if err != nil {
+				t.Fatalf("config %s: %v", name, err)
+			}
+			err = harness.RunFresh(harness.RunParams{
+				RepoDir:      repoDir,
+				Matrix:       m,
+				ConfigName:   name,
+				ToRef:        toRef,
+				AccountID:    accountID,
+				Profile:      profile,
+				RunID:        runID + "-fresh-" + name,
+				Namespace:    namespace,
+				DRRegion:     m.Defaults.DRRegion,
+				RestoreDrill: cfg.HarnessFlag("restore_drill"),
+				EnableDR:     cfg.HarnessFlag("enable_dr"),
+			})
+			if err != nil {
+				t.Fatalf("fresh %s (%s): %v", name, toRef, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Consolidation (was on the unmerged harness-fresh-and-az-guard branch)
Lands the only unmerged harness work onto master so there's one canonical harness: **RunFresh** + `fresh_test.go` (fresh single-instance deploy/validate/teardown), the `SCENARIO` selector + az-env-gap guard, Aurora deploy, stable test-binary path (stops firewall re-prompts), and the DDVTEST_ACCOUNT_ID default. (The other ~9 `harness-*` branches were already squash-merged — verified, disposable.)

## Hardening — so a failed run doesn't leave AWS resources behind
The last upgrade run failed and stranded infra. Three root causes fixed:

1. **Keep the worktree on failure** (`refs.go`/`run.go`). The applied-worktree marker pointed at the run's worktree, but it was removed unconditionally on exit — so `cleanup-orphans` found a stale marker and fell back to the **live tree** (wrong code/refs), unable to destroy. Now kept on failure (mirrors the marker's keep-on-failure rule).

2. **Clear the stale state digest** (`cleanup-orphans.sh`). An interrupted apply leaves the DynamoDB `<key>-md5` digest out of sync with S3, so the destroy aborts with *"state data in S3 does not have the expected content"* and strands the physical infra. The lock-release now also drops the digest (we're tearing down → terragrunt reads live S3 + writes a fresh digest). **This was the actual AWS-infra stranding cause.**

3. **Re-login to Vault before teardown** (`terragrunt.go`). A long run outlasts the AWS-auth token TTL, so the logical destroy 403s on every vault data source. Best-effort re-login via the same aws role (shell-free — no injection); run.sh exports `VAULT_AWS_PROFILE/ROLE`. Lower-impact (physical destroy + the backstop's own re-auth are the safety net) but removes the noise + cleans Vault KV secrets.

`go build`/`go vet`/`go test ./harness` clean; `bash -n` clean on both scripts.

Follow-up (separate project): a tag-based janitor (run_id + ttl) as the durable backstop even if a run hard-crashes mid-teardown.