### PR TITLE
fix(logical): apply dozuki-operator image redirect on all clouds, not just Azure

### DIFF
--- a/terraform/logical/kubernetes.tf
+++ b/terraform/logical/kubernetes.tf
@@ -549,7 +549,7 @@ resource "helm_release" "app" {
 
   # helm provider 3.x: set/set_sensitive are list-of-object attributes, not
   # repeatable blocks. Section groupings preserved as comments.
-  set = concat([
+  set = [
     # --- General ---
     { name = "hostname", value = var.dns_domain_name },
     { name = "dns_validation", value = var.cloud == "aws" && !local.is_us_gov && !local.tls_manual && contains(["dozuki.cloud", "dozuki.com", "dozuki.app", "dozuki.guide"], replace(var.dns_domain_name, "/^[^.]+\\./", "")) ? "true" : "false" },
@@ -659,14 +659,20 @@ resource "helm_release" "app" {
     { name = "connectivity.connectors-worker.messageBroker.brokerList", value = var.msk_bootstrap_brokers },
     { name = "connectivity.connectors-worker.redis.host", value = "dozuki-redis-master" },
     { name = "connectivity.connectors-worker.redis.tls", value = "false" },
-    ], var.cloud == "azure" ? [
-    # --- Operator (azure: pull from GHCR mirror, not ECR) ---
-    # The operator subchart reads its OWN imagePullSecrets (it does not honor
-    # global.imagePullSecrets), so the GHCR pull secret must be set explicitly.
+
+    # --- Operator ---
+    # Redirect the operator subchart to the env's registry. Its default repo is the
+    # commercial ECR (069…), which GovCloud and Azure can't reach; ${var.image_repository}
+    # already points at the right registry per env, so this applies on EVERY cloud/partition
+    # with no gate (commercial AWS resolves back to its own ECR). The tag is intentionally
+    # left to the subchart default (its appVersion) — exactly the operator image the haul
+    # bundles/mirrors — so the deployed tag can never drift from what was published. The
+    # subchart reads its OWN imagePullSecrets (it does not honor global.imagePullSecrets);
+    # ghcr-pull is required for Azure GHCR and is harmless on AWS (the node's ECR creds
+    # serve the ECR registry, so a non-matching secret is ignored).
     { name = "dozuki-operator.image.repository", value = "${var.image_repository}/dozuki-operator" },
-    { name = "dozuki-operator.image.tag", value = var.operator_image_tag },
     { name = "dozuki-operator.imagePullSecrets[0].name", value = "ghcr-pull" },
-  ] : [])
+  ]
 
   set_sensitive = [
     { name = "db.password", value = local.db_master_password },


### PR DESCRIPTION
## Problem

On the GovCloud ECP deploy, `helm_release.app` timed out (`context deadline exceeded`, wait=true/900s) even though the entire app stack was healthy — the **only** unready pod was `dozuki-operator`, stuck in `ImagePullBackOff` pulling `069174876992.dkr.ecr.us-east-1.amazonaws.com/dozuki-operator:3.1.0` (commercial ECR, unreachable from the airgapped gov cluster).

Root cause: the operator image override was wrapped in `var.cloud == "azure" ? [...] : []`, so on GovCloud (`cloud="aws"`) it was never applied and the subchart used its default commercial-ECR repo.

## Fix

- Lift the `dozuki-operator.image.repository` + `imagePullSecrets` overrides **out of the Azure gate** so they apply on every cloud/partition. `${var.image_repository}` already resolves to the right registry per env (commercial ECR on standard AWS, gov ECR on GovCloud, GHCR on Azure) — no partition gate needed.
- **Drop the `image.tag` override.** It pinned `var.operator_image_tag` (default `3.0.3`), which had drifted from the subchart's bundled appVersion (`3.1.0` — the tag the haul actually mirrors). Leaving the tag at the subchart default keeps the deployed operator in lockstep with what the airgap bundle publishes. `var.operator_image_tag` is now unused.

## Note

The operator image is bundled by the haul but lands in gov ECR **untagged** (the haul digest-pins everything) — a separate `dozuki_helm/gen-manifest.sh` fix (keep `repo:tag@digest`) makes it tag-pullable. Until that ships, the operator tag must be hand-mirrored into gov ECR for this to resolve.
