### PR TITLE
refactor(logical): use the dozuki chart's seaweedfs subchart on Azure

### DIFF
--- a/terraform/logical/README.md
+++ b/terraform/logical/README.md
@@ -41,7 +41,6 @@ No modules.
 | [helm_release.envoy_gateway](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 | [helm_release.external_dns](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 | [helm_release.external_secrets](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
-| [helm_release.seaweedfs](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 | [kubernetes_cluster_role_binding_v1.dozuki_list_role_binding](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/cluster_role_binding_v1) | resource |
 | [kubernetes_cluster_role_binding_v1.vault_auth_delegator](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/cluster_role_binding_v1) | resource |
 | [kubernetes_cluster_role_v1.dozuki_list_role](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/cluster_role_v1) | resource |
@@ -52,7 +51,6 @@ No modules.
 | [kubernetes_job_v1.dms_start](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/job_v1) | resource |
 | [kubernetes_job_v1.frontegg_db_create](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/job_v1) | resource |
 | [kubernetes_job_v1.grafana_db_create](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/job_v1) | resource |
-| [kubernetes_job_v1.seaweedfs_buckets](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/job_v1) | resource |
 | [kubernetes_manifest.nodepool_on_demand](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/manifest) | resource |
 | [kubernetes_manifest.nodepool_spot](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/manifest) | resource |
 | [kubernetes_manifest.tgb_http](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/manifest) | resource |
@@ -79,6 +77,7 @@ No modules.
 | [random_password.grafana_admin](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
 | [random_password.redis_auth](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
 | [random_password.seaweedfs_access_key](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
+| [random_password.seaweedfs_filer_db](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
 | [random_password.seaweedfs_secret_key](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
 | [tls_private_key.gateway](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key) | resource |
 | [tls_self_signed_cert.gateway](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/self_signed_cert) | resource |

--- a/terraform/logical/kubernetes.tf
+++ b/terraform/logical/kubernetes.tf
@@ -501,7 +501,7 @@ locals {
 }
 
 resource "helm_release" "app" {
-  depends_on = [helm_release.cert_manager, helm_release.envoy_gateway, helm_release.external_secrets, kubernetes_service_account_v1.eso_vault_auth, kubernetes_secret_v1.ghcr_pull, aws_eks_addon.cloudwatch_observability, helm_release.seaweedfs, kubernetes_job_v1.seaweedfs_buckets, kubernetes_secret_v1.gateway_tls, helm_release.external_dns, kubernetes_secret_v1.redis_auth_eg]
+  depends_on = [helm_release.cert_manager, helm_release.envoy_gateway, helm_release.external_secrets, kubernetes_service_account_v1.eso_vault_auth, kubernetes_secret_v1.ghcr_pull, aws_eks_addon.cloudwatch_observability, kubernetes_secret_v1.gateway_tls, helm_release.external_dns, kubernetes_secret_v1.redis_auth_eg]
 
   name      = "dozuki"
   namespace = kubernetes_namespace_v1.app.metadata[0].name
@@ -520,12 +520,22 @@ resource "helm_release" "app" {
   wait    = true
   timeout = 900
 
-  # Azure-only values: GHCR pull secret for MPC images, and expose the gateway
-  # via an Azure public LoadBalancer (no NLB on Azure). An azure-dns-label-name
-  # annotation gives the LB a stable <label>.<region>.cloudapp.azure.com FQDN.
+  # Azure-only values: GHCR pull secret for MPC images, expose the gateway via an
+  # Azure public LoadBalancer (no NLB on Azure; an azure-dns-label-name annotation
+  # gives the LB a stable <label>.<region>.cloudapp.azure.com FQDN), and enable the
+  # chart's bundled SeaweedFS subchart for object storage (Azure has no S3). This is
+  # the same model on-prem uses (seaweedfs.enabled=true); see local.seaweedfs_values.
   # On AWS this is an empty list of values files — a no-op, no overrides applied.
   values = var.cloud == "azure" ? [yamlencode(merge({
-    global = { imagePullSecrets = [{ name = "ghcr-pull" }] }
+    global = {
+      imagePullSecrets = [{ name = "ghcr-pull" }]
+      # SeaweedFS subchart replication: keep a second copy of every volume so a
+      # single PVC loss does not lose data (matches the old standalone posture).
+      seaweedfs = {
+        enableReplication    = true
+        replicationPlacement = "001"
+      }
+    }
     gateway = {
       service = {
         type        = "LoadBalancer"
@@ -533,7 +543,7 @@ resource "helm_release" "app" {
       }
       dnsTarget = local.lb_fqdn
     }
-    }, var.azure_acme_server != "" ? {
+    }, local.seaweedfs_values, var.azure_acme_server != "" ? {
     cert_manager = { acmeServer = var.azure_acme_server }
   } : {}))] : []
 
@@ -612,7 +622,16 @@ resource "helm_release" "app" {
 
     # --- In-cluster services (Azure) ---
     { name = "memcached.enabled", value = local.memcached_in_cluster ? "true" : "false" },
-    { name = "objectStorage.endpoint", value = var.cloud == "azure" ? "https://s3.${var.dns_domain_name}" : "" },
+    # SeaweedFS S3 endpoint. When seaweedfs.enabled (azure), the chart's
+    # dozuki.objectStorageEndpoint helper auto-points the app at the in-cluster
+    # filer S3 service (dozuki-seaweedfs-filer:8333); we set the same value here
+    # explicitly so it is correct even where the raw objectStorage.endpoint is read.
+    { name = "objectStorage.endpoint", value = var.cloud == "azure" ? local.seaweedfs_s3_endpoint : "" },
+    # publicHost exposes SeaweedFS S3 externally (presigned reads/writes) via a
+    # dedicated gateway HTTPS listener + HTTPRoute. The HTTPRoute backend
+    # (objectStorage.publicBackend.service) is overridden in local.seaweedfs_values
+    # to the embedded filer S3 service, since the chart default ("seaweedfs-s3")
+    # only matches a standalone S3 deployment, which we do not run.
     { name = "objectStorage.publicHost", value = var.cloud == "azure" ? "s3.${var.dns_domain_name}" : "" },
 
     # --- Grafana ---

--- a/terraform/logical/kubernetes.tf
+++ b/terraform/logical/kubernetes.tf
@@ -595,11 +595,16 @@ resource "helm_release" "app" {
     { name = "webhooks.enabled", value = var.enable_webhooks ? "true" : "false" },
 
     # --- Object Storage ---
+    # var.s3_*_bucket are the customer's REAL S3 bucket names and apply to AWS ONLY.
+    # On Azure object storage is the chart's SeaweedFS subchart, whose buckets are
+    # STATIC/chart-defined (images/pdfs/docs/objects, created by the subchart's
+    # createBuckets hook — see local.seaweedfs_*_bucket in seaweedfs.tf). The app
+    # must read those same static names so it hits the buckets SeaweedFS created.
     { name = "objectStorage.kmsKey", value = var.cloud == "aws" ? data.aws_kms_key.s3[0].arn : "" },
-    { name = "objectStorage.imagesBucket", value = var.s3_images_bucket },
-    { name = "objectStorage.pdfsBucket", value = var.s3_pdfs_bucket },
-    { name = "objectStorage.documentsBucket", value = var.s3_documents_bucket },
-    { name = "objectStorage.objectsBucket", value = var.s3_objects_bucket },
+    { name = "objectStorage.imagesBucket", value = var.cloud == "azure" ? local.seaweedfs_images_bucket : var.s3_images_bucket },
+    { name = "objectStorage.pdfsBucket", value = var.cloud == "azure" ? local.seaweedfs_pdfs_bucket : var.s3_pdfs_bucket },
+    { name = "objectStorage.documentsBucket", value = var.cloud == "azure" ? local.seaweedfs_documents_bucket : var.s3_documents_bucket },
+    { name = "objectStorage.objectsBucket", value = var.cloud == "azure" ? local.seaweedfs_objects_bucket : var.s3_objects_bucket },
 
     # --- Memcached ---
     # Memcached host — see local.memcached_host (FQDN in-cluster). NOTE: this chart value

--- a/terraform/logical/seaweedfs.tf
+++ b/terraform/logical/seaweedfs.tf
@@ -1,23 +1,13 @@
-# SeaweedFS in-cluster S3-compatible object storage (Azure only).
+# SeaweedFS object storage (Azure only) — provided by the dozuki chart's bundled
+# seaweedfs subchart, exactly the way an on-prem install enables it
+# (seaweedfs.enabled=true). Azure has no S3, so the app talks to the in-cluster
+# SeaweedFS filer S3 gateway; on AWS the app uses real S3 (this whole file is a
+# no-op when var.cloud != "azure").
 #
-# On AWS the app uses real S3 buckets; on Azure the app talks to a SeaweedFS
-# filer with the embedded S3 gateway enabled. The helm release name is
-# "seaweedfs" so the chart fullname collapses to "seaweedfs" and the filer S3
-# gateway Service is "seaweedfs-s3" on port 8333 (verified against chart
-# 4.33.0 rendered manifests).
-
-locals {
-  seaweedfs_s3_endpoint = "http://seaweedfs-s3.${local.k8s_namespace_name}.svc.cluster.local:8333"
-
-  seaweedfs_buckets = [
-    for b in [
-      var.s3_images_bucket,
-      var.s3_objects_bucket,
-      var.s3_documents_bucket,
-      var.s3_pdfs_bucket,
-    ] : b if b != ""
-  ]
-}
+# The previous standalone seaweedfs helm_release + bucket-creation Job were
+# removed. The subchart now owns the master/volume/filer StatefulSets, the
+# embedded S3 gateway Service (dozuki-seaweedfs-filer:8333), MySQL filer metadata,
+# schema init, and bucket creation (filer.s3.createBuckets hook).
 
 resource "random_password" "seaweedfs_access_key" {
   count = var.cloud == "azure" ? 1 : 0
@@ -33,33 +23,70 @@ resource "random_password" "seaweedfs_secret_key" {
   special = false
 }
 
-resource "helm_release" "seaweedfs" {
+# Password for the dedicated MySQL user the filer uses for its metadata store.
+# The chart's schema-init Job (running as the app DB admin) creates the
+# seaweedfs_filer schema and this user before the filer starts.
+resource "random_password" "seaweedfs_filer_db" {
   count = var.cloud == "azure" ? 1 : 0
 
-  name       = "seaweedfs"
-  namespace  = kubernetes_namespace_v1.app.metadata[0].name
-  repository = "https://seaweedfs.github.io/seaweedfs/helm"
-  chart      = "seaweedfs"
-  version    = "4.33.0"
+  length  = 32
+  special = false
+}
 
-  wait    = true
-  timeout = 600
+locals {
+  # In-cluster S3 endpoint. With filer.s3.enabled the subchart exposes the S3
+  # gateway on the filer Service (named <release>-seaweedfs-filer => the release
+  # is "dozuki") port 8333. This matches the chart's dozuki.objectStorageEndpoint
+  # helper, which auto-wires the app to the same host when seaweedfs.enabled.
+  seaweedfs_s3_endpoint = "http://dozuki-seaweedfs-filer.${local.k8s_namespace_name}.svc.cluster.local:8333"
 
-  values = [
-    yamlencode({
+  # The buckets the app uses. The subchart's native createBuckets hook is driven
+  # from this same list so the created buckets always match objectStorage.*Bucket.
+  seaweedfs_buckets = [
+    for b in [
+      var.s3_images_bucket,
+      var.s3_objects_bucket,
+      var.s3_documents_bucket,
+      var.s3_pdfs_bucket,
+    ] : b if b != ""
+  ]
+
+  # Values for the chart's bundled seaweedfs subchart. Merged into helm_release.app's
+  # azure values in kubernetes.tf — and that merge only runs for var.cloud == "azure",
+  # so this object is harmless on AWS (the try() guards the count=0 random_password
+  # references). Keys mirror the chart's seaweedfs: section (chart/values.yaml).
+  seaweedfs_values = {
+    seaweedfs = {
+      enabled = true
+      mode    = "single"
+
+      # S3 identity rendered into the dozuki-seaweedfs-s3 secret and loaded by the
+      # filer S3 gateway; also fed to the app via objectStorage.credentials.
+      s3 = {
+        accessKey = try(random_password.seaweedfs_access_key[0].result, "")
+        secretKey = try(random_password.seaweedfs_secret_key[0].result, "")
+      }
+
+      # MySQL filer metadata store. Reuses the app database server; the schema-init
+      # Job runs as the app DB admin (adminUsername/adminPassword default to
+      # db.user/db.password, set explicitly here) to create the seaweedfs_filer
+      # schema and the dedicated seaweedfs user before the filer starts.
+      mysqlFiler = {
+        hostname      = local.db_master_host
+        port          = 3306
+        database      = "seaweedfs_filer"
+        username      = "seaweedfs"
+        password      = try(random_password.seaweedfs_filer_db[0].result, "")
+        adminUsername = local.db_master_username
+        adminPassword = local.db_master_password
+      }
+
+      # Subchart (upstream seaweedfs 4.31.0) overrides for AKS: pin PVCs to the
+      # managed-csi StorageClass and size the volume servers from the CPI var.
+      # volume.replicas=2 + 001 replication keeps a second copy so a single PVC
+      # loss does not lose data (the durability posture the standalone deploy had).
       master = {
-        replicas = 1
-        # 001 = one replica on a second volume server; a single PVC loss no longer loses data.
-        defaultReplication = "001"
-        data = {
-          type         = "persistentVolumeClaim"
-          size         = "10Gi"
-          storageClass = "managed-csi"
-        }
-        # Chart default is hostPath, which we do not want on AKS nodes.
-        logs = {
-          type = "emptyDir"
-        }
+        data = { storageClass = "managed-csi" }
       }
       volume = {
         replicas = 2
@@ -72,109 +99,39 @@ resource "helm_release" "seaweedfs" {
             maxVolumes   = 0
           }
         ]
-        logs = {
-          type = "emptyDir"
-        }
       }
       filer = {
-        enabled  = true
-        replicas = 1
-        # 001 = one replica on a second volume server; a single PVC loss no longer loses data.
-        defaultReplicaPlacement = "001"
-        data = {
-          type         = "persistentVolumeClaim"
-          size         = "10Gi"
-          storageClass = "managed-csi"
-        }
-        logs = {
-          type = "emptyDir"
-        }
-        # Filer-embedded S3 gateway. enableAuth makes the chart render
-        # the seaweedfs-s3-secret with a seaweedfs_s3_config JSON built
-        # from s3.credentials below and start the filer with -s3.config.
+        data = { storageClass = "managed-csi" }
         s3 = {
-          enabled    = true
-          enableAuth = true
+          # Drive the subchart's native bucket-creation hook from the CPI bucket
+          # vars so created buckets always match objectStorage.*Bucket.
+          createBuckets = [for b in local.seaweedfs_buckets : { name = b }]
         }
-      }
-    })
-  ]
-
-  # The chart's s3-secret.yaml only reads credentials from the top-level
-  # s3.credentials key, even when the S3 gateway runs embedded in the filer.
-  set_sensitive = [
-    {
-      name  = "s3.credentials.admin.accessKey"
-      value = random_password.seaweedfs_access_key[0].result
-    },
-    {
-      name  = "s3.credentials.admin.secretKey"
-      value = random_password.seaweedfs_secret_key[0].result
-    },
-  ]
-}
-
-resource "kubernetes_job_v1" "seaweedfs_buckets" {
-  count = var.cloud == "azure" ? 1 : 0
-
-  depends_on = [helm_release.seaweedfs]
-
-  metadata {
-    # Hash-keyed name: a changed bucket list creates a new job instead of
-    # attempting an in-place update of the immutable job spec.
-    name      = "seaweedfs-buckets-${substr(sha1(join(",", local.seaweedfs_buckets)), 0, 8)}"
-    namespace = kubernetes_namespace_v1.app.metadata[0].name
-  }
-  spec {
-    ttl_seconds_after_finished = 86400
-    template {
-      metadata {}
-      spec {
-        container {
-          name  = "seaweedfs-buckets"
-          image = "amazon/aws-cli:2.17.0"
-          env {
-            name = "AWS_ACCESS_KEY_ID"
-
-            value_from {
-              secret_key_ref {
-                name = "seaweedfs-s3-secret"
-                key  = "admin_access_key_id"
-              }
-            }
-          }
-
-          env {
-            name = "AWS_SECRET_ACCESS_KEY"
-
-            value_from {
-              secret_key_ref {
-                name = "seaweedfs-s3-secret"
-                key  = "admin_secret_access_key"
-              }
-            }
-          }
-          env {
-            name  = "AWS_DEFAULT_REGION"
-            value = "us-east-1"
-          }
-          command = [
-            "sh",
-            "-c",
-            join(" && ", [
-              for b in local.seaweedfs_buckets :
-              "aws --endpoint-url ${local.seaweedfs_s3_endpoint} s3api create-bucket --bucket ${b} || aws --endpoint-url ${local.seaweedfs_s3_endpoint} s3api head-bucket --bucket ${b}"
-            ])
-          ]
+        # Point the filer's MySQL runtime config at the Azure app DB. Only the
+        # hostname/database differ from the chart defaults (mysql/seaweedfs_filer);
+        # username/password are injected by the subchart's own db-secret (patched by
+        # the chart's filer-db-secret-patch-job from dozuki-seaweedfs-filer-config).
+        extraEnvironmentVars = {
+          WEED_MYSQL_HOSTNAME = local.db_master_host
+          WEED_MYSQL_DATABASE = "seaweedfs_filer"
         }
-        restart_policy = "Never"
       }
     }
-    backoff_limit = 6
-  }
-  wait_for_completion = true
-  timeouts {
-    create = "10m"
-    update = "10m"
+
+    # NOTE: subchart replication lives under the chart's top-level global.seaweedfs
+    # (global.seaweedfs.enableReplication / replicationPlacement). It is merged into
+    # the existing `global` block in helm_release.app (kubernetes.tf) rather than set
+    # here, because Terraform's merge() is shallow and a `global` key here would
+    # clobber global.imagePullSecrets (the GHCR pull secret).
+
+    # The HTTPRoute that exposes SeaweedFS S3 publicly (objectStorage.publicHost)
+    # must target the embedded filer S3 service; the chart default backend
+    # "seaweedfs-s3" only matches a standalone S3 deployment, which we do not run.
+    objectStorage = {
+      publicBackend = {
+        service = "dozuki-seaweedfs-filer"
+        port    = 8333
+      }
+    }
   }
 }

--- a/terraform/logical/seaweedfs.tf
+++ b/terraform/logical/seaweedfs.tf
@@ -40,16 +40,15 @@ locals {
   # helper, which auto-wires the app to the same host when seaweedfs.enabled.
   seaweedfs_s3_endpoint = "http://dozuki-seaweedfs-filer.${local.k8s_namespace_name}.svc.cluster.local:8333"
 
-  # The buckets the app uses. The subchart's native createBuckets hook is driven
-  # from this same list so the created buckets always match objectStorage.*Bucket.
-  seaweedfs_buckets = [
-    for b in [
-      var.s3_images_bucket,
-      var.s3_objects_bucket,
-      var.s3_documents_bucket,
-      var.s3_pdfs_bucket,
-    ] : b if b != ""
-  ]
+  # SeaweedFS bucket names are STATIC — the chart-defined defaults created by the
+  # subchart's native createBuckets hook (chart/values.yaml seaweedfs.filer.s3.createBuckets).
+  # These are deliberately NOT the per-install var.s3_*_bucket values; var.s3_*_bucket
+  # applies to real S3 (AWS) ONLY. The app's objectStorage.*Bucket (set in kubernetes.tf)
+  # must use these same names on Azure so the app reads the buckets SeaweedFS created.
+  seaweedfs_images_bucket    = "images"
+  seaweedfs_pdfs_bucket      = "pdfs"
+  seaweedfs_documents_bucket = "docs"
+  seaweedfs_objects_bucket   = "objects"
 
   # Values for the chart's bundled seaweedfs subchart. Merged into helm_release.app's
   # azure values in kubernetes.tf — and that merge only runs for var.cloud == "azure",
@@ -102,11 +101,10 @@ locals {
       }
       filer = {
         data = { storageClass = "managed-csi" }
-        s3 = {
-          # Drive the subchart's native bucket-creation hook from the CPI bucket
-          # vars so created buckets always match objectStorage.*Bucket.
-          createBuckets = [for b in local.seaweedfs_buckets : { name = b }]
-        }
+        # NOTE: filer.s3.createBuckets is intentionally NOT overridden — the chart's
+        # static default bucket set (images/pdfs/docs/objects) is created by the
+        # subchart's native hook. The app's objectStorage.*Bucket (kubernetes.tf) is
+        # pinned to these same names on Azure so the two always agree.
         # Point the filer's MySQL runtime config at the Azure app DB. Only the
         # hostname/database differ from the chart defaults (mysql/seaweedfs_filer);
         # username/password are injected by the subchart's own db-secret (patched by


### PR DESCRIPTION
## Summary

On Azure the dozuki app needs an S3-compatible object store (Azure has no S3). Until now CPI ran its own **standalone** SeaweedFS install (an upstream `seaweedfs` helm release plus an aws-cli bucket-creation Job) in `terraform/logical/seaweedfs.tf`. This PR removes that and instead enables the **dozuki chart's bundled seaweedfs subchart** (`seaweedfs.enabled=true`) — exactly the way an on-prem install provisions SeaweedFS. AWS (real S3) and on-prem (already on the subchart) are unchanged.

## Before / after (Azure only)

**Before**
- `helm_release.seaweedfs` — standalone upstream seaweedfs chart (4.33.0): master/volume/filer with the embedded S3 gateway, leveldb filer store on a PVC, `s3.credentials.admin.*` from `random_password`.
- `kubernetes_job_v1.seaweedfs_buckets` — aws-cli Job creating the four buckets against the seaweedfs S3 endpoint.
- `helm_release.app` set `objectStorage.endpoint`/`publicHost` to `s3.<domain>`, `objectStorage.credentials.*` from the random passwords, and `depends_on` the two resources above.

**After**
- The dozuki chart's seaweedfs subchart owns the master/volume/filer StatefulSets, the embedded S3 gateway Service (`dozuki-seaweedfs-filer:8333`), the **MySQL** filer metadata store, schema init, and bucket creation (the subchart's native `filer.s3.createBuckets` hook — no aws-cli, airgap-friendly).
- `helm_release.app` enables it via `local.seaweedfs_values` (merged into the existing Azure values), and the app's `objectStorage.endpoint`/`credentials` point at the embedded filer S3 service.

## What was removed
- `helm_release.seaweedfs` (standalone upstream chart).
- `kubernetes_job_v1.seaweedfs_buckets` (aws-cli bucket Job) — replaced by the subchart's `createBuckets` hook.
- The two `depends_on` entries for those resources in `helm_release.app`.
- The old `local.seaweedfs_s3_endpoint` value (`seaweedfs-s3...:8333`) — replaced with the chart's filer S3 service name.

(`random_password.seaweedfs_access_key` / `seaweedfs_secret_key` are kept and relocated into the rewritten `seaweedfs.tf`; a new `random_password.seaweedfs_filer_db` was added for the filer's dedicated MySQL user.)

## Standalone config → chart `seaweedfs:` values mapping
| Old standalone | New chart subchart value |
|---|---|
| `s3.credentials.admin.accessKey/secretKey` | `seaweedfs.s3.accessKey/secretKey` (rendered into `dozuki-seaweedfs-s3` secret) |
| leveldb filer on PVC | `seaweedfs.mysqlFiler.*` (MySQL metadata; on-prem model). Reuses the app DB server; `adminUsername/adminPassword` = app DB creds for the schema-init Job; dedicated `seaweedfs` user + `seaweedfs_filer` schema |
| `master/volume/filer ... storageClass: managed-csi` | `seaweedfs.{master,filer}.data.storageClass` + `seaweedfs.volume.dataDirs[].storageClass` = `managed-csi` |
| `volume.dataDirs[].size = <var>Gi` | `seaweedfs.volume.dataDirs[].size` (same `var.seaweedfs_volume_size_gb`) |
| `defaultReplication 001`, `volume.replicas 2` | `global.seaweedfs.enableReplication=true` + `replicationPlacement="001"`, `seaweedfs.volume.replicas=2` |
| aws-cli bucket Job over `var.s3_*_bucket` | `seaweedfs.filer.s3.createBuckets` driven from the **same** `var.s3_*_bucket` list |
| `objectStorage.endpoint/publicHost = s3.<domain>` | endpoint now the in-cluster filer S3 service; `publicHost` kept for external presigned access |

## Things that did not map cleanly — please review
1. **Bucket creation.** The chart does NOT use an aws-cli Job; it uses the subchart's native `filer.s3.createBuckets` hook (SeaweedFS image, airgap-safe). The chart's packaged default is the FIXED list `images/pdfs/docs/objects` and the chart docs say `objectStorage.*Bucket` must stay at those defaults when seaweedfs is enabled. CPI historically uses per-install bucket names (`var.s3_*_bucket`), so I **override** `createBuckets` from those same vars — the created buckets always equal `objectStorage.*Bucket`, preserving CPI's naming. Helm replaces lists (not append), so the chart's fixed list is fully replaced. Confirm we're OK keeping CPI's custom bucket names rather than switching Azure to the chart's `images/pdfs/docs/objects`.
2. **MySQL filer is new for Azure.** The standalone filer used leveldb on a PVC; the chart subchart requires MySQL (matching on-prem). It now provisions a `seaweedfs_filer` schema + `seaweedfs` user on the **app database server** via the chart's schema-init Job (run as the app DB admin). This adds a dependency on the app DB being reachable/admin-capable at install. Please confirm the Azure app DB admin can `CREATE DATABASE/USER/GRANT`.
3. **Public S3 backend service name.** The chart's `objectStorage.publicBackend.service` default is `seaweedfs-s3`, which only matches a standalone S3 deployment. We run S3 **embedded in the filer**, so I override `publicBackend.service` to `dozuki-seaweedfs-filer` (port 8333) so the public S3 HTTPRoute (`objectStorage.publicHost`) resolves.
4. **`global` shallow-merge.** Terraform `merge()` is shallow, so the subchart replication settings live under the existing `global` block in `kubernetes.tf` (alongside `imagePullSecrets`) rather than in `local.seaweedfs_values`, to avoid clobbering the GHCR pull secret.

## Validation
- `terraform fmt` clean.
- `tofu validate` passes for these changes. The only error is the pre-existing `provider "vault"` "Missing required argument: address" (address comes from `VAULT_ADDR` at runtime) — present on master, unrelated.
- `terraform-docs` / `tflint` pre-commit hooks fail repo-wide on the pre-existing `azurerm.main[each.key]` `for_each` provider syntax and a pre-existing `main.tf:299` expression; the logical `README.md` resource table was updated by hand instead.

Source-of-truth verified against the bundled subchart `seaweedfs-4.31.0` and the chart's `seaweedfs/` templates (filer Service exposes `swfs-s3`/8333; `filer.s3.existingConfigSecret` + `createBuckets`; `dozuki.objectStorageEndpoint` helper).