### PR TITLE
fix(azure): public Key Vault when no CIDR allowlist + workloadidentity kubelogin

### DIFF
--- a/terraform/logical/variables.tf
+++ b/terraform/logical/variables.tf
@@ -296,13 +296,13 @@ variable "azure_eso_identity_client_id" {
 }
 
 variable "azure_kubelogin_login" {
-  description = "kubelogin --login mode: azurecli on a workstation, msi on an Azure VM with managed identity."
+  description = "kubelogin --login mode: azurecli on a workstation, msi on an Azure VM, or workloadidentity for OIDC federation (Spacelift — reads AZURE_FEDERATED_TOKEN_FILE / AZURE_CLIENT_ID / AZURE_TENANT_ID from the run env)."
   type        = string
   default     = "azurecli"
 
   validation {
-    condition     = contains(["azurecli", "msi"], var.azure_kubelogin_login)
-    error_message = "azure_kubelogin_login must be azurecli or msi."
+    condition     = contains(["azurecli", "msi", "workloadidentity"], var.azure_kubelogin_login)
+    error_message = "azure_kubelogin_login must be azurecli, msi, or workloadidentity."
   }
 }
 

--- a/terraform/physical-azure/keyvault.tf
+++ b/terraform/physical-azure/keyvault.tf
@@ -1,7 +1,11 @@
 # Key Vault names: 3-24 chars, globally unique.
 # "kv-" + identifier_compact (max 15) + "-" + 4-char suffix = max 23.
-# Deny-by-default firewall: in-cluster access (ESO) rides the AKS subnet's
-# Key Vault service endpoint; the deployer seeds secrets through kv_allowed_cidrs.
+# Firewall mirrors the AKS API (aks.tf): with kv_allowed_cidrs set, deny by
+# default and allowlist those CIDRs (the kit pins the operator's egress IP);
+# with it empty, the vault is public (default_action = Allow), RBAC-gated only —
+# required on the Spacelift public-worker path, where worker egress IPs aren't
+# allowlistable. In-cluster access (ESO) always rides the AKS subnet's Key Vault
+# service endpoint regardless.
 # Follow-up: private endpoint + public_network_access_enabled = false.
 resource "azurerm_key_vault" "this" {
   name                       = "kv-${local.identifier_compact}-${random_string.suffix.result}"
@@ -14,7 +18,7 @@ resource "azurerm_key_vault" "this" {
   soft_delete_retention_days = 30
 
   network_acls {
-    default_action             = "Deny"
+    default_action             = length(var.kv_allowed_cidrs) > 0 ? "Deny" : "Allow"
     bypass                     = "AzureServices"
     virtual_network_subnet_ids = [azurerm_subnet.aks.id]
     ip_rules                   = var.kv_allowed_cidrs


### PR DESCRIPTION
## Summary

Two fixes uncovered while bringing up the dev Azure stack through Spacelift
(public workers).

### 1. Key Vault locked itself out of the public worker (the physical blocker)
`keyvault.tf` hardcoded `network_acls.default_action = "Deny"`, so an empty
`kv_allowed_cidrs` denied everything. The physical apply got ~14 min in (VNet,
AKS, MySQL, Key Vault all created) then failed:
```
Key Vault GetSecret → 403 ForbiddenByFirewall
Client address: <spacelift-worker-ip> is not authorized
```
The deployer has **Key Vault Administrator** (RBAC) — it's purely the network
firewall. Fix: mirror the AKS API (`aks.tf`), which is already public when its
allowlist is empty — `default_action = length(kv_allowed_cidrs) > 0 ? "Deny" : "Allow"`.
Set → deny + allowlist (kit pins the operator IP); empty → public, RBAC-gated
(Spacelift, where worker IPs can't be allowlisted).

### 2. kubelogin `workloadidentity` mode
`azure_kubelogin_login` only accepted `azurecli`/`msi`; neither works on a
Spacelift worker. Add `workloadidentity` so the logical layer authenticates to
AKS via OIDC federation (kubelogin reads `AZURE_FEDERATED_TOKEN_FILE` /
`AZURE_CLIENT_ID` / `AZURE_TENANT_ID` from the run env — set on the stack in
infra-live, coming next).

## Test Plan
- [x] `fmt`
- [ ] Release + bump azure env `infra_version`; re-run physical → Key Vault step
      passes, apply completes
- [ ] Logical run with `workloadidentity` (after the env wiring + SP AKS access)