### PR TITLE
test(harness): version_defaults so new refs need no matrix entry

### DIFF
--- a/live/tests/harness/config.go
+++ b/live/tests/harness/config.go
@@ -29,9 +29,15 @@ type Config struct {
 }
 
 type Matrix struct {
-	Defaults Defaults                          `yaml:"defaults"`
-	Versions map[string]map[string]interface{} `yaml:"versions"`
-	Configs  []Config                          `yaml:"configs"`
+	Defaults Defaults `yaml:"defaults"`
+	// VersionDefaults are version vars (image_tag, chart_version, …) applied to
+	// EVERY ref. A ref's entry in Versions overrides matching keys. This lets a
+	// ref with no explicit Versions entry (e.g. a freshly tagged release, or
+	// auto:latest) still resolve — most refs share the same images/charts, so
+	// you set them once here instead of per ref.
+	VersionDefaults map[string]interface{}            `yaml:"version_defaults"`
+	Versions        map[string]map[string]interface{} `yaml:"versions"`
+	Configs         []Config                          `yaml:"configs"`
 }
 
 func LoadMatrix(path string) (*Matrix, error) {
@@ -62,11 +68,26 @@ func (m *Matrix) MergedInputs(c Config, ref string) map[string]interface{} {
 			out[k] = v
 		}
 	}
+	// version_defaults first, then the ref-specific entry overrides them.
+	for k, v := range m.VersionDefaults {
+		out[k] = v
+	}
 	for k, v := range m.Versions[ref] {
 		out[k] = v
 	}
 	out["environment"] = c.Env
 	return out
+}
+
+// VersionVar returns a single version variable for a ref: the ref-specific
+// entry wins, otherwise the version_defaults value (nil if neither sets it).
+func (m *Matrix) VersionVar(ref, key string) interface{} {
+	if rv, ok := m.Versions[ref]; ok {
+		if v, ok := rv[key]; ok {
+			return v
+		}
+	}
+	return m.VersionDefaults[key]
 }
 
 // HarnessFlag returns the boolean value of a harness-only feature flag for
@@ -80,7 +101,11 @@ func (c Config) HarnessFlag(name string) bool {
 	return false
 }
 
+// VersionProfileExists reports whether a ref can be resolved: either it has an
+// explicit Versions entry, or version_defaults supplies a base for any ref.
 func (m *Matrix) VersionProfileExists(ref string) bool {
-	_, ok := m.Versions[ref]
-	return ok
+	if _, ok := m.Versions[ref]; ok {
+		return true
+	}
+	return len(m.VersionDefaults) > 0
 }

--- a/live/tests/harness/config_test.go
+++ b/live/tests/harness/config_test.go
@@ -57,3 +57,57 @@ func TestMergedInputsExcludesHarnessOnlyKeys(t *testing.T) {
 		t.Errorf("HarnessFlag(nonexistent) = true, want false")
 	}
 }
+
+func TestVersionDefaults(t *testing.T) {
+	m := &Matrix{
+		VersionDefaults: map[string]interface{}{
+			"image_tag":     "default-app",
+			"chart_version": "0.4.1",
+		},
+		Versions: map[string]map[string]interface{}{
+			"v6.0": {"image_tag": "old-app"}, // overrides image_tag; inherits chart_version
+		},
+		Configs: []Config{{Name: "min_default", Env: "min", FeatureFlags: map[string]interface{}{"enable_bi": false}}},
+	}
+	cfg, _ := m.Config("min_default")
+
+	// A ref with NO explicit entry inherits all defaults.
+	newRef := m.MergedInputs(cfg, "v7.1.2")
+	if newRef["image_tag"] != "default-app" {
+		t.Errorf("v7.1.2 image_tag = %v, want default-app (inherited)", newRef["image_tag"])
+	}
+	if newRef["chart_version"] != "0.4.1" {
+		t.Errorf("v7.1.2 chart_version = %v, want 0.4.1 (inherited)", newRef["chart_version"])
+	}
+
+	// A ref-specific key overrides the default; unspecified keys still inherit.
+	old := m.MergedInputs(cfg, "v6.0")
+	if old["image_tag"] != "old-app" {
+		t.Errorf("v6.0 image_tag = %v, want old-app (override)", old["image_tag"])
+	}
+	if old["chart_version"] != "0.4.1" {
+		t.Errorf("v6.0 chart_version = %v, want 0.4.1 (inherited default)", old["chart_version"])
+	}
+
+	// VersionVar: ref override wins, else default.
+	if got := m.VersionVar("v6.0", "image_tag"); got != "old-app" {
+		t.Errorf("VersionVar(v6.0,image_tag) = %v, want old-app", got)
+	}
+	if got := m.VersionVar("v7.1.2", "chart_version"); got != "0.4.1" {
+		t.Errorf("VersionVar(v7.1.2,chart_version) = %v, want 0.4.1", got)
+	}
+
+	// VersionProfileExists is true for ANY ref once defaults are set.
+	if !m.VersionProfileExists("v7.1.2") {
+		t.Errorf("VersionProfileExists(v7.1.2) = false, want true (defaults set)")
+	}
+
+	// Without defaults, only refs with an explicit entry resolve.
+	empty := &Matrix{Versions: map[string]map[string]interface{}{"v6.0": {}}}
+	if empty.VersionProfileExists("v7.1.2") {
+		t.Errorf("VersionProfileExists(v7.1.2) = true with no defaults, want false")
+	}
+	if !empty.VersionProfileExists("v6.0") {
+		t.Errorf("VersionProfileExists(v6.0) = false, want true (explicit entry)")
+	}
+}

