### PR TITLE
fix(physical): disable restrict_fk_on_non_standard_key on Aurora 8.4 for dozuki migrations

### DIFF
--- a/terraform/physical/aurora.tf
+++ b/terraform/physical/aurora.tf
@@ -54,6 +54,14 @@ module "aurora" {
       { name = "binlog_format", value = "ROW", apply_method = "pending-reboot" },
       { name = "binlog_row_image", value = "full", apply_method = "pending-reboot" },
       { name = "binlog_checksum", value = "NONE", apply_method = "pending-reboot" },
+      # MySQL 8.4 (Aurora 8.4) defaults restrict_fk_on_non_standard_key=ON, rejecting a
+      # foreign key whose referenced column lacks a unique/PK index. The dozuki schema
+      # migrations add such a FK (major_release_approval_processid -> approval_processes)
+      # that passed on 8.0; on 8.4 it fails ("Missing unique key for constraint ...") and
+      # aborts db-initialize, leaving the schema half-built (login then 500s on a missing
+      # password_requirements_revisions table). Restore the 8.0 behavior. Dynamic var, so
+      # immediate (no reboot).
+      { name = "restrict_fk_on_non_standard_key", value = "0", apply_method = "immediate" },
     ]
   }
 


### PR DESCRIPTION
MySQL 8.4 defaults `restrict_fk_on_non_standard_key=ON`, rejecting FKs whose referenced column lacks a unique/PK index. A dozuki schema migration adds such a FK (`major_release_approval_processid` -> `approval_processes`) that passed on MySQL 8.0; on Aurora 8.4 it fails (`Missing unique key for constraint`) and aborts `db-initialize`, leaving the schema half-built. The migration Job then falsely reports Complete on its retry, and the app 500s on `/Login` with `Table 'password_requirements_revisions' does not exist`.\n\nSet it OFF in the Aurora cluster parameter group to restore the 8.0 behavior. Dynamic var → `apply_method=immediate` (no reboot). Matches the documented internal fix for this on 8.4.\n\nAfter this releases + the param applies, the dozuki DBs need a **clean re-migrate** (drop + re-run the Job) since the current schema is already half-built.