### PR TITLE
feat(harness): re-entrant phase CLI (provision/upgrade/validate/teardown)

### DIFF
--- a/live/tests/PHASES.md
+++ b/live/tests/PHASES.md
@@ -1,0 +1,51 @@
+# Driving harness phases individually
+
+The harness exposes four re-entrant phases via `cmd/harness`
+(`provision` / `upgrade` / `validate` / `teardown`). Each is a separate process that
+reconstructs run state from the **run manifest** in S3
+(`<state-bucket>/<run-id>-<config>/harness-manifest.json`, alongside the Terraform
+state) plus the live TF outputs. This is exactly how the Argo Workflow invokes each
+step; locally you drive the same code via `run.sh PHASE=...`.
+
+## Local usage
+
+Reuse the **same `RUN_ID`** across all phases of one run:
+
+```bash
+RID=local-$(date +%s)
+
+# Upgrade scenario
+PHASE=provision SCENARIO_FLAG="--scenario upgrade" FROM_REF=v6.0.3 TO_REF=v7.1.0 \
+  CONFIGS=min_default RUN_ID=$RID ./run.sh
+PHASE=upgrade   CONFIGS=min_default RUN_ID=$RID ./run.sh
+PHASE=validate  CONFIGS=min_default RUN_ID=$RID ./run.sh
+PHASE=teardown  CONFIGS=min_default RUN_ID=$RID ./run.sh
+
+# Fresh scenario (no upgrade step)
+PHASE=provision SCENARIO_FLAG="--scenario fresh" TO_REF=auto:latest \
+  CONFIGS=min_default RUN_ID=$RID ./run.sh
+PHASE=validate  CONFIGS=min_default RUN_ID=$RID ./run.sh
+PHASE=teardown  CONFIGS=min_default RUN_ID=$RID ./run.sh
+```
+
+- `KEEP_ON_FAILURE=1` on the `teardown` (or full) run leaves a failed stack up for
+  live debugging instead of destroying it.
+- `teardown` is idempotent and safe to re-run; with no manifest it is a no-op.
+- The Vault tunnel + SSO checks in `run.sh` still apply in PHASE mode (each phase that
+  applies/destroys terragrunt needs Vault), unless you preset `VAULT_TOKEN` /
+  `SKIP_VAULT_TUNNEL=1`.
+
+## Full-run parity (unchanged)
+
+Omit `PHASE` to run the whole scenario via `go test` exactly as before:
+
+```bash
+SCENARIO=fresh CONFIGS=min_default ./run.sh
+```
+
+## Manifest fields (cross-phase state)
+
+`scenario`, `from_ref`/`to_ref`, `delete_after` (TTL, set once at provision),
+`applied_ref` (which ref's code matches the deployed state — drives teardown), and
+`baseline_rev` (the pre-upgrade helm revision the upgrade proof checks against).
+Everything else the validators need is re-derived from live TF outputs each phase.

--- a/live/tests/cmd/harness/main.go
+++ b/live/tests/cmd/harness/main.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/Dozuki/CloudPrem-Infra/live/tests/harness"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+)
+
+const usage = `usage: harness <provision|upgrade|validate|teardown> [flags]
+  common: --run-id --config --repo-dir --account-id --profile --region --matrix --state-bucket [--mem-store]
+  provision: --scenario <upgrade|fresh> --from-ref --to-ref --namespace
+  teardown:  --keep-on-failure --failed`
+
+func main() { os.Exit(dispatch(os.Args[1:], os.Stderr)) }
+
+func dispatch(args []string, stderr io.Writer) int {
+	if len(args) == 0 {
+		fmt.Fprintln(stderr, usage)
+		return 2
+	}
+	sub, rest := args[0], args[1:]
+	fs := flag.NewFlagSet(sub, flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	var (
+		runID    = fs.String("run-id", "", "base run id")
+		cfgName  = fs.String("config", "", "matrix config name")
+		repoDir  = fs.String("repo-dir", ".", "repo root")
+		acct     = fs.String("account-id", "", "DDVtest account id")
+		profile  = fs.String("profile", "", "AWS profile (empty in-cluster)")
+		region   = fs.String("region", "us-east-1", "region")
+		matrix   = fs.String("matrix", "live/tests/matrix.yaml", "matrix path")
+		bucket   = fs.String("state-bucket", "", "harness state bucket")
+		memStore = fs.Bool("mem-store", false, "use in-memory manifest store (dry-run/test)")
+		scenario = fs.String("scenario", "upgrade", "provision: upgrade|fresh")
+		fromRef  = fs.String("from-ref", "", "provision: baseline ref")
+		toRef    = fs.String("to-ref", "", "provision: target ref")
+		ns       = fs.String("namespace", "dozuki", "app namespace")
+		keepFail = fs.Bool("keep-on-failure", false, "teardown: keep stack if failed")
+		failed   = fs.Bool("failed", false, "teardown: mark run failed (full diagnostics)")
+	)
+	if err := fs.Parse(rest); err != nil {
+		return 2
+	}
+
+	switch sub {
+	case "provision", "upgrade", "validate", "teardown":
+	default:
+		fmt.Fprintln(stderr, usage)
+		return 2
+	}
+	if *runID == "" || *cfgName == "" {
+		fmt.Fprintln(stderr, "error: --run-id and --config are required\n"+usage)
+		return 2
+	}
+
+	ctx := context.Background()
+	m, err := harness.LoadMatrix(*matrix)
+	if err != nil {
+		fmt.Fprintf(stderr, "load matrix: %v\n", err)
+		return 1
+	}
+
+	var store harness.ManifestStore
+	if *memStore {
+		store = harness.NewMemStore()
+	} else {
+		if *bucket == "" {
+			fmt.Fprintln(stderr, "error: --state-bucket required (or pass --mem-store)")
+			return 2
+		}
+		awsCfg, cerr := loadAWS(ctx, *profile, *region)
+		if cerr != nil {
+			fmt.Fprintf(stderr, "aws config: %v\n", cerr)
+			return 1
+		}
+		store = harness.NewS3Store(s3.NewFromConfig(awsCfg), *bucket)
+	}
+
+	p := harness.PhaseParams{
+		RepoDir: *repoDir, Matrix: m, Store: store, ConfigName: *cfgName,
+		RunID: *runID, AccountID: *acct, Profile: *profile, Region: *region,
+	}
+
+	var perr error
+	switch sub {
+	case "provision":
+		// deleteAfter computed here only if creating; persisted in manifest thereafter.
+		ttl := m.Defaults.ReaperTTLHours
+		if ttl == 0 {
+			ttl = 24
+		}
+		da := deleteAfterFromTTL(ttl)
+		fr, tr := resolveRefs(*repoDir, m, *fromRef, *toRef, *scenario)
+		perr = p.Provision(ctx, *scenario, fr, tr, da, *ns)
+	case "upgrade":
+		perr = p.Upgrade(ctx)
+	case "validate":
+		perr = p.Validate(ctx)
+	case "teardown":
+		perr = p.Teardown(ctx, *keepFail, *failed)
+	}
+	if perr != nil {
+		fmt.Fprintf(stderr, "%s failed: %v\n", sub, perr)
+		return 1
+	}
+	return 0
+}
+
+// loadAWS loads AWS config for an optional shared-config profile + region.
+func loadAWS(ctx context.Context, profile, region string) (aws.Config, error) {
+	opts := []func(*config.LoadOptions) error{config.WithRegion(region)}
+	if profile != "" {
+		opts = append(opts, config.WithSharedConfigProfile(profile))
+	}
+	return config.LoadDefaultConfig(ctx, opts...)
+}

--- a/live/tests/cmd/harness/main_test.go
+++ b/live/tests/cmd/harness/main_test.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestDispatchUnknownSubcommand(t *testing.T) {
+	var b bytes.Buffer
+	if code := dispatch([]string{"frobnicate"}, &b); code == 0 {
+		t.Fatalf("unknown subcommand should be non-zero")
+	}
+	if !strings.Contains(b.String(), "usage") {
+		t.Fatalf("expected usage text, got %q", b.String())
+	}
+}
+
+func TestDispatchProvisionRequiresFlags(t *testing.T) {
+	var b bytes.Buffer
+	// missing --run-id/--config → non-zero with a clear message
+	if code := dispatch([]string{"provision", "--scenario", "fresh"}, &b); code == 0 {
+		t.Fatalf("missing required flags should fail")
+	}
+}

--- a/live/tests/cmd/harness/refs.go
+++ b/live/tests/cmd/harness/refs.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"time"
+
+	"github.com/Dozuki/CloudPrem-Infra/live/tests/harness"
+)
+
+// deleteAfterFromTTL returns now()+ttl as an RFC3339 UTC string. Only used when a
+// manifest is first created; thereafter the stored value is reused.
+func deleteAfterFromTTL(ttlHours int) string {
+	return time.Now().Add(time.Duration(ttlHours) * time.Hour).UTC().Format(time.RFC3339)
+}
+
+// resolveRefs resolves auto:latest / auto:latest-1 against the repo's tags and
+// blanks fromRef for the fresh scenario.
+func resolveRefs(repoDir string, m *harness.Matrix, fromRef, toRef, scenario string) (string, string) {
+	harness.FetchOrigin(repoDir)
+	tags, _ := harness.NewestTags(repoDir)
+	if fromRef == "" {
+		fromRef = m.Defaults.FromRef
+	}
+	if toRef == "" {
+		toRef = m.Defaults.ToRef
+	}
+	fr, _ := harness.ResolveRef(fromRef, tags)
+	tr, _ := harness.ResolveRef(toRef, tags)
+	if scenario == "fresh" {
+		fr = ""
+	}
+	return fr, tr
+}

--- a/live/tests/cmd/harness/refs_test.go
+++ b/live/tests/cmd/harness/refs_test.go
@@ -1,0 +1,16 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+func TestDeleteAfterFromTTL(t *testing.T) {
+	got, err := time.Parse(time.RFC3339, deleteAfterFromTTL(24))
+	if err != nil {
+		t.Fatalf("not RFC3339: %v", err)
+	}
+	if d := time.Until(got); d < 23*time.Hour || d > 25*time.Hour {
+		t.Fatalf("ttl ~24h expected, got %v", d)
+	}
+}

--- a/live/tests/go.mod
+++ b/live/tests/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/eks v1.86.0
 	github.com/aws/aws-sdk-go-v2/service/rds v1.119.3
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.104.0
+	github.com/aws/smithy-go v1.27.1
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/apimachinery v0.30.0
 	k8s.io/client-go v0.30.0
@@ -30,7 +31,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sso v1.31.3 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.36.6 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.43.3 // indirect
-	github.com/aws/smithy-go v1.27.1 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/emicklei/go-restful/v3 v3.11.0 // indirect
 	github.com/go-logr/logr v1.4.1 // indirect

--- a/live/tests/harness/manifest.go
+++ b/live/tests/harness/manifest.go
@@ -1,0 +1,70 @@
+package harness
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+)
+
+const ManifestObjectName = "harness-manifest.json"
+
+// RunManifest is the durable, cross-phase state for one (run, config). It lives in
+// S3 under the run's state prefix so any phase pod can reconstruct what an earlier
+// phase established. Fields here are exactly those NOT re-derivable from live TF
+// outputs: the scenario, the resolved refs, the shared deleteAfter, which ref is
+// currently applied (drives teardown), and the pre-upgrade baseline helm revision
+// (gone once the upgrade applies, but needed by the upgrade proof).
+type RunManifest struct {
+	Scenario     string `json:"scenario"` // "upgrade" | "fresh"
+	ConfigName   string `json:"config_name"`
+	FromRef      string `json:"from_ref"` // empty for fresh
+	ToRef        string `json:"to_ref"`
+	DeleteAfter  string `json:"delete_after"` // RFC3339, shared by both worktrees
+	AppliedRef   string `json:"applied_ref"`  // ref whose code matches deployed state
+	BaselineRev  int    `json:"baseline_rev"` // helm revision before upgrade (0 until set)
+	Namespace    string `json:"namespace"`
+	AccountID    string `json:"account_id"`
+	Region       string `json:"region"`
+	DRRegion     string `json:"dr_region"`
+	RestoreDrill bool   `json:"restore_drill"`
+	EnableDR     bool   `json:"enable_dr"`
+}
+
+// ManifestStore persists a RunManifest keyed by state prefix (e.g. "run1-min/").
+type ManifestStore interface {
+	Load(ctx context.Context, statePrefix string) (*RunManifest, bool, error)
+	Save(ctx context.Context, statePrefix string, m *RunManifest) error
+}
+
+// MemStore is an in-memory ManifestStore for tests and local dry-runs.
+type MemStore struct {
+	mu sync.Mutex
+	m  map[string][]byte
+}
+
+func NewMemStore() *MemStore { return &MemStore{m: map[string][]byte{}} }
+
+func (s *MemStore) Load(_ context.Context, statePrefix string) (*RunManifest, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	b, ok := s.m[statePrefix]
+	if !ok {
+		return nil, false, nil
+	}
+	var rm RunManifest
+	if err := json.Unmarshal(b, &rm); err != nil {
+		return nil, false, err
+	}
+	return &rm, true, nil
+}
+
+func (s *MemStore) Save(_ context.Context, statePrefix string, m *RunManifest) error {
+	b, err := json.Marshal(m)
+	if err != nil {
+		return err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.m[statePrefix] = b
+	return nil
+}

--- a/live/tests/harness/manifest_s3.go
+++ b/live/tests/harness/manifest_s3.go
@@ -1,0 +1,64 @@
+package harness
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/smithy-go"
+)
+
+// S3API is the minimal S3 surface the manifest store needs (so tests inject a fake).
+type S3API interface {
+	GetObject(context.Context, *s3.GetObjectInput, ...func(*s3.Options)) (*s3.GetObjectOutput, error)
+	PutObject(context.Context, *s3.PutObjectInput, ...func(*s3.Options)) (*s3.PutObjectOutput, error)
+}
+
+// S3Store persists the manifest in the harness state bucket under the run prefix.
+type S3Store struct {
+	client S3API
+	bucket string
+}
+
+func NewS3Store(client S3API, bucket string) *S3Store { return &S3Store{client: client, bucket: bucket} }
+
+func (s *S3Store) key(statePrefix string) string { return statePrefix + ManifestObjectName }
+
+func (s *S3Store) Load(ctx context.Context, statePrefix string) (*RunManifest, bool, error) {
+	out, err := s.client.GetObject(ctx, &s3.GetObjectInput{
+		Bucket: aws.String(s.bucket), Key: aws.String(s.key(statePrefix)),
+	})
+	if err != nil {
+		var ae smithy.APIError
+		if errors.As(err, &ae) && (ae.ErrorCode() == "NoSuchKey" || ae.ErrorCode() == "NotFound") {
+			return nil, false, nil
+		}
+		return nil, false, err
+	}
+	defer out.Body.Close()
+	b, err := io.ReadAll(out.Body)
+	if err != nil {
+		return nil, false, err
+	}
+	var rm RunManifest
+	if err := json.Unmarshal(b, &rm); err != nil {
+		return nil, false, err
+	}
+	return &rm, true, nil
+}
+
+func (s *S3Store) Save(ctx context.Context, statePrefix string, m *RunManifest) error {
+	b, err := json.Marshal(m)
+	if err != nil {
+		return err
+	}
+	_, err = s.client.PutObject(ctx, &s3.PutObjectInput{
+		Bucket: aws.String(s.bucket), Key: aws.String(s.key(statePrefix)),
+		Body: bytes.NewReader(b), ContentType: aws.String("application/json"),
+	})
+	return err
+}

