### PR TITLE
fix(physical): dr_aurora subnet for_each empty case must be a set, not a tuple

### DIFF
--- a/terraform/physical/dr_aurora.tf
+++ b/terraform/physical/dr_aurora.tf
@@ -39,7 +39,7 @@ resource "aws_vpc" "dr_aurora" {
 
 # One private /24 per AZ (up to 3), carved from dr_vpc_cidr.
 resource "aws_subnet" "dr_aurora" {
-  for_each          = local.aurora_dr_enabled ? toset(slice(data.aws_availability_zones.dr[0].names, 0, min(3, length(data.aws_availability_zones.dr[0].names)))) : []
+  for_each          = local.aurora_dr_enabled ? toset(slice(data.aws_availability_zones.dr[0].names, 0, min(3, length(data.aws_availability_zones.dr[0].names)))) : toset([])
   provider          = aws.dr
   vpc_id            = aws_vpc.dr_aurora[0].id
   availability_zone = each.value


### PR DESCRIPTION
Plan-time failure on DR-off stacks (sharedgov, `enable_dr=false`): `aws_subnet.dr_aurora` for_each fell back to `[]` (empty tuple), which OpenTofu rejects ("for_each must be a map, or set of strings ... value of type tuple"). The 7.1.2→7.3.2 jump pulled in this DR-Aurora code, so it surfaced the moment sharedgov re-pinned to v7.3.2 — physical failed, and logical was skipped as its dependency.\n\nFix: `: []` → `: toset([])` so the empty case matches the `set(string)` of the enabled branch.\n\nUnblocks the sharedgov physical plan; after this releases I'll bump `infra_version` to it.