### PR TITLE
fix(azure): helm provider authenticates to GHCR for the OCI chart pull

### DIFF
--- a/terraform/logical/main.tf
+++ b/terraform/logical/main.tf
@@ -100,14 +100,22 @@ provider "helm" {
 
   # OCI chart-pull auth (helm provider 3.x: `registries` is a list attribute,
   # replacing 2.x's repeatable `registry {}` block). AWS authenticates
-  # in-Terraform via the ECR token. Azure pulls the
-  # chart from GHCR using an ambient `helm registry login` performed by the
-  # azure-config bootstrap, so no provider-level registry creds are set there.
-  registries = var.cloud == "aws" ? [{
-    url      = "oci://${var.image_repository}"
-    username = data.aws_ecr_authorization_token.chart[0].user_name
-    password = data.aws_ecr_authorization_token.chart[0].password
-  }] : []
+  # in-Terraform via the ECR token. Azure authenticates to GHCR with the
+  # ghcr_pull_* creds (same ones used for the cluster image-pull secret) — the
+  # kit does an ambient `helm registry login`, but a Spacelift worker has no
+  # such login, so the provider must carry the creds itself.
+  registries = (
+    var.cloud == "aws" ? [{
+      url      = "oci://${var.image_repository}"
+      username = data.aws_ecr_authorization_token.chart[0].user_name
+      password = data.aws_ecr_authorization_token.chart[0].password
+    }] :
+    var.ghcr_pull_token != "" ? [{
+      url      = "oci://${var.image_repository}"
+      username = var.ghcr_pull_username
+      password = var.ghcr_pull_token
+    }] : []
+  )
 }
 
 provider "vault" {


### PR DESCRIPTION
## Summary

On the Spacelift azure path, `helm_release.app` failed to pull the private chart:
```
Unable to locate chart oci://ghcr.io/dozuki/charts/dozuki: failed to perform
"FetchReference" on source: GET … (auth)
```
The helm provider configured OCI registry creds **only for AWS** (ECR token);
azure relied on the `azure-config` kit's *ambient* `helm registry login`
(bootstrap.sh) — which a Spacelift worker doesn't run. Add an azure branch to
`registries` using the existing `ghcr_pull_username` / `ghcr_pull_token` vars
(the same creds that already feed the cluster image-pull secret).

Discovered driving the dev azure deploy end-to-end: OIDC backend, the vault
provider, and kubelogin→AKS all work; this was the last plan-time failure.

## Test Plan
- [x] `fmt`
- [ ] Release + bump azure `infra_version`; set `TF_VAR_ghcr_pull_*` on the azure
      logical stack → `helm_release.app` chart resolves, logical plans/applies