--- a/live/tests/harness/manifest_s3_test.go
+++ b/live/tests/harness/manifest_s3_test.go
@@ -1,0 +1,46 @@
+package harness
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/smithy-go"
+)
+
+type fakeS3 struct{ objs map[string][]byte }
+
+func (f *fakeS3) GetObject(_ context.Context, in *s3.GetObjectInput, _ ...func(*s3.Options)) (*s3.GetObjectOutput, error) {
+	b, ok := f.objs[*in.Key]
+	if !ok {
+		return nil, &smithy.GenericAPIError{Code: "NoSuchKey"}
+	}
+	return &s3.GetObjectOutput{Body: io.NopCloser(bytes.NewReader(b))}, nil
+}
+func (f *fakeS3) PutObject(_ context.Context, in *s3.PutObjectInput, _ ...func(*s3.Options)) (*s3.PutObjectOutput, error) {
+	b, _ := io.ReadAll(in.Body)
+	f.objs[*in.Key] = b
+	return &s3.PutObjectOutput{}, nil
+}
+
+func TestS3StoreRoundTripAndMissing(t *testing.T) {
+	ctx := context.Background()
+	f := &fakeS3{objs: map[string][]byte{}}
+	s := NewS3Store(f, "state-bucket")
+
+	if _, ok, err := s.Load(ctx, "run1-min/"); err != nil || ok {
+		t.Fatalf("missing load: ok=%v err=%v", ok, err)
+	}
+	if err := s.Save(ctx, "run1-min/", &RunManifest{ToRef: "v7.1.0", Scenario: "fresh"}); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	if _, ok := f.objs["run1-min/harness-manifest.json"]; !ok {
+		t.Fatalf("expected object at run1-min/harness-manifest.json, have %v", f.objs)
+	}
+	got, ok, err := s.Load(ctx, "run1-min/")
+	if err != nil || !ok || got.ToRef != "v7.1.0" {
+		t.Fatalf("load: ok=%v err=%v got=%+v", ok, err, got)
+	}
+}

