### PR TITLE
chore: exclude live/tests (harness) from release-please

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,7 +6,8 @@
     ".": {
       "release-type": "simple",
       "package-name": "cloudprem-infra",
-      "changelog-path": "CHANGELOG.md"
+      "changelog-path": "CHANGELOG.md",
+      "exclude-paths": ["live/tests"]
     }
   }
 }


### PR DESCRIPTION
## Problem
`feat:`/`fix:` commits to the upgrade harness (`live/tests/`) bump the **product** version even though the harness is test tooling, not the released product. PR #208 (`feat(harness): version_defaults`) opened release PR #209 proposing 7.2.0 — unwanted. (This repo squashes with the commit message, so the commit *type* governs, regardless of the PR title.)

## Fix
Add `exclude-paths: ["live/tests"]` to the release-please package config. Per the release-please schema: *"If all files from commit belong to one of the paths it will be skipped."* So a commit that only touches `live/tests` is ignored by release-please; mixed commits that also touch product paths still count. Result: only real terraform / repo-config changes drive version bumps.

## Effect
After merge, release-please re-evaluates and drops the harness `feat:` commit → the pending 7.2.0 PR (#209) should empty out / close (no releasable changes). This `chore:` config change itself is non-bumping.