### PR TITLE
feat: delete_after tag + harness stamping for ResourceReaper

### DIFF
--- a/live/tests/harness/config.go
+++ b/live/tests/harness/config.go
@@ -20,6 +20,7 @@ type Defaults struct {
 	DRRegion          string   `yaml:"dr_region"`
 	EnvPath           string   `yaml:"env_path"`
 	CriticalWorkloads []string `yaml:"critical_workloads"`
+	ReaperTTLHours    int      `yaml:"reaper_ttl_hours"`
 }
 
 type Config struct {

--- a/live/tests/harness/config_test.go
+++ b/live/tests/harness/config_test.go
@@ -58,6 +58,13 @@ func TestMergedInputsExcludesHarnessOnlyKeys(t *testing.T) {
 	}
 }
 
+func TestWithDeleteAfter(t *testing.T) {
+	out := withDeleteAfter(map[string]interface{}{"x": 1}, "2026-06-24T00:00:00Z")
+	if out["delete_after"] != "2026-06-24T00:00:00Z" {
+		t.Errorf("delete_after = %v", out["delete_after"])
+	}
+}
+
 func TestVersionDefaults(t *testing.T) {
 	m := &Matrix{
 		VersionDefaults: map[string]interface{}{

--- a/live/tests/harness/run.go
+++ b/live/tests/harness/run.go
@@ -45,12 +45,13 @@ type RunParams struct {
 	ToRef             string // resolved concrete ref
 	AccountID         string
 	Profile           string
-	RunID             string   // unique per run; namespaces state
-	Namespace         string   // app namespace, e.g. "dozuki"
-	DRRegion          string   // DR region (e.g. "us-west-2"); set from matrix defaults
-	RestoreDrill      bool     // run the RDS restore drill
-	EnableDR          bool     // DR validators enabled (enable_dr flag)
-	CriticalWorkloads []string // critical workload name globs; empty → DefaultCriticalWorkloads()
+	RunID             string    // unique per run; namespaces state
+	Namespace         string    // app namespace, e.g. "dozuki"
+	DRRegion          string    // DR region (e.g. "us-west-2"); set from matrix defaults
+	RestoreDrill      bool      // run the RDS restore drill
+	EnableDR          bool      // DR validators enabled (enable_dr flag)
+	CriticalWorkloads []string  // critical workload name globs; empty → DefaultCriticalWorkloads()
+	StartTime         time.Time // wall-clock run start; used to compute deleteAfter (zero → time.Now())
 }
 
 // RunUpgrade executes apply(baseline) -> validate -> apply(target) -> validate
@@ -74,6 +75,17 @@ func RunUpgrade(p RunParams) (err error) {
 	phaseMarks = nil
 	runStart = time.Now()
 	defer func() { printSummary(p, cfg, err) }()
+
+	// Compute deleteAfter once so both worktrees of this upgrade share the same value.
+	startTime := p.StartTime
+	if startTime.IsZero() {
+		startTime = runStart
+	}
+	ttl := p.Matrix.Defaults.ReaperTTLHours
+	if ttl == 0 {
+		ttl = 24
+	}
+	deleteAfter := startTime.Add(time.Duration(ttl) * time.Hour).UTC().Format(time.RFC3339)
 
 	ctx := context.Background()
 	base := filepath.Join(p.RepoDir, "live", "tests", "__worktrees__", p.RunID)
@@ -132,10 +144,10 @@ func RunUpgrade(p RunParams) (err error) {
 	// runs against the applied worktree, appliedWT) always has a valid config to
 	// clean up with, even if the baseline apply fails before the target env.hcl
 	// would otherwise be written.
-	if werr := WriteEnvHCL(filepath.Join(fromWT.Dir, envSub), p.Matrix.MergedInputs(cfg, p.FromRef)); werr != nil {
+	if werr := WriteEnvHCL(filepath.Join(fromWT.Dir, envSub), withDeleteAfter(p.Matrix.MergedInputs(cfg, p.FromRef), deleteAfter)); werr != nil {
 		return werr
 	}
-	if werr := WriteEnvHCL(filepath.Join(toWT.Dir, envSub), p.Matrix.MergedInputs(cfg, p.ToRef)); werr != nil {
+	if werr := WriteEnvHCL(filepath.Join(toWT.Dir, envSub), withDeleteAfter(p.Matrix.MergedInputs(cfg, p.ToRef), deleteAfter)); werr != nil {
 		return werr
 	}
 
@@ -180,7 +192,7 @@ func RunUpgrade(p RunParams) (err error) {
 	}
 
 	// ---- Target (upgrade) apply against the SAME state prefix + validate ----
-	if werr := WriteEnvHCL(filepath.Join(toWT.Dir, envSub), p.Matrix.MergedInputs(cfg, p.ToRef)); werr != nil {
+	if werr := WriteEnvHCL(filepath.Join(toWT.Dir, envSub), withDeleteAfter(p.Matrix.MergedInputs(cfg, p.ToRef), deleteAfter)); werr != nil {
 		return werr
 	}
 	step("UPGRADE apply: %s -> %s (same state prefix; terragrunt run-all apply)", p.FromRef, p.ToRef)
@@ -233,6 +245,17 @@ func RunFresh(p RunParams) (err error) {
 	runStart = time.Now()
 	defer func() { printSummary(p, cfg, err) }()
 
+	// Compute deleteAfter for this run.
+	startTime := p.StartTime
+	if startTime.IsZero() {
+		startTime = runStart
+	}
+	ttl := p.Matrix.Defaults.ReaperTTLHours
+	if ttl == 0 {
+		ttl = 24
+	}
+	deleteAfter := startTime.Add(time.Duration(ttl) * time.Hour).UTC().Format(time.RFC3339)
+
 	ctx := context.Background()
 	base := filepath.Join(p.RepoDir, "live", "tests", "__worktrees__", p.RunID)
 	region := p.Matrix.Defaults.Region
@@ -270,7 +293,7 @@ func RunFresh(p RunParams) (err error) {
 		}
 	}
 
-	if werr := WriteEnvHCL(filepath.Join(wt.Dir, envSub), p.Matrix.MergedInputs(cfg, p.ToRef)); werr != nil {
+	if werr := WriteEnvHCL(filepath.Join(wt.Dir, envSub), withDeleteAfter(p.Matrix.MergedInputs(cfg, p.ToRef), deleteAfter)); werr != nil {
 		return werr
 	}
 
@@ -561,6 +584,15 @@ func printSummary(p RunParams, cfg Config, err error) {
 	line(" Artifacts: live/tests/.artifacts/%s/  (run log + diagnostics; bundled to S3 by run.sh)", p.RunID)
 	line("======================================================================")
 	fmt.Fprint(os.Stderr, b.String())
+}
+
+// withDeleteAfter sets in["delete_after"] = ts and returns the same map, so it
+// can be used inline at WriteEnvHCL call sites. Every worktree written by a run
+// carries this timestamp, allowing the ResourceReaper to purge orphans left behind
+// by a failed teardown.
+func withDeleteAfter(in map[string]interface{}, ts string) map[string]interface{} {
+	in["delete_after"] = ts
+	return in
 }
 
 // truncate collapses s to its first line and caps it at n bytes for the summary table.

--- a/live/tests/matrix.yaml
+++ b/live/tests/matrix.yaml
@@ -7,6 +7,7 @@ defaults:
   region: "us-east-1"
   dr_region: "us-west-2"
   env_path: "live/standard/us-east-1"   # parent dir holding region.hcl; the config's env dir is <env_path>/<env>
+  reaper_ttl_hours: 24   # resources get deleteAfter = run start + this; the reaper purges them after, if teardown failed
 
 # Default version vars applied to EVERY ref (image_tag, chart_version, …). A ref
 # only needs an entry under `versions:` below if it DIFFERS from these. A freshly

--- a/terraform/logical/kubernetes.tf
+++ b/terraform/logical/kubernetes.tf
@@ -478,6 +478,11 @@ resource "aws_eks_addon" "cloudwatch_observability" {
   resolve_conflicts_on_create = "OVERWRITE"
   resolve_conflicts_on_update = "OVERWRITE"
 
+  tags = merge(
+    {},
+    var.delete_after != "" ? { deleteAfter = var.delete_after } : {},
+  )
+
   # Headroom for the first node's Karpenter cold-start on a brand-new cluster.
   timeouts {
     create = "40m"

--- a/terraform/logical/variables.tf
+++ b/terraform/logical/variables.tf
@@ -453,3 +453,9 @@ variable "memcached_in_cluster" {
   type        = bool
   default     = true
 }
+
+variable "delete_after" {
+  description = "Optional RFC3339 timestamp. When set, the AWS EKS addon resource is tagged deleteAfter=<value> so the ResourceReaper janitor can purge it after that time if teardown fails. Empty = no tag (normal deploys)."
+  type        = string
+  default     = ""
+}

--- a/terraform/physical/main.tf
+++ b/terraform/physical/main.tf
@@ -49,12 +49,15 @@ locals {
 
   # --Tags for all resources--
   // If you add a tag, it must never be blank.
-  tags = {
-    Terraform   = "true"
-    Project     = "Dozuki"
-    Identifier  = coalesce(var.customer, "Dozuki")
-    Environment = var.environment
-  }
+  tags = merge(
+    {
+      Terraform   = "true"
+      Project     = "Dozuki"
+      Identifier  = coalesce(var.customer, "Dozuki")
+      Environment = var.environment
+    },
+    var.delete_after != "" ? { deleteAfter = var.delete_after } : {},
+  )
 
   is_us_gov = data.aws_partition.current.partition == "aws-us-gov"
 

--- a/terraform/physical/variables.tf
+++ b/terraform/physical/variables.tf
@@ -432,4 +432,10 @@ variable "memcached_in_cluster" {
   default     = true
 }
 
+variable "delete_after" {
+  description = "Optional RFC3339 timestamp. When set, every resource is tagged deleteAfter=<value> so the ResourceReaper janitor can purge it after that time if teardown fails. Empty = no tag (normal deploys)."
+  type        = string
+  default     = ""
+}
+
 # --- END App Configuration --- #


### PR DESCRIPTION
## deleteAfter tagging — fuel for the ResourceReaper janitor

Lets ResourceReaper (the DDVtest cost-janitor) authoritatively purge resources a failed harness teardown leaves behind.

- **physical / logical** gain an optional `delete_after` (RFC3339 string) input; when set, resources get a `deleteAfter=<value>` tag (conditional merge — normal deploys are unaffected). Logical only has one taggable AWS resource (the cloudwatch-observability addon); the cost-heavy orphans are physical.
- **harness** (`live/tests`) computes `deleteAfter = run-start + reaper_ttl_hours` (default 24h) and stamps it into every `env.hcl` it writes (all 4 WriteEnvHCL sites across RunUpgrade + RunFresh).

End-to-end: `delete_after` (var) → `deleteAfter` (tag) = exactly what ResourceReaper's `__global__` `tag:deleteAfter` filter gates on. Normal flow: teardown deletes the resources; `deleteAfter` never matters. Failure flow: orphans carry `deleteAfter` → ResourceReaper purges them after expiry. `go build/vet/test` pass.