--- a/live/tests/harness/manifest_test.go
+++ b/live/tests/harness/manifest_test.go
@@ -1,0 +1,33 @@
+package harness
+
+import (
+	"context"
+	"testing"
+)
+
+func TestMemStoreRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	s := NewMemStore()
+
+	if _, ok, err := s.Load(ctx, "run1-min/"); err != nil || ok {
+		t.Fatalf("empty load: got ok=%v err=%v, want ok=false err=nil", ok, err)
+	}
+
+	want := &RunManifest{
+		Scenario: "upgrade", ConfigName: "min_default",
+		FromRef: "v6.0.3", ToRef: "v6.1-release",
+		DeleteAfter: "2026-06-25T00:00:00Z", AppliedRef: "v6.0.3",
+		BaselineRev: 0, Namespace: "dozuki", AccountID: "076248559428",
+		Region: "us-east-1", DRRegion: "us-west-2",
+	}
+	if err := s.Save(ctx, "run1-min/", want); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	got, ok, err := s.Load(ctx, "run1-min/")
+	if err != nil || !ok {
+		t.Fatalf("load after save: ok=%v err=%v", ok, err)
+	}
+	if got.ToRef != "v6.1-release" || got.AppliedRef != "v6.0.3" || got.Scenario != "upgrade" {
+		t.Fatalf("round trip mismatch: %+v", got)
+	}
+}

