### PR TITLE
feat(physical): Aurora Global Database cross-region DR (Phase 2)

### DIFF
--- a/terraform/physical/README.md
+++ b/terraform/physical/README.md
@@ -2,7 +2,7 @@
 ## Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.11.1 |
 | <a name="requirement_archive"></a> [archive](#requirement\_archive) | 2.8.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 6.0 |
@@ -13,18 +13,18 @@
 ## Providers
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="provider_archive"></a> [archive](#provider\_archive) | 2.8.0 |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 6.0 |
-| <a name="provider_aws.dns"></a> [aws.dns](#provider\_aws.dns) | ~> 6.0 |
-| <a name="provider_aws.dr"></a> [aws.dr](#provider\_aws.dr) | ~> 6.0 |
-| <a name="provider_null"></a> [null](#provider\_null) | ~> 3.0 |
-| <a name="provider_random"></a> [random](#provider\_random) | ~> 3.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.51.0 |
+| <a name="provider_aws.dns"></a> [aws.dns](#provider\_aws.dns) | 6.51.0 |
+| <a name="provider_aws.dr"></a> [aws.dr](#provider\_aws.dr) | 6.51.0 |
+| <a name="provider_null"></a> [null](#provider\_null) | 3.3.0 |
+| <a name="provider_random"></a> [random](#provider\_random) | 3.9.0 |
 
 ## Modules
 
 | Name | Source | Version |
-|------|--------|---------|
+| ---- | ------ | ------- |
 | <a name="module_aurora"></a> [aurora](#module\_aurora) | terraform-aws-modules/rds-aurora/aws | 10.2.0 |
 | <a name="module_bastion"></a> [bastion](#module\_bastion) | terraform-aws-modules/autoscaling/aws | ~> 9.0 |
 | <a name="module_bastion_sg"></a> [bastion\_sg](#module\_bastion\_sg) | terraform-aws-modules/security-group/aws | ~> 5.0 |
@@ -52,7 +52,7 @@
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [aws_cloudwatch_event_rule.dms_task_state_changed_rule](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_rule) | resource |
 | [aws_cloudwatch_event_target.dms_task_state_changed_target](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_target) | resource |
 | [aws_cloudwatch_metric_alarm.aurora_acu](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
@@ -64,6 +64,7 @@
 | [aws_cloudwatch_metric_alarm.rds_storage_space_alarm](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
 | [aws_db_instance_automated_backups_replication.primary](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_instance_automated_backups_replication) | resource |
 | [aws_db_parameter_group.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_parameter_group) | resource |
+| [aws_db_subnet_group.dr_aurora](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_subnet_group) | resource |
 | [aws_dms_certificate.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dms_certificate) | resource |
 | [aws_dms_endpoint.source](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dms_endpoint) | resource |
 | [aws_dms_endpoint.target](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dms_endpoint) | resource |
@@ -100,11 +101,13 @@
 | [aws_iam_role_policy_attachment.lambda_basic_execution](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.lambda_iam_alias](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.s3_replication](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_kms_alias.dr_aurora](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_alias) | resource |
 | [aws_kms_alias.dr_rds](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_alias) | resource |
 | [aws_kms_alias.dr_s3](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_alias) | resource |
 | [aws_kms_alias.rds_cmk](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_alias) | resource |
 | [aws_kms_alias.s3](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_alias) | resource |
 | [aws_kms_key.bi](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
+| [aws_kms_key.dr_aurora](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
 | [aws_kms_key.dr_rds](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
 | [aws_kms_key.dr_s3](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
 | [aws_kms_key.eks](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
@@ -116,6 +119,8 @@
 | [aws_lambda_permission.sns_to_slack_permission](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_permission) | resource |
 | [aws_msk_cluster.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/msk_cluster) | resource |
 | [aws_msk_configuration.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/msk_configuration) | resource |
+| [aws_rds_cluster.dr_aurora_secondary](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/rds_cluster) | resource |
+| [aws_rds_global_cluster.aurora](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/rds_global_cluster) | resource |
 | [aws_route53_record.subdomain](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.subsite_subdomain](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.vault](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
@@ -144,6 +149,7 @@
 | [aws_secretsmanager_secret.replica_database_credentials](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret) | resource |
 | [aws_secretsmanager_secret_version.primary_database_credentials](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_version) | resource |
 | [aws_secretsmanager_secret_version.replica_database_credentials](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_version) | resource |
+| [aws_security_group.dr_aurora](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_security_group.elasticache](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_security_group.kafka](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_security_group.vault_endpoint](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
@@ -163,6 +169,8 @@
 | [aws_ssm_association.bastion_mysql_config](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_association) | resource |
 | [aws_ssm_document.bastion_kubernetes_config](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_document) | resource |
 | [aws_ssm_document.bastion_mysql_config](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_document) | resource |
+| [aws_subnet.dr_aurora](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet) | resource |
+| [aws_vpc.dr_aurora](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc) | resource |
 | [aws_vpc_endpoint.s3](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_endpoint) | resource |
 | [aws_vpc_endpoint.vault](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_endpoint) | resource |
 | [null_resource.cluster_urls](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
@@ -176,6 +184,7 @@
 | [archive_file.slack_sns_lambda](https://registry.terraform.io/providers/hashicorp/archive/2.8.0/docs/data-sources/file) | data source |
 | [aws_ami.amazon_linux_2023](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
 | [aws_availability_zones.available](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/availability_zones) | data source |
+| [aws_availability_zones.dr](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/availability_zones) | data source |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_iam_policy_document.cluster_access](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.dr_s3_replication](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
@@ -210,9 +219,9 @@
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_alarm_email"></a> [alarm\_email](#input\_alarm\_email) | Email address to send status alarms to. | `string` | `""` | no |
-| <a name="input_app_access_cidrs"></a> [app\_access\_cidrs](#input\_app\_access\_cidrs) | These CIDRs will be allowed to connect to Dozuki. If running a public site, use the default value. Otherwise you probably want to lock this down to the VPC or your VPN CIDR. | `list(string)` | <pre>[<br>  "0.0.0.0/0"<br>]</pre> | no |
+| <a name="input_app_access_cidrs"></a> [app\_access\_cidrs](#input\_app\_access\_cidrs) | These CIDRs will be allowed to connect to Dozuki. If running a public site, use the default value. Otherwise you probably want to lock this down to the VPC or your VPN CIDR. | `list(string)` | <pre>[<br/>  "0.0.0.0/0"<br/>]</pre> | no |
 | <a name="input_app_public_access"></a> [app\_public\_access](#input\_app\_public\_access) | Should the app and dashboard be accessible via a publicly routable IP and domain? | `bool` | `true` | no |
 | <a name="input_aurora_engine_version"></a> [aurora\_engine\_version](#input\_aurora\_engine\_version) | Aurora MySQL engine version, full aws RDS format (e.g. 8.4.mysql\_aurora.8.4.7 — the bare 8.4.7 is rejected with 'Cannot find version'). Fresh cluster: an 8.4 version. Snapshot-restore migration: an 8.0-compatible version first, then upgrade. | `string` | `"8.4.mysql_aurora.8.4.7"` | no |
 | <a name="input_aurora_max_acu"></a> [aurora\_max\_acu](#input\_aurora\_max\_acu) | Aurora Serverless v2 maximum capacity (ACUs). | `number` | `16` | no |
@@ -224,14 +233,15 @@
 | <a name="input_bi_dms_enabled"></a> [bi\_dms\_enabled](#input\_bi\_dms\_enabled) | If BI is enabled, whether or not to use DMS for conditional replication if true or a basic RDS read replica if false. | `bool` | `false` | no |
 | <a name="input_bi_public_access"></a> [bi\_public\_access](#input\_bi\_public\_access) | NOTE: This is mutually exclusive with VPN access, both cannot be enabled at the same time. If BI is enabled and you need access to the BI database server from outside the amazon network, set this to true. | `bool` | `false` | no |
 | <a name="input_bi_vpn_access"></a> [bi\_vpn\_access](#input\_bi\_vpn\_access) | NOTE: This is mutually exclusive with public BI access, both cannot be enabled at the same time. If BI is enabled we can create an OpenVPN connection to the BI database for secure internet access to the server. | `bool` | `false` | no |
-| <a name="input_bi_vpn_user_list"></a> [bi\_vpn\_user\_list](#input\_bi\_vpn\_user\_list) | List of users to create OpenVPN configurations for usint mutual authentication. | `list(string)` | <pre>[<br>  "root"<br>]</pre> | no |
+| <a name="input_bi_vpn_user_list"></a> [bi\_vpn\_user\_list](#input\_bi\_vpn\_user\_list) | List of users to create OpenVPN configurations for usint mutual authentication. | `list(string)` | <pre>[<br/>  "root"<br/>]</pre> | no |
 | <a name="input_cf_template_version"></a> [cf\_template\_version](#input\_cf\_template\_version) | Version of the CloudFormation template that deployed this stack for validation | `number` | `0` | no |
 | <a name="input_customer"></a> [customer](#input\_customer) | The customer name for resource names and tagging. This will also be the autogenerated subdomain. | `string` | `""` | no |
 | <a name="input_db_engine"></a> [db\_engine](#input\_db\_engine) | Database engine for this stack: 'rds' (provisioned RDS MySQL) or 'aurora' (Aurora MySQL 8.4 Serverless v2). Default 'aurora' for new stacks. EXISTING rds stacks must pin db\_engine='rds' in env.hcl, or a deploy will try to replace the DB — the Spacelift db-replace-guard plan policy blocks that accidental rds->aurora switch (override per stack with the allow-db-replace label for a deliberate migration). | `string` | `"aurora"` | no |
 | <a name="input_dms_allocated_storage"></a> [dms\_allocated\_storage](#input\_dms\_allocated\_storage) | How many GB to allocate for the DMS replication instance | `string` | `100` | no |
 | <a name="input_dms_instance_type"></a> [dms\_instance\_type](#input\_dms\_instance\_type) | The instance type for the DMS replication instance | `string` | `"dms.r5.large"` | no |
 | <a name="input_dr_region"></a> [dr\_region](#input\_dr\_region) | The DR region (concrete value). Normally injected by the Spacelift admin layer via TG\_AWS\_DR\_REGION; may be set explicitly to override. Never auto-derived in workload TF. | `string` | `""` | no |
-| <a name="input_eks_enabled_log_types"></a> [eks\_enabled\_log\_types](#input\_eks\_enabled\_log\_types) | EKS control-plane log types to stream to CloudWatch Logs. Defaults to all 5 (audit, api, authenticator, controllerManager, scheduler) for compliance (SOC2 / Vanta require audit logs at minimum). Set to [] to disable cluster logging entirely (not recommended). | `list(string)` | <pre>[<br>  "api",<br>  "audit",<br>  "authenticator",<br>  "controllerManager",<br>  "scheduler"<br>]</pre> | no |
+| <a name="input_dr_vpc_cidr"></a> [dr\_vpc\_cidr](#input\_dr\_vpc\_cidr) | CIDR for the minimal DR-region VPC that hosts the headless Aurora global-database secondary (private subnets only; no NAT/IGW). Must not overlap the primary VPC. Only used when the Aurora DR secondary is created (aurora engine + enable\_dr). | `string` | `"10.99.0.0/20"` | no |
+| <a name="input_eks_enabled_log_types"></a> [eks\_enabled\_log\_types](#input\_eks\_enabled\_log\_types) | EKS control-plane log types to stream to CloudWatch Logs. Defaults to all 5 (audit, api, authenticator, controllerManager, scheduler) for compliance (SOC2 / Vanta require audit logs at minimum). Set to [] to disable cluster logging entirely (not recommended). | `list(string)` | <pre>[<br/>  "api",<br/>  "audit",<br/>  "authenticator",<br/>  "controllerManager",<br/>  "scheduler"<br/>]</pre> | no |
 | <a name="input_eks_k8s_version"></a> [eks\_k8s\_version](#input\_eks\_k8s\_version) | Kubernetes version override. Leave null to let EKS Auto Mode manage the version. Set explicitly only to pin a specific version. | `string` | `null` | no |
 | <a name="input_eks_kms_key_id"></a> [eks\_kms\_key\_id](#input\_eks\_kms\_key\_id) | AWS KMS key identifier for EKS encryption. The identifier can be one of the following format: Key id, key ARN, alias name or alias ARN | `string` | `""` | no |
 | <a name="input_elasticache_cluster_size"></a> [elasticache\_cluster\_size](#input\_elasticache\_cluster\_size) | Cluster size | `number` | `1` | no |
@@ -253,14 +263,14 @@
 | <a name="input_rds_kms_key_id"></a> [rds\_kms\_key\_id](#input\_rds\_kms\_key\_id) | AWS KMS key identifier for RDS encryption. The identifier can be one of the following format: Key id, key ARN, alias name or alias ARN | `string` | `"alias/aws/rds"` | no |
 | <a name="input_rds_max_allocated_storage"></a> [rds\_max\_allocated\_storage](#input\_rds\_max\_allocated\_storage) | The maximum size to which AWS will scale the database (Gb) | `number` | `500` | no |
 | <a name="input_rds_multi_az"></a> [rds\_multi\_az](#input\_rds\_multi\_az) | If true we will tell RDS to automatically deploy and manage a highly available standby instance of your database. Enabling this doubles the cost of the RDS instance but without it you are susceptible to downtime if the AWS availability zone your RDS instance is in becomes unavailable. | `bool` | `true` | no |
-| <a name="input_rds_preferred_instance_classes"></a> [rds\_preferred\_instance\_classes](#input\_rds\_preferred\_instance\_classes) | A list of preferred RDS instance classes, the first available in the list will be used. See this page for a breakdown of the performance and cost differences between the different instance types: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.DBInstanceClass.html | `list(string)` | <pre>[<br>  "db.m5.large",<br>  "db.m4.large"<br>]</pre> | no |
+| <a name="input_rds_preferred_instance_classes"></a> [rds\_preferred\_instance\_classes](#input\_rds\_preferred\_instance\_classes) | A list of preferred RDS instance classes, the first available in the list will be used. See this page for a breakdown of the performance and cost differences between the different instance types: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.DBInstanceClass.html | `list(string)` | <pre>[<br/>  "db.m5.large",<br/>  "db.m4.large"<br/>]</pre> | no |
 | <a name="input_rds_snapshot_identifier"></a> [rds\_snapshot\_identifier](#input\_rds\_snapshot\_identifier) | We can seed the database from an existing RDS snapshot in this region. Type the snapshot identifier in this field or leave blank to start with a fresh database. Note: If you do use a snapshot it's critical that during stack updates you continue to include the snapshot identifier in this parameter. Clearing this parameter after using it will cause AWS to spin up a new fresh DB and delete your old one. | `string` | `""` | no |
 | <a name="input_s3_block_public_access"></a> [s3\_block\_public\_access](#input\_s3\_block\_public\_access) | To conform with SCP we can disable adding a public access block to the S3 buckets. This should only be disabled if absolutely necessary. | `bool` | `true` | no |
-| <a name="input_s3_existing_buckets"></a> [s3\_existing\_buckets](#input\_s3\_existing\_buckets) | List of the existing Dozuki buckets to use. Do not include the logging bucket. | <pre>list(object({<br>    type        = string<br>    bucket_name = string<br>  }))</pre> | `[]` | no |
+| <a name="input_s3_existing_buckets"></a> [s3\_existing\_buckets](#input\_s3\_existing\_buckets) | List of the existing Dozuki buckets to use. Do not include the logging bucket. | <pre>list(object({<br/>    type        = string<br/>    bucket_name = string<br/>  }))</pre> | `[]` | no |
 | <a name="input_s3_kms_key_id"></a> [s3\_kms\_key\_id](#input\_s3\_kms\_key\_id) | AWS KMS key identifier for S3 encryption. The identifier can be one of the following format: Key id, key ARN, alias name or alias ARN | `string` | `""` | no |
 | <a name="input_slack_webhook_url"></a> [slack\_webhook\_url](#input\_slack\_webhook\_url) | URL to an optional Slack webhook for SNS alerts. | `string` | `""` | no |
 | <a name="input_sso_admin_role_arn"></a> [sso\_admin\_role\_arn](#input\_sso\_admin\_role\_arn) | Exact IAM role ARN for the SSO AdministratorAccess permission set in this account. Required for kubectl/Lens access from workstations. Find it via: aws iam list-roles --query "Roles[?contains(RoleName,'AWSReservedSSO\_AWSAdministratorAccess')].Arn" | `string` | `""` | no |
-| <a name="input_subdomain_format"></a> [subdomain\_format](#input\_subdomain\_format) | Subdomain format specifying the order and/inclusion of customer, environment, and region (e.g., [%CUSTOMER%, %ENVIRONMENT%, %REGION%]) | `list(string)` | <pre>[<br>  "%CUSTOMER%",<br>  "%ENVIRONMENT%",<br>  "%REGION%",<br>  "%ACCOUNT%"<br>]</pre> | no |
+| <a name="input_subdomain_format"></a> [subdomain\_format](#input\_subdomain\_format) | Subdomain format specifying the order and/inclusion of customer, environment, and region (e.g., [%CUSTOMER%, %ENVIRONMENT%, %REGION%]) | `list(string)` | <pre>[<br/>  "%CUSTOMER%",<br/>  "%ENVIRONMENT%",<br/>  "%REGION%",<br/>  "%ACCOUNT%"<br/>]</pre> | no |
 | <a name="input_subdomain_override"></a> [subdomain\_override](#input\_subdomain\_override) | For upgrades only, new stacks use `customer`. If the previous version used an identifier but you want the subdomain to be different, add it here. | `string` | `""` | no |
 | <a name="input_use_existing_s3_kms"></a> [use\_existing\_s3\_kms](#input\_use\_existing\_s3\_kms) | To use the s3\_kms\_key\_id provided for the new s3 buckets as well, set this to true. | `bool` | `false` | no |
 | <a name="input_vault_endpoint_service_name"></a> [vault\_endpoint\_service\_name](#input\_vault\_endpoint\_service\_name) | VPC Endpoint Service name for the Vault PrivateLink service (e.g. com.amazonaws.vpce.us-east-1.vpce-svc-xxx). Deploy vault-privatelink-service first. | `string` | n/a | yes |
@@ -270,7 +280,9 @@
 ## Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
+| <a name="output_aurora_dr_global_cluster_id"></a> [aurora\_dr\_global\_cluster\_id](#output\_aurora\_dr\_global\_cluster\_id) | Aurora global cluster id (empty unless the Aurora DR secondary is enabled). |
+| <a name="output_aurora_dr_secondary_endpoint"></a> [aurora\_dr\_secondary\_endpoint](#output\_aurora\_dr\_secondary\_endpoint) | Reader endpoint of the headless DR secondary (populated once instances exist post-failover). |
 | <a name="output_azs_count"></a> [azs\_count](#output\_azs\_count) | n/a |
 | <a name="output_bastion_asg_name"></a> [bastion\_asg\_name](#output\_bastion\_asg\_name) | n/a |
 | <a name="output_bi_database_credential_secret"></a> [bi\_database\_credential\_secret](#output\_bi\_database\_credential\_secret) | If BI is enabled, this is the ARN to the AWS SecretsManager secret that contains the connection information for the BI database. |

--- a/terraform/physical/dr.tf
+++ b/terraform/physical/dr.tf
@@ -44,9 +44,9 @@ check "dr_region_valid" {
 # Aurora DR is the deferred Global Database "Plan B". S3 content replicates either way.
 check "dr_rds_replicable" {
   assert {
-    condition = !var.enable_dr || local.dr_rds_enabled
+    condition = !var.enable_dr || local.dr_rds_enabled || local.aurora_dr_enabled
     error_message = local.db_is_aurora ? (
-      "DR is enabled and S3 content replicates cross-region, but the Aurora database does NOT: cross-region Aurora DR (Global Database) is not yet implemented (the deferred \"Plan B\"). Only db_engine=\"rds\" currently supports automated-backup cross-region replication. The Aurora cluster is still encrypted with a customer-managed key when rds_adopt_dr_cmk is set."
+      "DR is enabled and S3 content replicates cross-region. The Aurora database replicates only when the global-database secondary is configured — ensure enable_dr is true and the admin layer injected a same-partition dr_region. (On GovCloud, confirm the engine version supports Global Database.)"
       ) : (
       "DR is enabled and S3 content replicates cross-region, but the RDS database does NOT: it is encrypted with an AWS-managed KMS key, so its automated backups are ineligible for cross-region replication. Adopt a customer-managed key — rds_adopt_dr_cmk = true (the default) for a fresh DB, or pin rds_kms_key_id to an existing CMK (a key change replaces the DB). See the DR cold-recovery runbook."
     )

--- a/terraform/physical/dr_aurora.tf
+++ b/terraform/physical/dr_aurora.tf
@@ -1,0 +1,151 @@
+# Aurora cross-region DR (DR Phase 2) — headless Aurora Global Database secondary in
+# var.dr_region. Gated on enable_dr (like the rest of dr.tf) and only for the aurora
+# engine. The CMK on the primary (dr.tf rds_cmk, used by aurora.tf) is the prerequisite.
+#
+# Adoption is NON-DESTRUCTIVE: aws_rds_global_cluster adopts the EXISTING primary cluster
+# in place via source_db_cluster_identifier. The rds-aurora module's aws_rds_cluster
+# already ignore_changes on global_cluster_identifier, so AWS stamping the global
+# membership onto the primary neither drifts nor replaces it. The db-replace-guard PLAN
+# policy is the backstop if that ever regresses.
+#
+# Partition-aware: aurora_dr_partition_ok stays true — Global Database is available for
+# the pinned 8.4 engine in BOTH the aws and aws-us-gov partitions (gov DR is gov-west <->
+# gov-east; verified 2026-06-23, see the DR Phase 2 spec). Flip to a partition check only
+# if a future engine/region loses Global Database in gov.
+locals {
+  aurora_dr_partition_ok = true
+  aurora_dr_enabled      = local.db_is_aurora && var.enable_dr && local.aurora_dr_partition_ok
+}
+
+# DR-region AZs (aws.dr is the Terragrunt-generated DR provider).
+data "aws_availability_zones" "dr" {
+  count    = local.aurora_dr_enabled ? 1 : 0
+  provider = aws.dr
+  state    = "available"
+}
+
+# --- DR-region networking ----------------------------------------------------
+# A secondary Aurora cluster is VPC-bound even when headless, so it needs a DB
+# subnet group in the DR region. Minimal footprint: private subnets only, no NAT/IGW
+# (the headless cluster needs no egress; failover instances live in these subnets).
+resource "aws_vpc" "dr_aurora" {
+  count                = local.aurora_dr_enabled ? 1 : 0
+  provider             = aws.dr
+  cidr_block           = var.dr_vpc_cidr
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+  tags                 = merge(local.tags, { Name = "${local.identifier}-dr-aurora" })
+}
+
+# One private /24 per AZ (up to 3), carved from dr_vpc_cidr.
+resource "aws_subnet" "dr_aurora" {
+  for_each          = local.aurora_dr_enabled ? toset(slice(data.aws_availability_zones.dr[0].names, 0, min(3, length(data.aws_availability_zones.dr[0].names)))) : []
+  provider          = aws.dr
+  vpc_id            = aws_vpc.dr_aurora[0].id
+  availability_zone = each.value
+  cidr_block        = cidrsubnet(var.dr_vpc_cidr, 4, index(data.aws_availability_zones.dr[0].names, each.value))
+  tags              = merge(local.tags, { Name = "${local.identifier}-dr-aurora-${each.value}" })
+}
+
+resource "aws_db_subnet_group" "dr_aurora" {
+  count       = local.aurora_dr_enabled ? 1 : 0
+  provider    = aws.dr
+  name_prefix = "${local.identifier}-dr-aurora-"
+  subnet_ids  = [for s in aws_subnet.dr_aurora : s.id]
+  tags        = local.tags
+}
+
+resource "aws_security_group" "dr_aurora" {
+  count       = local.aurora_dr_enabled ? 1 : 0
+  provider    = aws.dr
+  name_prefix = "${local.identifier}-dr-aurora-"
+  description = "DR-region Aurora global secondary (headless; ingress added at failover)"
+  vpc_id      = aws_vpc.dr_aurora[0].id
+  tags        = local.tags
+
+  # No ingress while headless. On failover the runbook adds ingress for the promoted
+  # cluster from the app's DR-region SG. Egress is intra-VPC only (no IGW).
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = [var.dr_vpc_cidr]
+  }
+}
+
+# --- DR-region CMK for the secondary's storage (mirrors aws_kms_key.dr_rds) ----
+resource "aws_kms_key" "dr_aurora" {
+  count                   = local.aurora_dr_enabled ? 1 : 0
+  provider                = aws.dr
+  description             = "${local.identifier} DR Aurora global secondary storage"
+  enable_key_rotation     = true
+  deletion_window_in_days = var.protect_resources ? 30 : 7
+  tags                    = local.tags
+}
+
+resource "aws_kms_alias" "dr_aurora" {
+  count         = local.aurora_dr_enabled ? 1 : 0
+  provider      = aws.dr
+  name_prefix   = "alias/${local.identifier}/dr/aurora/"
+  target_key_id = aws_kms_key.dr_aurora[0].id
+}
+
+# --- Global cluster: adopt the existing primary in place ----------------------
+resource "aws_rds_global_cluster" "aurora" {
+  count                        = local.aurora_dr_enabled ? 1 : 0
+  global_cluster_identifier    = "${local.identifier}-global"
+  engine                       = "aurora-mysql"
+  engine_version               = var.aurora_engine_version
+  source_db_cluster_identifier = module.aurora[0].cluster_arn
+  force_destroy                = true
+
+  lifecycle {
+    # After adoption AWS stamps these onto the global cluster from the source cluster;
+    # they are the adoption seed, not ongoing config. Avoid perpetual diffs / replace.
+    ignore_changes = [source_db_cluster_identifier, engine_version]
+  }
+}
+
+# --- Headless secondary cluster in the DR region (no instances) ---------------
+resource "aws_rds_cluster" "dr_aurora_secondary" {
+  count    = local.aurora_dr_enabled ? 1 : 0
+  provider = aws.dr
+
+  cluster_identifier        = "${local.identifier}-dr"
+  engine                    = "aurora-mysql"
+  engine_version            = var.aurora_engine_version
+  global_cluster_identifier = aws_rds_global_cluster.aurora[0].id
+  storage_encrypted         = true
+  kms_key_id                = aws_kms_key.dr_aurora[0].arn
+  # Required for an ENCRYPTED cross-region global secondary: the provider builds a
+  # presigned URL to the primary region from source_region. Without it CreateDBCluster
+  # fails at apply (not caught by validate or a plan-preview).
+  source_region          = data.aws_region.current.region
+  db_subnet_group_name   = aws_db_subnet_group.dr_aurora[0].name
+  vpc_security_group_ids = [aws_security_group.dr_aurora[0].id]
+
+  # master_username / master_password / database_name are inherited from the global
+  # primary and must NOT be set on a secondary.
+  skip_final_snapshot = !var.protect_resources
+  apply_immediately   = !var.protect_resources
+
+  # NO aws_rds_cluster_instance => headless: storage replication only, no compute cost.
+  # Failover provisions an instance (see the Aurora failover runbook).
+
+  lifecycle {
+    ignore_changes = [replication_source_identifier]
+  }
+
+  depends_on = [aws_rds_global_cluster.aurora]
+}
+
+# --- Outputs (consumed by the failover runbook) -------------------------------
+output "aurora_dr_global_cluster_id" {
+  description = "Aurora global cluster id (empty unless the Aurora DR secondary is enabled)."
+  value       = try(aws_rds_global_cluster.aurora[0].id, "")
+}
+
+output "aurora_dr_secondary_endpoint" {
+  description = "Reader endpoint of the headless DR secondary (populated once instances exist post-failover)."
+  value       = try(aws_rds_cluster.dr_aurora_secondary[0].reader_endpoint, "")
+}

--- a/terraform/physical/variables.tf
+++ b/terraform/physical/variables.tf
@@ -379,6 +379,12 @@ variable "dr_region" {
   default     = ""
 }
 
+variable "dr_vpc_cidr" {
+  description = "CIDR for the minimal DR-region VPC that hosts the headless Aurora global-database secondary (private subnets only; no NAT/IGW). Must not overlap the primary VPC. Only used when the Aurora DR secondary is created (aurora engine + enable_dr)."
+  type        = string
+  default     = "10.99.0.0/20"
+}
+
 variable "rds_adopt_dr_cmk" {
   description = "When true (the default DR-ready posture), the database is created with a Terraform-managed customer KMS key so it is encrypted under a CMK — the prerequisite for cross-region DR (RDS automated-backup replication; Aurora is CMK-encrypted but its cross-region replication is the deferred Global-Database Plan B). EXISTING stacks created with the AWS-managed key MUST pin this to false (or pin rds_kms_key_id to their already-adopted CMK): a KMS-key change replaces the database. The db-replace-guard PLAN policy blocks any such unintended replacement (it requires the allow-db-replace stack label), so this default is fail-safe."
   type        = bool


### PR DESCRIPTION
Implements DR Phase 2 — a **headless Aurora Global Database** secondary for cross-region DB DR, closing the Aurora gap left when CMK became the default (DR Phase 1 only covers the `rds` engine).

## What
`terraform/physical/dr_aurora.tf` (new), gated on `enable_dr` + `db_engine="aurora"`:
- **Adopts the existing primary cluster in place** via `aws_rds_global_cluster.source_db_cluster_identifier` — non-destructive (see below).
- **Minimal DR-region VPC** (`var.dr_vpc_cidr`, default `10.99.0.0/20`): private subnets + DB subnet group + SG, **no NAT/IGW** (a secondary cluster is VPC-bound even when headless).
- **DR-region CMK** (mirrors `aws_kms_key.dr_rds`).
- **Headless secondary** `aws_rds_cluster` (no `aws_rds_cluster_instance` → storage replication only, no idle compute), `source_region` set for the encrypted cross-region secondary.
- Folds Aurora into the `dr_rds_replicable` check; adds global-cluster-id + secondary-endpoint outputs.

Partition-aware (`aurora_dr_partition_ok` stays `true`): Global Database is available for the pinned 8.4 engine in **both** `aws` and `aws-us-gov` (gov = gov-west↔gov-east). Failover is runbook-driven (cold tier; headless secondary gets an instance at promotion).

## Non-destructive adoption (the #1 risk — verified)
The `terraform-aws-modules/rds-aurora` module's `aws_rds_cluster.this` already has `lifecycle { ignore_changes = [..., global_cluster_identifier] }`. So when the global cluster adopts the primary, AWS stamps `global_cluster_identifier` onto it and the module **ignores** it — no drift, no detach, no replace. Matches the provider's "global cluster from existing DB cluster" example. The `db-replace-guard` PLAN policy is the runtime backstop.

## Validation
- `tofu validate` ✓ (stub providers).
- **Senior code review** ✓ — found & fixed one blocker: encrypted cross-region secondary needs `source_region` (fails at `CreateDBCluster` otherwise; not caught by validate/plan). Adoption-safety, count-gating, provider (`aws.dr`) usage all confirmed correct.
- ⚠️ A local `terragrunt plan` against min was **not** a faithful gate (the `--terragrunt-source` override didn't load the admin-injected inputs → planned an empty config). The **zero-destroy gate should be a Spacelift preview on min** (where inputs load correctly); the encrypted-secondary create is only provable by a real apply (min is the dev target).

## Notes
- Failover/failback/teardown runbook: local docs (`docs/runbooks/aurora-global-db-failover.md`, not committed per no-repo-docs).
- Spec: `docs/specs/2026-06-23-aurora-global-database-dr-design.md`.
- Rides into the next release (release-please). When min picks it up, its Spacelift run creates the global cluster + headless secondary — the real end-to-end validation, with the guard backstopping the adoption.