### PR TITLE
fix: Vault AWS-auth signs against gov regional STS on GovCloud

### DIFF
--- a/terraform/logical/main.tf
+++ b/terraform/logical/main.tf
@@ -126,9 +126,20 @@ provider "vault" {
     content {
       path   = "auth/aws/login"
       method = "aws"
-      parameters = {
-        role = "deployer"
-      }
+      # On GovCloud the AWS-auth login must sign sts:GetCallerIdentity against the
+      # gov regional STS endpoint. The SDK/env default to the commercial global
+      # endpoint (sts.amazonaws.com), which rejects gov credentials with
+      # "Credential should be scoped to a valid region" — even with AWS_REGION /
+      # AWS_STS_REGIONAL_ENDPOINTS set, the generic auth_login doesn't pick them up.
+      # aws_region + aws_sts_endpoint in parameters ARE consumed by the provider's
+      # AWS signing. (Assumes us-gov-west-1, the only gov region in use.)
+      parameters = merge(
+        { role = "deployer" },
+        local.is_us_gov ? {
+          aws_region       = "us-gov-west-1"
+          aws_sts_endpoint = "https://sts.us-gov-west-1.amazonaws.com"
+        } : {}
+      )
     }
   }
 }


### PR DESCRIPTION
Logical apply on GovCloud fails reading Vault secrets:
```
PUT .../v1/auth/aws/login → 403 from STS: Credential should be scoped to a valid region
```
The vault provider's generic `auth_login` (method=aws) signs `sts:GetCallerIdentity` against the **commercial global** endpoint (`sts.amazonaws.com`); gov creds are rejected. Setting `AWS_REGION`/`AWS_STS_REGIONAL_ENDPOINTS` on the stack did **not** fix it (the generic auth_login doesn't read them).

Fix: pass `aws_region` + `aws_sts_endpoint` in the `auth_login` parameters (these ARE consumed by the provider's AWS signer), gated on `is_us_gov`, targeting `sts.us-gov-west-1.amazonaws.com`. `Release-As: 7.1.2`.

Note: validated with `terraform validate`; the runtime behavior needs a GovCloud Vault to confirm — will verify on the next `ECP-SharedGovCloud-Logical` run after bumping the ref to v7.1.2.