--- a/live/tests/harness/phases.go
+++ b/live/tests/harness/phases.go
@@ -1,0 +1,289 @@
+package harness
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/Dozuki/CloudPrem-Infra/live/tests/validation"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+)
+
+// PhaseParams carries everything a single re-entrant phase needs. Unlike RunParams
+// (which held in-memory worktree/appliedWT state for a whole run), PhaseParams holds
+// only inputs derivable from CLI flags + the matrix; durable cross-phase state lives
+// in the manifest fetched via Store.
+type PhaseParams struct {
+	RepoDir    string
+	Matrix     *Matrix
+	Store      ManifestStore
+	ConfigName string
+	RunID      string // full per-config base run id (e.g. "local-1719..."); prefix adds "-<config>/"
+	AccountID  string
+	Profile    string
+	Region     string
+}
+
+func (p PhaseParams) statePrefix(cfg Config) string {
+	return p.RunID + "-" + cfg.Name + "/"
+}
+
+// prepareWorktree is the re-entrant replacement for run.go's inline worktree+tg
+// setup: recreate the worktree for ref, scaffold the gitignored live envs, write
+// env.hcl (with the shared deleteAfter), and return the worktree + its TGOptions +
+// the env dir. Safe to call from any phase/pod.
+func (p PhaseParams) prepareWorktree(ref string, initSub bool, cfg Config, deleteAfter string) (*Worktree, TGOptions, string, error) {
+	base := filepath.Join(p.RepoDir, "live", "tests", "__worktrees__", p.RunID)
+	wt, err := AddWorktree(p.RepoDir, base, ref, initSub)
+	if err != nil {
+		return nil, TGOptions{}, "", err
+	}
+	if gerr := generateLiveEnvs(wt.Dir); gerr != nil {
+		return nil, TGOptions{}, "", fmt.Errorf("generate live envs for %s: %w", ref, gerr)
+	}
+	envSub := filepath.Join(p.Matrix.Defaults.EnvPath, cfg.Env)
+	envDir := filepath.Join(wt.Dir, envSub)
+	if werr := WriteEnvHCL(envDir, withDeleteAfter(p.Matrix.MergedInputs(cfg, ref), deleteAfter)); werr != nil {
+		return nil, TGOptions{}, "", werr
+	}
+	identifier := ""
+	if customer, _ := cfg.FeatureFlags["customer"].(string); customer != "" {
+		identifier = customer + "-" + cfg.Env
+	}
+	tg := TGOptions{
+		WorkingDir:   envDir,
+		AccountID:    p.AccountID,
+		Region:       p.Region,
+		Profile:      p.Profile,
+		BucketPrefix: "",
+		StatePrefix:  p.statePrefix(cfg),
+		NLBName:      identifier,
+	}
+	return wt, tg, envDir, nil
+}
+
+// stateBucket mirrors live/root.hcl remote_state:
+// ${TG_BUCKET_PREFIX}dozuki-terraform-state-<region>-<account>. The manifest lands
+// in the SAME bucket as TF state, under the run's state prefix.
+func stateBucket(accountID, region string) string {
+	return os.Getenv("TG_BUCKET_PREFIX") + "dozuki-terraform-state-" + region + "-" + accountID
+}
+
+// awsConfigFor loads AWS config for an optional shared-config profile + region.
+func awsConfigFor(ctx context.Context, profile, region string) (aws.Config, error) {
+	opts := []func(*config.LoadOptions) error{config.WithRegion(region)}
+	if profile != "" {
+		opts = append(opts, config.WithSharedConfigProfile(profile))
+	}
+	return config.LoadDefaultConfig(ctx, opts...)
+}
+
+// loadOrInitManifest returns the existing manifest for this (run,config) or creates
+// a fresh one. deleteAfter is honored ONLY on creation; an existing manifest's value
+// (and all prior phase state) is preserved — this is what makes phases re-entrant.
+func (p PhaseParams) loadOrInitManifest(ctx context.Context, cfg Config, scenario, fromRef, toRef, deleteAfter string) (*RunManifest, error) {
+	if rm, ok, err := p.Store.Load(ctx, p.statePrefix(cfg)); err != nil {
+		return nil, err
+	} else if ok {
+		return rm, nil
+	}
+	rm := &RunManifest{
+		Scenario: scenario, ConfigName: cfg.Name,
+		FromRef: fromRef, ToRef: toRef, DeleteAfter: deleteAfter,
+		Region: p.Region, DRRegion: p.Matrix.Defaults.DRRegion,
+		RestoreDrill: cfg.HarnessFlag("restore_drill"), EnableDR: cfg.HarnessFlag("enable_dr"),
+	}
+	return rm, p.Store.Save(ctx, p.statePrefix(cfg), rm)
+}
+
+// Provision applies the baseline (upgrade scenario) or the single ref (fresh
+// scenario), validates it, and records baseline state in the manifest. Re-entrant:
+// re-running re-applies (terragrunt is convergent) and reuses the manifest.
+func (p PhaseParams) Provision(ctx context.Context, scenario, fromRef, toRef, deleteAfter, namespace string) (err error) {
+	cfg, err := p.Matrix.Config(p.ConfigName)
+	if err != nil {
+		return err
+	}
+	rm, err := p.loadOrInitManifest(ctx, cfg, scenario, fromRef, toRef, deleteAfter)
+	if err != nil {
+		return err
+	}
+	rm.Namespace, rm.AccountID = namespace, p.AccountID
+
+	applyRef := toRef
+	initSub := true
+	if scenario == "upgrade" {
+		applyRef = fromRef
+	}
+	wt, tg, _, err := p.prepareWorktree(applyRef, initSub, cfg, rm.DeleteAfter)
+	if err != nil {
+		return err
+	}
+	defer wt.removeUnlessFailed(p.RepoDir, &err)
+
+	step("PROVISION apply: %s (terragrunt run-all apply)", applyRef)
+	if aerr := tg.Apply(); aerr != nil {
+		return fmt.Errorf("provision apply: %w", aerr)
+	}
+	rm.AppliedRef = applyRef
+	if serr := p.Store.Save(ctx, p.statePrefix(cfg), rm); serr != nil {
+		return serr
+	}
+
+	rp := RunParams{Matrix: p.Matrix, Namespace: namespace, Profile: p.Profile}
+	rev, _, caps, verr := validateStack(tg, rp, p.Region)
+	if verr != nil {
+		return fmt.Errorf("provision validation: %w", verr)
+	}
+	if scenario == "upgrade" {
+		rm.BaselineRev = rev
+		if serr := p.Store.Save(ctx, p.statePrefix(cfg), rm); serr != nil {
+			return serr
+		}
+		outs, oerr := readOutputs(tg, p.Region)
+		if oerr != nil {
+			return fmt.Errorf("provision readOutputs (sentinel): %w", oerr)
+		}
+		if caps.HasGuideBuckets {
+			if serr := validation.WriteSentinel(ctx, p.Region, outs.GuideBuckets[0], p.statePrefix(cfg)); serr != nil {
+				return fmt.Errorf("continuity sentinel write: %w", serr)
+			}
+		}
+	}
+	step("provision validated ✓ (helm revision %d)", rev)
+	return nil
+}
+
+// Upgrade applies the target ref against the SAME state prefix the baseline used,
+// then records ToRef as applied. Requires a prior upgrade-scenario Provision.
+func (p PhaseParams) Upgrade(ctx context.Context) (err error) {
+	cfg, err := p.Matrix.Config(p.ConfigName)
+	if err != nil {
+		return err
+	}
+	rm, ok, err := p.Store.Load(ctx, p.statePrefix(cfg))
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return fmt.Errorf("no manifest for %s — run provision first", p.statePrefix(cfg))
+	}
+	if rm.Scenario == "fresh" {
+		return fmt.Errorf("upgrade phase invalid for fresh scenario (run %s)", p.statePrefix(cfg))
+	}
+	wt, tg, _, err := p.prepareWorktree(rm.ToRef, false, cfg, rm.DeleteAfter)
+	if err != nil {
+		return err
+	}
+	defer wt.removeUnlessFailed(p.RepoDir, &err)
+
+	step("UPGRADE apply: %s -> %s (same state prefix)", rm.FromRef, rm.ToRef)
+	if aerr := tg.Apply(); aerr != nil {
+		return fmt.Errorf("upgrade apply: %w", aerr)
+	}
+	rm.AppliedRef = rm.ToRef
+	return p.Store.Save(ctx, p.statePrefix(cfg), rm)
+}
+
+// Validate runs the post-apply assertion suite against the currently-applied ref.
+// For upgrades it also proves the helm revision advanced past the manifest's
+// recorded BaselineRev and verifies the continuity sentinel; for fresh it skips
+// both. Re-entrant: reads everything it needs from the manifest + live outputs.
+func (p PhaseParams) Validate(ctx context.Context) (err error) {
+	cfg, err := p.Matrix.Config(p.ConfigName)
+	if err != nil {
+		return err
+	}
+	rm, ok, err := p.Store.Load(ctx, p.statePrefix(cfg))
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return fmt.Errorf("no manifest for %s — run provision first", p.statePrefix(cfg))
+	}
+	wt, tg, _, err := p.prepareWorktree(rm.AppliedRef, false, cfg, rm.DeleteAfter)
+	if err != nil {
+		return err
+	}
+	defer wt.removeUnlessFailed(p.RepoDir, &err)
+
+	rp := RunParams{
+		Matrix: p.Matrix, Namespace: rm.Namespace, Profile: p.Profile,
+		RunID: p.statePrefix(cfg), DRRegion: rm.DRRegion,
+		RestoreDrill: rm.RestoreDrill, EnableDR: rm.EnableDR, ToRef: rm.ToRef,
+	}
+	rev, kc, caps, verr := validateStack(tg, rp, p.Region)
+	if verr != nil {
+		return fmt.Errorf("validation: %w", verr)
+	}
+	if rev < 1 {
+		return fmt.Errorf("helm release not deployed (revision %d)", rev)
+	}
+	outs, oerr := readOutputs(tg, p.Region)
+	if oerr != nil {
+		return fmt.Errorf("readOutputs: %w", oerr)
+	}
+	if rm.Scenario == "upgrade" {
+		wantChart, _ := p.Matrix.VersionVar(rm.ToRef, "chart_version").(string)
+		step("verifying upgrade proof (advanced from rev %d; chart %q)", rm.BaselineRev, wantChart)
+		if rerr := validation.AssertUpgraded(kc, rm.Namespace, "dozuki", rm.BaselineRev, wantChart); rerr != nil {
+			return fmt.Errorf("upgrade proof: %w", rerr)
+		}
+		return runInfraValidators(ctx, rp, p.Region, caps, outs, true)
+	}
+	return runInfraValidators(ctx, rp, p.Region, caps, outs, false)
+}
+
+// Teardown destroys the run's stack against whichever ref the manifest records as
+// applied (essential for cross-architecture upgrades: target code cannot destroy
+// baseline state). No manifest → nothing was provisioned → no-op success. Idempotent.
+func (p PhaseParams) Teardown(ctx context.Context, keepOnFailure, failed bool) (err error) {
+	cfg, err := p.Matrix.Config(p.ConfigName)
+	if err != nil {
+		return err
+	}
+	rm, ok, err := p.Store.Load(ctx, p.statePrefix(cfg))
+	if err != nil {
+		return err
+	}
+	if !ok {
+		step("teardown: no manifest for %s — nothing to destroy", p.statePrefix(cfg))
+		return nil
+	}
+	if failed && keepOnFailure {
+		step("teardown SKIPPED (--keep-on-failure): stack for %s left up for debugging", p.statePrefix(cfg))
+		return nil
+	}
+	ref := rm.AppliedRef
+	if ref == "" {
+		ref = rm.ToRef
+	}
+	wt, tg, _, err := p.prepareWorktree(ref, false, cfg, rm.DeleteAfter)
+	if err != nil {
+		return err
+	}
+	defer wt.removeUnlessFailed(p.RepoDir, &err)
+
+	identifier := ""
+	if customer, _ := cfg.FeatureFlags["customer"].(string); customer != "" {
+		identifier = customer + "-" + cfg.Env
+	}
+	// captureDiagnostics reads RepoDir/RunID/ConfigName/FromRef/ToRef/Profile/Namespace
+	// off RunParams; `identifier` ("<customer>-<env>") IS the EKS cluster name (run.go).
+	// RunID drives the .artifacts/<id> dir — use the per-config id WITHOUT trailing slash.
+	rp := RunParams{
+		RepoDir: p.RepoDir, RunID: strings.TrimSuffix(p.statePrefix(cfg), "/"),
+		ConfigName: cfg.Name, FromRef: rm.FromRef, ToRef: rm.ToRef,
+		Profile: p.Profile, Namespace: rm.Namespace, Matrix: p.Matrix,
+	}
+	step("capturing diagnostics -> .artifacts/%s (full=%v)", rp.RunID, failed)
+	captureDiagnostics(rp, p.Region, identifier, failed, tg, tg.WorkingDir, "")
+	step("TEARDOWN: destroy against %s", ref)
+	if derr := tg.Destroy(); derr != nil {
+		return fmt.Errorf("destroy: %w", derr)
+	}
+	return nil
+}