--- a/live/tests/harness/run.go
+++ b/live/tests/harness/run.go
@@ -195,7 +195,7 @@ func RunUpgrade(p RunParams) (err error) {
 	if verr != nil {
 		return fmt.Errorf("upgrade validation: %w", verr)
 	}
-	wantChart, _ := p.Matrix.Versions[p.ToRef]["chart_version"].(string)
+	wantChart, _ := p.Matrix.VersionVar(p.ToRef, "chart_version").(string)
 	step("verifying upgrade proof (helm revision advanced from %d; chart %q)", baselineRev, wantChart)
 	if rerr := validation.AssertUpgraded(kc, p.Namespace, "dozuki", baselineRev, wantChart); rerr != nil {
 		return fmt.Errorf("upgrade proof: %w", rerr)

--- a/live/tests/matrix.yaml
+++ b/live/tests/matrix.yaml
@@ -8,9 +8,21 @@ defaults:
   dr_region: "us-west-2"
   env_path: "live/standard/us-east-1"   # parent dir holding region.hcl; the config's env dir is <env_path>/<env>
 
-# Version vars supplied per ref. Keys absent on a ref are simply not set.
-# (Undeclared TF_VAR_* are ignored by Terraform, so superset keys are safe on
-# older refs that don't declare them.)
+# Default version vars applied to EVERY ref (image_tag, chart_version, …). A ref
+# only needs an entry under `versions:` below if it DIFFERS from these. A freshly
+# tagged release that uses the current images + chart (the common case) needs NO
+# entry — `auto:latest` and any new vX.Y.Z inherit these. Update when the current
+# release's images/chart change. (Undeclared TF_VAR_* are ignored by Terraform,
+# so a superset of keys is safe on older refs that don't declare them.)
+version_defaults:
+  image_tag: "3625f3c7a3fe9bd3fb87b03a23a4cbb683d44ded.4"
+  nextjs_tag: "2.23.0"
+  chart_version: "0.4.1"   # current dozuki OCI chart (logical layer default @ 7.1.x)
+  image_repository: "069174876992.dkr.ecr.us-east-1.amazonaws.com"
+
+# Per-ref OVERRIDES — only keys that DIFFER from version_defaults need to be here.
+# The v6.0.x baselines predate the OCI chart; they inherit chart_version 0.4.1
+# from the defaults (harmless: their logical layer doesn't declare it).
 versions:
   v6.0:
     image_tag: "3625f3c7a3fe9bd3fb87b03a23a4cbb683d44ded.4"


### PR DESCRIPTION
## Problem
Every new release required adding a `versions:` entry to `matrix.yaml` (image_tag, chart_version, …) or the harness errored (`no version profile for to_ref`). Most refs share the same images/chart, so that's repetitive — and `auto:latest` couldn't resolve a brand-new tag.

## Change
Adds a **`version_defaults:`** block applied to *every* ref. A ref's `versions:` entry now only needs the keys that **differ** from the defaults. A freshly tagged release that uses the current images+chart (the common case) needs **no entry** — `auto:latest` and any new `vX.Y.Z` inherit the defaults.

- `config.go`: `VersionDefaults` field; `MergedInputs` merges defaults then the ref override; new `VersionVar(ref,key)` helper; `VersionProfileExists` true when defaults are set.
- `run.go`: the upgrade-proof `chart_version` lookup uses `VersionVar` (defaults-aware) so a ref with no entry still asserts the right chart.
- `matrix.yaml`: `version_defaults` = current image_tag/nextjs_tag/chart_version (`0.4.1`)/image_repository; existing v6.x entries kept as overrides (zero behavior change).
- `config_test.go`: covers inherit, override, `VersionVar`, and `VersionProfileExists` with/without defaults.

## Effect
Testing e.g. `FROM_REF=v6.0.3 TO_REF=v7.1.2` (or `auto:latest`) now needs **no matrix edit**. `go test ./...` passes.