### PR TITLE
fix(logical): disable PROXY protocol on the Azure gateway (clientIP.mode=none)

### DIFF
--- a/terraform/logical/kubernetes.tf
+++ b/terraform/logical/kubernetes.tf
@@ -595,6 +595,15 @@ resource "helm_release" "app" {
     { name = "ingress.hosts[0].hostname", value = coalesce(var.ingress_hostname, var.dns_domain_name) },
     { name = "gateway.hosts[0].hostname", value = coalesce(var.ingress_hostname, var.dns_domain_name) },
     { name = "gateway.hosts[0].tlsSecretName", value = "tls-secret" },
+    # Client-IP detection. The chart defaults to proxyProtocol (real client IP via
+    # PROXY protocol v2 from an AWS NLB). Azure's L4 Standard LB cannot prepend a
+    # PROXY preamble, so Envoy RESETS every gateway connection — which makes the
+    # cert-manager HTTP-01 challenge on :80 unreachable (LE can't fetch the token →
+    # the cert never issues → the :443 listener never programs → no public HTTPS).
+    # "none" renders no ClientTrafficPolicy; the Envoy service's
+    # externalTrafficPolicy=Local still preserves the real client source IP to Envoy
+    # (so GeoIP/WAF/logging keep working). AWS keeps proxyProtocol (its NLB sends it).
+    { name = "gateway.clientIP.mode", value = var.cloud == "azure" ? "none" : "proxyProtocol" },
     # Manual TLS. Supplied certs: chart renders the typed tls-secret (externallyManaged
     # false). Generated self-signed: Terraform renders it (externallyManaged true).
     { name = "tls.enabled", value = local.tls_manual ? "true" : "false" },


### PR DESCRIPTION
## Problem
On the Azure MPC deploy the app was healthy but **public HTTPS never came up**. Root cause: the dozuki chart defaults `gateway.clientIP.mode=proxyProtocol` (real client IP via PROXY protocol v2 from an AWS NLB). Azure's **L4 Standard LB cannot prepend a PROXY preamble**, so Envoy **RESET every gateway connection** (reproduced even on Envoy's ClusterIP). That made the cert-manager **HTTP-01 challenge on :80 unreachable** → the LE cert never issued → the :443 listener never programmed → no HTTPS. Same class as the GovCloud HTTP-01 listener issue; on AWS the NLB sends PROXY protocol so it works there.

## Fix
`gateway.clientIP.mode=none` on Azure → no ClientTrafficPolicy rendered, Envoy accepts plain connections. `externalTrafficPolicy=Local` already preserves the real client IP. AWS keeps `proxyProtocol` (inline `var.cloud == "azure" ? "none" : "proxyProtocol"`).

## Validation
- `helm template`: `mode=none` → ClientTrafficPolicy absent; `proxyProtocol` → present (AWS unchanged).
- **Live on azure dev:** removed the policy → HTTP-01 completed → LE cert issued → `https://mpc-dev.dozuki.cloud/Login` = **200**, trusted LE cert (issuer CN=YR2). This PR makes it permanent.