--- a/live/tests/harness/phases_provision_test.go
+++ b/live/tests/harness/phases_provision_test.go
@@ -1,0 +1,34 @@
+package harness
+
+import (
+	"context"
+	"testing"
+)
+
+func TestLoadOrInitManifestCreatesThenReuses(t *testing.T) {
+	ctx := context.Background()
+	m := &Matrix{Defaults: Defaults{ReaperTTLHours: 24}}
+	store := NewMemStore()
+	p := PhaseParams{Matrix: m, Store: store, ConfigName: "min_default", RunID: "run1"}
+	cfg := Config{Name: "min_default", Env: "min"}
+
+	rm, err := p.loadOrInitManifest(ctx, cfg, "upgrade", "v6.0.3", "v6.1-release", "2026-06-25T00:00:00Z")
+	if err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	if rm.Scenario != "upgrade" || rm.FromRef != "v6.0.3" || rm.DeleteAfter != "2026-06-25T00:00:00Z" {
+		t.Fatalf("created manifest wrong: %+v", rm)
+	}
+	// Mutate + persist, then re-init must REUSE the stored deleteAfter, not the new arg.
+	rm.BaselineRev = 7
+	if err := store.Save(ctx, p.statePrefix(cfg), rm); err != nil {
+		t.Fatal(err)
+	}
+	rm2, err := p.loadOrInitManifest(ctx, cfg, "upgrade", "v6.0.3", "v6.1-release", "9999-01-01T00:00:00Z")
+	if err != nil {
+		t.Fatalf("reuse: %v", err)
+	}
+	if rm2.BaselineRev != 7 || rm2.DeleteAfter != "2026-06-25T00:00:00Z" {
+		t.Fatalf("re-init should reuse stored manifest: %+v", rm2)
+	}
+}

--- a/live/tests/harness/phases_teardown_test.go
+++ b/live/tests/harness/phases_teardown_test.go
@@ -1,0 +1,15 @@
+package harness
+
+import (
+	"context"
+	"testing"
+)
+
+func TestTeardownNoManifestIsNoop(t *testing.T) {
+	ctx := context.Background()
+	m := &Matrix{Configs: []Config{{Name: "min_default", Env: "min"}}}
+	p := PhaseParams{Matrix: m, Store: NewMemStore(), ConfigName: "min_default", RunID: "run1"}
+	if err := p.Teardown(ctx, false, false); err != nil {
+		t.Fatalf("teardown with no manifest should be a no-op, got %v", err)
+	}
+}

--- a/live/tests/harness/phases_test.go
+++ b/live/tests/harness/phases_test.go
@@ -1,0 +1,66 @@
+package harness
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+// makeTagRepo creates a throwaway git repo with a minimal live/generate_live_env.sh
+// so generateLiveEnvs + worktree add succeed offline.
+func makeTagRepo(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	for _, args := range [][]string{
+		{"init", "-q"}, {"config", "user.email", "t@t"}, {"config", "user.name", "t"},
+	} {
+		c := exec.Command("git", args...)
+		c.Dir = dir
+		if out, err := c.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	if err := os.MkdirAll(filepath.Join(dir, "live"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	script := "#!/usr/bin/env bash\nmkdir -p standard/us-east-1/min\n"
+	if err := os.WriteFile(filepath.Join(dir, "live", "generate_live_env.sh"), []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, args := range [][]string{{"add", "-A"}, {"commit", "-qm", "init"}, {"tag", "v0.0.1"}} {
+		c := exec.Command("git", args...)
+		c.Dir = dir
+		if out, err := c.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	return dir
+}
+
+func TestPrepareWorktreeReentrant(t *testing.T) {
+	repo := makeTagRepo(t)
+	m := &Matrix{
+		Defaults:        Defaults{Region: "us-east-1", EnvPath: "standard/us-east-1"},
+		VersionDefaults: map[string]interface{}{"image_tag": "x"},
+		Configs:         []Config{{Name: "min_default", Env: "min", FeatureFlags: map[string]interface{}{"customer": "smoke"}}},
+	}
+	p := PhaseParams{RepoDir: repo, Matrix: m, Store: NewMemStore(), ConfigName: "min_default", RunID: "run1", Region: "us-east-1"}
+	cfg, _ := m.Config("min_default")
+
+	wt, tg, envDir, err := p.prepareWorktree("v0.0.1", true, cfg, "2026-06-25T00:00:00Z")
+	if err != nil {
+		t.Fatalf("prepare: %v", err)
+	}
+	if tg.StatePrefix != "run1-min_default/" {
+		t.Fatalf("state prefix = %q", tg.StatePrefix)
+	}
+	if _, err := os.Stat(filepath.Join(envDir, "env.hcl")); err != nil {
+		t.Fatalf("env.hcl not written: %v", err)
+	}
+	// Re-entrancy: calling again on a fresh process-equivalent must not error.
+	_ = wt.Remove(repo)
+	if _, _, _, err := p.prepareWorktree("v0.0.1", true, cfg, "2026-06-25T00:00:00Z"); err != nil {
+		t.Fatalf("second prepare (re-entrant): %v", err)
+	}
+}

--- a/live/tests/harness/phases_upgrade_test.go
+++ b/live/tests/harness/phases_upgrade_test.go
@@ -1,0 +1,26 @@
+package harness
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestUpgradeRequiresProvisionedUpgradeManifest(t *testing.T) {
+	ctx := context.Background()
+	m := &Matrix{Defaults: Defaults{Region: "us-east-1", EnvPath: "standard/us-east-1"},
+		Configs: []Config{{Name: "min_default", Env: "min"}}}
+	store := NewMemStore()
+	p := PhaseParams{RepoDir: t.TempDir(), Matrix: m, Store: store, ConfigName: "min_default", RunID: "run1", Region: "us-east-1"}
+
+	// No manifest yet → clear error.
+	if err := p.Upgrade(ctx); err == nil || !strings.Contains(err.Error(), "no manifest") {
+		t.Fatalf("want 'no manifest' error, got %v", err)
+	}
+	// Fresh scenario → refuse.
+	cfg, _ := m.Config("min_default")
+	_ = store.Save(ctx, p.statePrefix(cfg), &RunManifest{Scenario: "fresh", ToRef: "v7.1.0"})
+	if err := p.Upgrade(ctx); err == nil || !strings.Contains(err.Error(), "fresh") {
+		t.Fatalf("want 'fresh' refusal, got %v", err)
+	}
+}

--- a/live/tests/harness/phases_validate_test.go
+++ b/live/tests/harness/phases_validate_test.go
@@ -1,0 +1,16 @@
+package harness
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestValidateRequiresManifest(t *testing.T) {
+	ctx := context.Background()
+	m := &Matrix{Configs: []Config{{Name: "min_default", Env: "min"}}}
+	p := PhaseParams{Matrix: m, Store: NewMemStore(), ConfigName: "min_default", RunID: "run1"}
+	if err := p.Validate(ctx); err == nil || !strings.Contains(err.Error(), "no manifest") {
+		t.Fatalf("want 'no manifest', got %v", err)
+	}
+}

--- a/live/tests/harness/run.go
+++ b/live/tests/harness/run.go
@@ -6,11 +6,10 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/Dozuki/CloudPrem-Infra/live/tests/validation"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
 )
 
 // phaseMark records one step() marker (time + message) for the end-of-run summary.
@@ -19,8 +18,8 @@ type phaseMark struct {
 	msg string
 }
 
-// Per-run phase tracking, reset at the start of each RunUpgrade. The harness runs
-// configs sequentially, so a package-level recorder is sufficient (no concurrency).
+// Per-run phase tracking, reset at the start of each run. The harness runs configs
+// sequentially, so a package-level recorder is sufficient (no concurrency).
 var (
 	phaseMarks []phaseMark
 	runStart   time.Time
@@ -36,7 +35,7 @@ func step(format string, args ...interface{}) {
 	fmt.Fprintf(os.Stderr, "\n>> [harness %s] %s\n", time.Now().Format("15:04:05"), msg)
 }
 
-// RunParams configures one upgrade run.
+// RunParams configures one upgrade/fresh run (the local, single-process driver).
 type RunParams struct {
 	RepoDir           string
 	Matrix            *Matrix
@@ -54,29 +53,44 @@ type RunParams struct {
 	StartTime         time.Time // wall-clock run start; used to compute deleteAfter (zero → time.Now())
 }
 
-// RunUpgrade executes apply(baseline) -> validate -> apply(target) -> validate
-// -> prove -> destroy for one config. Returns the first error; always attempts
-// destroy.
+// phaseParamsFromRun adapts a local RunParams into PhaseParams, using an S3-backed
+// manifest store on the harness state bucket so local runs share the exact code path
+// (and S3 state) the Argo phases use. RunParams.RunID already includes the per-config
+// suffix from the scenario test, so strip it back to the base id that statePrefix
+// re-appends "-<config>/" to.
+func phaseParamsFromRun(p RunParams) (PhaseParams, error) {
+	ctx := context.Background()
+	awsCfg, err := awsConfigFor(ctx, p.Profile, p.Matrix.Defaults.Region)
+	if err != nil {
+		return PhaseParams{}, err
+	}
+	bucket := stateBucket(p.AccountID, p.Matrix.Defaults.Region)
+	base := strings.TrimSuffix(p.RunID, "-"+p.ConfigName)
+	return PhaseParams{
+		RepoDir: p.RepoDir, Matrix: p.Matrix, Store: NewS3Store(s3.NewFromConfig(awsCfg), bucket),
+		ConfigName: p.ConfigName, RunID: base, AccountID: p.AccountID,
+		Profile: p.Profile, Region: p.Matrix.Defaults.Region,
+	}, nil
+}
+
+// RunUpgrade executes provision(baseline) -> upgrade(target) -> validate for one
+// config, with teardown via defer. Returns the first error; always attempts teardown.
+// It composes the same re-entrant phases the Argo Workflow drives — this is the
+// local, single-process driver of them.
 func RunUpgrade(p RunParams) (err error) {
 	cfg, err := p.Matrix.Config(p.ConfigName)
 	if err != nil {
 		return err
 	}
-	if !p.Matrix.VersionProfileExists(p.FromRef) {
-		return fmt.Errorf("no version profile for from_ref %q in matrix", p.FromRef)
-	}
-	if !p.Matrix.VersionProfileExists(p.ToRef) {
-		return fmt.Errorf("no version profile for to_ref %q in matrix", p.ToRef)
-	}
-
-	// Track phases and print a final summary banner on the way out. Registered before
-	// the worktree/teardown defers so it runs LAST — the run's outcome, what ran (with
-	// per-phase durations), and artifact location at a glance, no log-grepping needed.
 	phaseMarks = nil
 	runStart = time.Now()
 	defer func() { printSummary(p, cfg, err) }()
 
-	// Compute deleteAfter once so both worktrees of this upgrade share the same value.
+	pp, derr := phaseParamsFromRun(p)
+	if derr != nil {
+		return derr
+	}
+	ctx := context.Background()
 	startTime := p.StartTime
 	if startTime.IsZero() {
 		startTime = runStart
@@ -87,165 +101,41 @@ func RunUpgrade(p RunParams) (err error) {
 	}
 	deleteAfter := startTime.Add(time.Duration(ttl) * time.Hour).UTC().Format(time.RFC3339)
 
-	ctx := context.Background()
-	base := filepath.Join(p.RepoDir, "live", "tests", "__worktrees__", p.RunID)
-	region := p.Matrix.Defaults.Region
+	// Teardown always runs (defer); the signal handler runs it on SIGINT/SIGTERM too.
+	defer func() { _ = pp.Teardown(ctx, false, err != nil) }()
+	stop := installTeardownOnSignal(func() { _ = pp.Teardown(ctx, false, true) }, os.Exit)
+	defer stop()
 
-	// Refresh remote-tracking refs so branch refs (e.g. v6.1-release) are checked out
-	// at their pushed state, not a stale local branch.
-	FetchOrigin(p.RepoDir)
-
-	step("preparing worktrees: %s (baseline) + %s (upgrade)", p.FromRef, p.ToRef)
-	// Baseline worktree initializes the chart git submodule (pre-#145 refs use it).
-	fromWT, err := AddWorktree(p.RepoDir, base, p.FromRef, true)
-	if err != nil {
+	if err = pp.Provision(ctx, "upgrade", p.FromRef, p.ToRef, deleteAfter, p.Namespace); err != nil {
 		return err
 	}
-	defer fromWT.removeUnlessFailed(p.RepoDir, &err)
-	toWT, err := AddWorktree(p.RepoDir, base, p.ToRef, false)
-	if err != nil {
+	if err = pp.Upgrade(ctx); err != nil {
 		return err
 	}
-	defer toWT.removeUnlessFailed(p.RepoDir, &err)
-
-	// The concrete live/<partition>/<region>/<env> trees are gitignored (generated
-	// from live/.skel by generate_live_env.sh), so a fresh worktree doesn't contain
-	// them. Scaffold them in each worktree before writing env.hcl / applying.
-	for _, wt := range []*Worktree{fromWT, toWT} {
-		if gerr := generateLiveEnvs(wt.Dir); gerr != nil {
-			return fmt.Errorf("generate live envs for %s: %w", wt.Ref, gerr)
-		}
+	if err = pp.Validate(ctx); err != nil {
+		return err
 	}
-
-	envSub := filepath.Join(p.Matrix.Defaults.EnvPath, cfg.Env)
-	fromEnvHCL := filepath.Join(fromWT.Dir, envSub, "env.hcl")
-	toEnvHCL := filepath.Join(toWT.Dir, envSub, "env.hcl")
-
-	// terraform local.identifier = "<customer>-<env>" — the name of both the NLB
-	// (teardown clears its deletion protection) and the EKS cluster (diagnostics dump).
-	identifier := ""
-	if customer, _ := cfg.FeatureFlags["customer"].(string); customer != "" {
-		identifier = customer + "-" + cfg.Env
-	}
-
-	tg := func(wt *Worktree) TGOptions {
-		return TGOptions{
-			WorkingDir:   filepath.Join(wt.Dir, envSub),
-			AccountID:    p.AccountID,
-			Region:       region,
-			Profile:      p.Profile,
-			BucketPrefix: "",
-			StatePrefix:  p.RunID + "-" + cfg.Name + "/",
-			NLBName:      identifier,
-		}
-	}
-
-	// Write env.hcl into BOTH worktrees up front so the deferred destroy (which
-	// runs against the applied worktree, appliedWT) always has a valid config to
-	// clean up with, even if the baseline apply fails before the target env.hcl
-	// would otherwise be written.
-	if werr := WriteEnvHCL(filepath.Join(fromWT.Dir, envSub), withDeleteAfter(p.Matrix.MergedInputs(cfg, p.FromRef), deleteAfter)); werr != nil {
-		return werr
-	}
-	if werr := WriteEnvHCL(filepath.Join(toWT.Dir, envSub), withDeleteAfter(p.Matrix.MergedInputs(cfg, p.ToRef), deleteAfter)); werr != nil {
-		return werr
-	}
-
-	// Track the worktree whose code matches what is deployed: baseline applies
-	// first, so default fromWT; flips to toWT only after the upgrade apply succeeds.
-	// The teardown destroys against THIS worktree (not always toWT) — essential for
-	// cross-architecture upgrades (e.g. v5.3->v6.1) where target code cannot destroy
-	// baseline state.
-	var appliedWT atomic.Pointer[Worktree]
-	appliedWT.Store(fromWT)
-	// Marker so the out-of-process cleanup-orphans backstop can destroy against the
-	// matching worktree too. Written for the baseline up front (a baseline-apply
-	// interrupt still leaves a correct from_ref marker).
-	_ = writeAppliedMarker(p.RepoDir, tg(fromWT).StatePrefix, tg(fromWT).WorkingDir)
-
-	teardown, stopSig := setupTeardown(p, region, identifier, &appliedWT, tg, fromEnvHCL, toEnvHCL, &err)
-	defer teardown(false)
-	defer stopSig()
-
-	// ---- Baseline apply + validate ----
-	step("BASELINE apply: %s (terragrunt run-all apply — physical then logical)", p.FromRef)
-	if aerr := tg(fromWT).Apply(); aerr != nil {
-		return fmt.Errorf("baseline apply: %w", aerr)
-	}
-	step("baseline applied — validating: cluster health (waits for pods Ready, up to 20m), endpoints, helm release")
-	baselineRev, _, baseCaps, verr := validateStack(tg(fromWT), p, region)
-	if verr != nil {
-		return fmt.Errorf("baseline validation: %w", verr)
-	}
-	step("baseline validated ✓ (helm revision %d)", baselineRev)
-
-	// ---- Pre-upgrade: write continuity sentinel if guide buckets are present ----
-	// Read outputs from the baseline to get guide bucket names for the sentinel.
-	baseOuts, err := readOutputs(tg(fromWT), region)
-	if err != nil {
-		return fmt.Errorf("baseline readOutputs (sentinel): %w", err)
-	}
-	if baseCaps.HasGuideBuckets {
-		if serr := validation.WriteSentinel(ctx, region, baseOuts.GuideBuckets[0], p.RunID); serr != nil {
-			return fmt.Errorf("continuity sentinel write: %w", serr)
-		}
-	}
-
-	// ---- Target (upgrade) apply against the SAME state prefix + validate ----
-	if werr := WriteEnvHCL(filepath.Join(toWT.Dir, envSub), withDeleteAfter(p.Matrix.MergedInputs(cfg, p.ToRef), deleteAfter)); werr != nil {
-		return werr
-	}
-	step("UPGRADE apply: %s -> %s (same state prefix; terragrunt run-all apply)", p.FromRef, p.ToRef)
-	if aerr := tg(toWT).Apply(); aerr != nil {
-		return fmt.Errorf("upgrade apply: %w", aerr)
-	}
-	// Upgrade applied: target code now matches the deployed state.
-	appliedWT.Store(toWT)
-	_ = writeAppliedMarker(p.RepoDir, tg(toWT).StatePrefix, tg(toWT).WorkingDir)
-	step("upgrade applied — validating: cluster health (up to 20m), endpoints, helm release")
-	_, kc, upCaps, verr := validateStack(tg(toWT), p, region)
-	if verr != nil {
-		return fmt.Errorf("upgrade validation: %w", verr)
-	}
-	wantChart, _ := p.Matrix.VersionVar(p.ToRef, "chart_version").(string)
-	step("verifying upgrade proof (helm revision advanced from %d; chart %q)", baselineRev, wantChart)
-	if rerr := validation.AssertUpgraded(kc, p.Namespace, "dozuki", baselineRev, wantChart); rerr != nil {
-		return fmt.Errorf("upgrade proof: %w", rerr)
-	}
-
-	// Post-upgrade validators — gated by detected capabilities; skips are logged.
-	step("upgrade proven ✓ — capability-gated post-upgrade validators")
-	outs, err := readOutputs(tg(toWT), region)
-	if err != nil {
-		return fmt.Errorf("post-upgrade readOutputs: %w", err)
-	}
-	if verr := runInfraValidators(ctx, p, region, upCaps, outs, true); verr != nil {
-		return verr
-	}
-
 	step("ALL VALIDATIONS PASSED ✓ — %s -> %s upgrade verified; tearing down next", p.FromRef, p.ToRef)
 	return nil
 }
 
-// RunFresh executes apply -> validate -> capability-gated infra validators ->
-// destroy for a SINGLE ref (p.ToRef). No baseline, no continuity sentinel, and no
-// upgrade proof — it verifies a clean from-scratch deploy of one release (a class
-// of bug that an in-place upgrade can mask). Returns the first error; always
-// attempts destroy.
+// RunFresh executes provision -> validate for a SINGLE ref (p.ToRef): no baseline, no
+// upgrade proof, no continuity sentinel — it verifies a clean from-scratch deploy (a
+// class of bug an in-place upgrade can mask). Teardown via defer; first error wins.
 func RunFresh(p RunParams) (err error) {
 	cfg, err := p.Matrix.Config(p.ConfigName)
 	if err != nil {
 		return err
 	}
-	if !p.Matrix.VersionProfileExists(p.ToRef) {
-		return fmt.Errorf("no version profile for to_ref %q in matrix", p.ToRef)
-	}
-
 	phaseMarks = nil
 	runStart = time.Now()
 	defer func() { printSummary(p, cfg, err) }()
 
-	// Compute deleteAfter for this run.
+	pp, derr := phaseParamsFromRun(p)
+	if derr != nil {
+		return derr
+	}
+	ctx := context.Background()
 	startTime := p.StartTime
 	if startTime.IsZero() {
 		startTime = runStart
@@ -256,109 +146,18 @@ func RunFresh(p RunParams) (err error) {
 	}
 	deleteAfter := startTime.Add(time.Duration(ttl) * time.Hour).UTC().Format(time.RFC3339)
 
-	ctx := context.Background()
-	base := filepath.Join(p.RepoDir, "live", "tests", "__worktrees__", p.RunID)
-	region := p.Matrix.Defaults.Region
+	defer func() { _ = pp.Teardown(ctx, false, err != nil) }()
+	stop := installTeardownOnSignal(func() { _ = pp.Teardown(ctx, false, true) }, os.Exit)
+	defer stop()
 
-	FetchOrigin(p.RepoDir)
-
-	step("preparing worktree: %s (fresh deploy)", p.ToRef)
-	wt, err := AddWorktree(p.RepoDir, base, p.ToRef, true)
-	if err != nil {
+	if err = pp.Provision(ctx, "fresh", "", p.ToRef, deleteAfter, p.Namespace); err != nil {
 		return err
 	}
-	defer wt.removeUnlessFailed(p.RepoDir, &err)
-
-	if gerr := generateLiveEnvs(wt.Dir); gerr != nil {
-		return fmt.Errorf("generate live envs for %s: %w", wt.Ref, gerr)
+	if err = pp.Validate(ctx); err != nil {
+		return err
 	}
-
-	envSub := filepath.Join(p.Matrix.Defaults.EnvPath, cfg.Env)
-	envHCL := filepath.Join(wt.Dir, envSub, "env.hcl")
-
-	identifier := ""
-	if customer, _ := cfg.FeatureFlags["customer"].(string); customer != "" {
-		identifier = customer + "-" + cfg.Env
-	}
-
-	tg := func(w *Worktree) TGOptions {
-		return TGOptions{
-			WorkingDir:   filepath.Join(w.Dir, envSub),
-			AccountID:    p.AccountID,
-			Region:       region,
-			Profile:      p.Profile,
-			BucketPrefix: "",
-			StatePrefix:  p.RunID + "-" + cfg.Name + "/",
-			NLBName:      identifier,
-		}
-	}
-
-	if werr := WriteEnvHCL(filepath.Join(wt.Dir, envSub), withDeleteAfter(p.Matrix.MergedInputs(cfg, p.ToRef), deleteAfter)); werr != nil {
-		return werr
-	}
-
-	var appliedWT atomic.Pointer[Worktree]
-	appliedWT.Store(wt)
-	_ = writeAppliedMarker(p.RepoDir, tg(wt).StatePrefix, tg(wt).WorkingDir)
-	teardown, stopSig := setupTeardown(p, region, identifier, &appliedWT, tg, envHCL, "", &err)
-	defer teardown(false)
-	defer stopSig()
-
-	step("FRESH apply: %s (terragrunt run-all apply — physical then logical)", p.ToRef)
-	if aerr := tg(wt).Apply(); aerr != nil {
-		return fmt.Errorf("fresh apply: %w", aerr)
-	}
-	step("applied — validating: cluster health (waits for pods Ready, up to 20m), endpoints, helm release")
-	rev, _, caps, verr := validateStack(tg(wt), p, region)
-	if verr != nil {
-		return fmt.Errorf("fresh validation: %w", verr)
-	}
-	if rev < 1 {
-		return fmt.Errorf("helm release %q not deployed (revision %d)", "dozuki", rev)
-	}
-	step("fresh deploy validated ✓ (helm revision %d) — capability-gated infra validators", rev)
-
-	outs, err := readOutputs(tg(wt), region)
-	if err != nil {
-		return fmt.Errorf("fresh readOutputs: %w", err)
-	}
-	if ierr := runInfraValidators(ctx, p, region, caps, outs, false); ierr != nil {
-		return ierr
-	}
-
 	step("ALL VALIDATIONS PASSED ✓ — %s fresh deploy verified; tearing down next", p.ToRef)
 	return nil
-}
-
-// setupTeardown builds the sync.Once teardown closure (capture diagnostics, then
-// destroy against the APPLIED worktree) and installs the SIGINT/SIGTERM handler.
-// Shared by RunUpgrade and RunFresh. errp points at the caller's named return so a
-// destroy error can surface; it is read ONLY on the non-interrupted path — the
-// signal path exits via os.Exit while the main goroutine is still running, so
-// reading err there would race.
-func setupTeardown(p RunParams, region, identifier string, appliedWT *atomic.Pointer[Worktree], tg func(*Worktree) TGOptions, fromEnvHCL, toEnvHCL string, errp *error) (teardown func(bool), stop func()) {
-	var once sync.Once
-	teardown = func(interrupted bool) {
-		once.Do(func() {
-			wt := appliedWT.Load()
-			failed := interrupted
-			if !interrupted {
-				failed = *errp != nil
-			}
-			step("capturing diagnostics -> .artifacts/%s (full=%v)", p.RunID, failed)
-			captureDiagnostics(p, region, identifier, failed, tg(wt), fromEnvHCL, toEnvHCL)
-			step("TEARDOWN: destroy against %s (logical best-effort, then ALWAYS physical)", wt.Ref)
-			derr := tg(wt).Destroy()
-			if !interrupted && derr != nil && *errp == nil {
-				*errp = fmt.Errorf("destroy: %w", derr)
-			}
-			if !failed {
-				removeAppliedMarker(p.RepoDir, tg(wt).StatePrefix)
-			}
-		})
-	}
-	stop = installTeardownOnSignal(func() { teardown(true) }, os.Exit)
-	return teardown, stop
 }
 
 // runInfraValidators runs the capability-gated infra assertions shared by fresh and

--- a/live/tests/run.sh
+++ b/live/tests/run.sh
@@ -249,6 +249,35 @@ else
   echo ">> az-env-gap guard DISABLED (NO_AZ_SHIM=1) — 'az' uses the ambient PATH." >&2
 fi
 
+# Optional PHASE mode: drive a SINGLE re-entrant phase via the harness CLI instead of
+# the whole go-test scenario — this is exactly how Argo Workflows invokes each phase.
+# State is shared across phases via the run manifest in S3 (<run-id>-<config>/
+# harness-manifest.json, at the same prefix as TF state), so reuse the SAME RUN_ID for
+# every phase of one run. Unset PHASE => unchanged full go-test path below (parity).
+#   PHASE=provision SCENARIO_FLAG="--scenario upgrade" FROM_REF=v6.0.3 TO_REF=v7.1.0 \
+#     CONFIGS=min_default ./run.sh
+#   PHASE=upgrade  CONFIGS=min_default RUN_ID=<same-id> ./run.sh
+#   PHASE=validate CONFIGS=min_default RUN_ID=<same-id> ./run.sh
+#   PHASE=teardown CONFIGS=min_default RUN_ID=<same-id> ./run.sh   # +KEEP_ON_FAILURE=1
+if [ -n "${PHASE:-}" ]; then
+  REPO_ROOT="$(git -C "$PWD" rev-parse --show-toplevel)"
+  # Manifest lives in the TF state bucket (live/root.hcl remote_state naming).
+  STATE_BUCKET="${STATE_BUCKET:-${TG_BUCKET_PREFIX:-}dozuki-terraform-state-${REGION:-us-east-1}-${DDVTEST_ACCOUNT_ID}}"
+  echo ">> PHASE mode: $PHASE (run-id=$RUN_ID config=${CONFIGS:-min_default} bucket=$STATE_BUCKET)" >&2
+  BIN="$PWD/.bin/harness"
+  mkdir -p "$PWD/.bin"
+  go build -o "$BIN" ./cmd/harness
+  _keep=""; [ "${KEEP_ON_FAILURE:-0}" = 1 ] && _keep="--keep-on-failure"
+  "$BIN" "$PHASE" \
+    --run-id "$RUN_ID" --config "${CONFIGS:-min_default}" \
+    --repo-dir "$REPO_ROOT" \
+    --account-id "$DDVTEST_ACCOUNT_ID" --profile "$AWS_PROFILE" \
+    --region "${REGION:-us-east-1}" --state-bucket "$STATE_BUCKET" \
+    --matrix "$PWD/matrix.yaml" \
+    ${SCENARIO_FLAG:-} ${FROM_REF:+--from-ref "$FROM_REF"} ${TO_REF:+--to-ref "$TO_REF"} ${_keep}
+  exit $?
+fi
+
 # Scenario selection: upgrade | fresh | both (default both). 'both' runs TestUpgrade
 # then TestFresh in one go-test process; a failure in EITHER makes go test exit non-zero.
 SCENARIO="${SCENARIO:-both}"


### PR DESCRIPTION
## What

Refactors the upgrade-test harness so each stage is an independently runnable,
**resumable** phase — the shape an Argo Workflow drives (one pod per phase) and the
basis for scheduled/triggered headless runs. Part of the Argo Workflows ops-platform
initiative (Plan 1 of 4).

## How

- **`RunManifest`** in S3 (beside TF state at `<run-id>-<config>/harness-manifest.json`)
  carries the cross-phase state that used to be in-memory: scenario, refs,
  `delete_after`, `applied_ref`, `baseline_rev`. `ManifestStore` has S3 + in-memory
  (test) implementations.
- **`harness/phases.go`** — `PhaseParams.{Provision,Upgrade,Validate,Teardown}`, each
  reconstructing worktree/tg + state from the manifest. Idempotent / re-entrant
  (teardown with no manifest is a no-op; phases can be re-run after a pod restart).
- **`cmd/harness`** — CLI dispatching to the phases (`--mem-store` for offline tests).
- **`RunUpgrade`/`RunFresh`** recomposed on the phases as the local single-process
  driver; the `scenarios` tests are unchanged and act as the regression guard.
- **`run.sh`** gains an optional `PHASE=<phase>` mode; unset `PHASE` keeps the
  byte-for-byte `go test` path (parity). See `PHASES.md`.

## Behavior change to note

Drops the in-memory `appliedWT` + `__worktrees__/.markers` handoff;
`manifest.applied_ref` replaces it. The bash `cleanup-orphans.sh` backstop therefore
no longer receives markers and falls back to live-tree destroy — acceptable since
teardown is now manifest-driven, and the planned CronWorkflow janitor supersedes that
backstop.

## Testing

`go build ./...`, `go test ./...` (incl. the `scenarios` regression guard), and
`go vet ./...` all green offline. The **live parity gate** — a real DDVtest
`provision -> validate -> teardown` run compared against the full `go test` path — is
**pending** (needs DDVtest creds + Vault) before retiring the GitHub Actions matrix.