### PR TITLE
feat(logical): opt-in shared-grafana dashboards wiring, drop dead grafana sets

### DIFF
--- a/terraform/logical/keyvault.tf
+++ b/terraform/logical/keyvault.tf
@@ -3,7 +3,7 @@
 # db credentials are seeded by the physical layer as "database-credentials".
 
 locals {
-  azure_kv_secrets = var.cloud == "azure" ? {
+  azure_kv_secrets = var.cloud == "azure" ? merge({
     cache = jsonencode({
       host = "dozuki-memcached"
     })
@@ -27,7 +27,15 @@ locals {
       password        = var.rustici_password
       managedPassword = var.rustici_managed_password
     })
-  } : {}
+    }, var.enable_dashboards ? {
+    # Keys match the chart's ESO remoteRef properties (see vault.tf's
+    # vault_kv_secret_v2.grafana for the AWS twin of this same entry).
+    grafana = jsonencode({
+      secret        = local.dashboards_jwt_secret
+      adminUser     = local.dashboards_admin_username
+      adminPassword = local.dashboards_admin_password
+    })
+  } : {}) : {}
 }
 
 resource "azurerm_key_vault_secret" "app" {

--- a/terraform/logical/kubernetes.tf
+++ b/terraform/logical/kubernetes.tf
@@ -658,10 +658,8 @@ resource "helm_release" "app" {
     # only matches a standalone S3 deployment, which we do not run.
     { name = "objectStorage.publicHost", value = var.cloud == "azure" ? "s3.${var.dns_domain_name}" : "" },
 
-    # --- Grafana ---
-    { name = "grafana.enabled", value = var.enable_bi ? "true" : "false" },
-    { name = "grafana.security.admin_user", value = local.grafana_admin_username },
-    { name = "grafana.datasource.host", value = local.db_bi_host },
+    # --- Dashboards (shared Grafana) ---
+    { name = "dashboards.enabled", value = var.enable_dashboards ? "true" : "false" },
 
     # --- Connectivity (sunset planned) ---
     { name = "connectivity.webhook-service.messageBroker.brokerList", value = var.msk_bootstrap_brokers },
@@ -691,6 +689,13 @@ resource "helm_release" "app" {
     # serve the ECR registry, so a non-matching secret is ignored).
     { name = "dozuki-operator.image.repository", value = "${var.image_repository}/dozuki-operator" },
     { name = "dozuki-operator.imagePullSecrets[0].name", value = "ghcr-pull" },
+    # GRAFANA_URL: tells the operator to run shared-Grafana org provisioning. The
+    # dashboards subchart forces nameOverride=dashboards-grafana and this chart's
+    # release name is always "dozuki" (helm_release.app.name), so the in-cluster
+    # Service is always dozuki-dashboards-grafana when dashboards.enabled. Left
+    # empty when disabled — a nonempty URL would point the operator at a Grafana
+    # that was never installed.
+    { name = "dozuki-operator.grafana.url", value = var.enable_dashboards ? "http://dozuki-dashboards-grafana" : "" },
   ]
 
   set_sensitive = [
@@ -700,8 +705,11 @@ resource "helm_release" "app" {
     { name = "objectStorage.credentials.accessKey", value = var.cloud == "azure" ? try(random_password.seaweedfs_access_key[0].result, "") : "" },
     { name = "objectStorage.credentials.secretKey", value = var.cloud == "azure" ? try(random_password.seaweedfs_secret_key[0].result, "") : "" },
     { name = "googleTranslate.token", value = var.google_translate_api_token },
-    { name = "grafana.security.admin_password", value = local.grafana_admin_password },
-    { name = "grafana.datasource.password", value = local.db_bi_password },
+    # Signs the inline JWKS the Envoy JWT SecurityPolicy validates against (see
+    # dozuki chart templates/gateway-dashboards.yaml) — must be the SAME value
+    # seeded into the "grafana" Vault/Key Vault secret's "secret" property, since
+    # ESO syncs that same value into grafana.json for the app to mint tokens with.
+    { name = "dashboards.jwtSecret", value = local.dashboards_jwt_secret },
   ]
 
   lifecycle {

--- a/terraform/logical/main.tf
+++ b/terraform/logical/main.tf
@@ -208,55 +208,14 @@ locals {
   # Kubernetes
   k8s_namespace_name = "dozuki"
 
-  // Map for app config
-
-  base_config_values = {
-    customer               = { value = coalesce(var.customer, "Dozuki") }
-    environment            = { value = var.environment }
-    aws_acct_id            = { value = var.cloud == "aws" ? data.aws_caller_identity.current[0].account_id : "" }
-    aws_region             = { value = var.cloud == "aws" ? data.aws_region.current[0].region : "us-east-1" }
-    hostname               = { value = var.dns_domain_name }
-    ingress_hostname       = { value = coalesce(var.ingress_hostname, var.dns_domain_name) }
-    bi_enabled             = { value = var.enable_bi ? "true" : "false" }
-    webhooks_enabled       = { value = var.enable_webhooks ? "true" : "false" }
-    memcached_host         = { value = local.memcached_host }
-    s3_kms_key             = { value = var.cloud == "aws" ? data.aws_kms_key.s3[0].arn : "" }
-    s3_images_bucket       = { value = var.s3_images_bucket }
-    s3_objects_bucket      = { value = var.s3_objects_bucket }
-    s3_documents_bucket    = { value = var.s3_documents_bucket }
-    s3_pdfs_bucket         = { value = var.s3_pdfs_bucket }
-    db_host                = { value = local.db_master_host }
-    db_user                = { value = local.db_master_username }
-    db_password            = { value = local.db_master_password }
-    rds_ca_cert            = { value = base64encode(file(local.ca_cert_pem_file)) }
-    msk_bootstrap_brokers  = { value = var.msk_bootstrap_brokers }
-    google_translate_token = { value = var.google_translate_api_token }
-    dns_validation         = { value = !local.is_us_gov && contains(["dozuki.cloud", "dozuki.com", "dozuki.app", "dozuki.guide"], replace(var.dns_domain_name, "/^[^.]+\\./", "")) ? "true" : "false" }
-    vault_enabled          = { value = "true" }
-    vault_address          = { value = var.vault_address }
-    image_repository       = { value = var.image_repository }
-    image_tag              = { value = var.image_tag }
-    nextjs_tag             = { value = var.nextjs_tag }
-    smtp_enabled           = { value = var.smtp_enabled ? "true" : "false" }
-    smtp_host              = { value = var.smtp_host }
-    smtp_from_address      = { value = var.smtp_from_address }
-    smtp_auth_enabled      = { value = var.smtp_auth_enabled ? "true" : "false" }
-    smtp_username          = { value = var.smtp_username }
-    smtp_password          = { value = var.smtp_password }
-  }
-
-  // Optional add-on for Grafana config
-  grafana_config_values = {
-    grafana_admin_username      = { value = local.grafana_admin_username }
-    grafana_admin_password      = { value = local.grafana_admin_password }
-    grafana_datasource_hostname = { value = local.db_bi_host }
-    grafana_datasource_password = { value = local.db_bi_password }
-    grafana_settings_hostname   = { value = local.db_master_host }
-    grafana_settings_username   = { value = local.db_master_username }
-    grafana_settings_password   = { value = local.db_master_password }
-    grafana_subpath             = { value = var.grafana_subpath }
-  }
-
+  # Dashboards (shared Grafana): jwt signing secret + admin creds, generated once
+  # per stack. Shared between the "grafana" Vault/Key Vault secret (vault.tf /
+  # keyvault.tf, read by ESO) and the dashboards.jwtSecret chart value (kubernetes.tf),
+  # which the Envoy Gateway JWT SecurityPolicy needs baked in at render time — a
+  # cluster secret alone isn't enough, ESO and Terraform must agree on the same value.
+  dashboards_jwt_secret     = var.enable_dashboards ? random_password.dashboards_jwt[0].result : ""
+  dashboards_admin_username = "admin"
+  dashboards_admin_password = var.enable_dashboards ? random_password.dashboards_admin[0].result : ""
 }
 
 check "vault_address_configured" {

--- a/terraform/logical/variables.tf
+++ b/terraform/logical/variables.tf
@@ -49,6 +49,12 @@ variable "enable_bi" {
   default     = false
 }
 
+variable "enable_dashboards" {
+  description = "Turns on the dozuki chart's shared Grafana dashboards subchart (dashboards.enabled) and the dozuki-operator's per-subsite Grafana-org provisioning (dozuki-operator.grafana.url). Generates and seeds the \"grafana\" Vault/Key Vault secret (jwt signing secret + admin credentials) this layer's ESO ExternalSecrets read - no manual secret seeding required. Requires chart_version >= 1.0.0 and the bundled dozuki-operator >= 4.0.0 (older pins silently no-op on dozuki-operator.grafana.url)."
+  type        = bool
+  default     = false
+}
+
 variable "google_translate_api_token" {
   description = "If using machine translation, enter your google translate API token here."
   type        = string

--- a/terraform/logical/vault.tf
+++ b/terraform/logical/vault.tf
@@ -215,67 +215,38 @@ resource "vault_kv_secret_v2" "smtp" {
   })
 }
 
-# --- System-wide secrets (read from Vault, pre-seeded by vault-infrastructure) --- #
+# --- Dashboards (shared Grafana) --- #
 
-data "vault_kv_secret_v2" "global_sentry" {
-  count = var.cloud == "aws" ? 1 : 0
-  mount = "secret"
-  name  = "dozuki/global/sentry"
+resource "random_password" "dashboards_jwt" {
+  count = var.enable_dashboards ? 1 : 0
+
+  length  = 40
+  special = false
 }
 
-data "vault_kv_secret_v2" "global_frontegg" {
-  count = var.cloud == "aws" ? 1 : 0
-  mount = "secret"
-  name  = "dozuki/global/frontegg"
+resource "random_password" "dashboards_admin" {
+  count = var.enable_dashboards ? 1 : 0
+
+  length  = 20
+  special = false
 }
 
-data "vault_kv_secret_v2" "global_surveyjs" {
-  count = var.cloud == "aws" ? 1 : 0
-  mount = "secret"
-  name  = "dozuki/global/surveyjs"
-}
+# Keys match the chart's ESO remoteRef properties exactly (dozuki chart
+# templates/vault/external-secret.yaml + templates/azure/external-secret.yaml):
+# "secret" signs/verifies the Envoy JWT SecurityPolicy and is baked into
+# grafana.json for the app to mint tokens with; adminUser/adminPassword seed the
+# dozuki-grafana-admin Secret the bundled Grafana subchart logs in with.
+resource "vault_kv_secret_v2" "grafana" {
+  count               = var.cloud == "aws" && var.enable_dashboards ? 1 : 0
+  mount               = "secret"
+  name                = "${local.vault_env_prefix}/grafana"
+  delete_all_versions = !var.protect_resources
 
-data "vault_kv_secret_v2" "global_rustici" {
-  count = var.cloud == "aws" ? 1 : 0
-  mount = "secret"
-  name  = "dozuki/global/rustici"
-}
-
-data "vault_kv_secret_v2" "global_ops" {
-  count = var.cloud == "aws" ? 1 : 0
-  mount = "secret"
-  name  = "dozuki/global/ops"
-}
-
-data "vault_kv_secret_v2" "global_slack" {
-  count = var.cloud == "aws" ? 1 : 0
-  mount = "secret"
-  name  = "dozuki/global/slack"
-}
-
-# --- Vault-sourced config values (replace devops/app/config SM when vault enabled) --- #
-
-locals {
-  vault_config_values = {
-    sentry_dsn                = { value = var.cloud == "aws" ? data.vault_kv_secret_v2.global_sentry[0].data["dsn"] : var.sentry_dsn }
-    frontegg_client_id        = { value = var.cloud == "aws" ? data.vault_kv_secret_v2.global_frontegg[0].data["clientId"] : var.frontegg_client_id }
-    frontegg_api_token        = { value = var.cloud == "aws" ? data.vault_kv_secret_v2.global_frontegg[0].data["apiToken"] : var.frontegg_api_token }
-    frontegg_docker_username  = { value = var.cloud == "aws" ? data.vault_kv_secret_v2.global_frontegg[0].data["dockerUsername"] : "" }
-    frontegg_docker_password  = { value = var.cloud == "aws" ? data.vault_kv_secret_v2.global_frontegg[0].data["dockerPassword"] : "" }
-    frontegg_auth_pubkey      = { value = var.cloud == "aws" ? data.vault_kv_secret_v2.global_frontegg[0].data["authPubkey"] : "" }
-    surveyjs_license_key      = { value = var.cloud == "aws" ? data.vault_kv_secret_v2.global_surveyjs[0].data["licenseKey"] : var.surveyjs_license_key }
-    rustici_password          = { value = var.cloud == "aws" ? data.vault_kv_secret_v2.global_rustici[0].data["password"] : var.rustici_password }
-    rustici_managed_password  = { value = var.cloud == "aws" ? data.vault_kv_secret_v2.global_rustici[0].data["managedPassword"] : var.rustici_managed_password }
-    ops_basic_auth            = { value = var.cloud == "aws" ? data.vault_kv_secret_v2.global_ops[0].data["basicAuth"] : "" }
-    infra_auth_password       = { value = var.cloud == "aws" ? data.vault_kv_secret_v2.global_ops[0].data["infraAuthPassword"] : "" }
-    slack_webhook_url         = { value = var.cloud == "aws" ? data.vault_kv_secret_v2.global_slack[0].data["webhookUrl"] : "" }
-    grafana_smtp_enabled      = { value = var.cloud == "aws" ? try(data.vault_kv_secret_v2.global_ops[0].data["grafanaSmtpEnabled"], "false") : "false" }
-    grafana_smtp_host         = { value = var.cloud == "aws" ? try(data.vault_kv_secret_v2.global_ops[0].data["grafanaSmtpHost"], "") : "" }
-    grafana_smtp_user         = { value = var.cloud == "aws" ? try(data.vault_kv_secret_v2.global_ops[0].data["grafanaSmtpUser"], "") : "" }
-    grafana_smtp_password     = { value = var.cloud == "aws" ? try(data.vault_kv_secret_v2.global_ops[0].data["grafanaSmtpPassword"], "") : "" }
-    grafana_smtp_from_address = { value = var.cloud == "aws" ? try(data.vault_kv_secret_v2.global_ops[0].data["grafanaSmtpFromAddress"], "") : "" }
-    grafana_smtp_starttls     = { value = var.cloud == "aws" ? try(data.vault_kv_secret_v2.global_ops[0].data["grafanaSmtpStarttls"], "OpportunisticStartTLS") : "OpportunisticStartTLS" }
-  }
+  data_json = jsonencode({
+    secret        = local.dashboards_jwt_secret
+    adminUser     = local.dashboards_admin_username
+    adminPassword = local.dashboards_admin_password
+  })
 }
 
 # --- State moves: resources gained `count` when the azure cloud gate was added --- #


### PR DESCRIPTION
## Summary

Pairs with dozuki chart 1.0.0 (shared Grafana replacing per-subsite grafana-operator) and dozuki-operator 4.0.0 (GRAFANA_URL-driven org provisioning).

**Dead code removed** (chart 1.0.0 deleted the `grafana.*` values these referenced):
- `helm_release.app` set entries: `grafana.enabled`, `grafana.security.admin_user`, `grafana.datasource.host`
- `helm_release.app` set_sensitive entries: `grafana.security.admin_password`, `grafana.datasource.password`
- Three zero-consumer locals left from a retired templatefile system: `base_config_values`, `grafana_config_values`, `vault_config_values`
- Six Vault data sources (`global_sentry`, `global_frontegg`, `global_surveyjs`, `global_rustici`, `global_ops`, `global_slack`) that existed only to feed `vault_config_values` - they did live Vault reads on every apply for a value nothing consumed.

Note: `enable_bi`'s existing per-subsite BI-replica-database Grafana provisioning (`bi.tf`, `random_password.grafana_admin`, the `grafana_url`/`grafana_admin_username`/`grafana_admin_password` outputs) is untouched - that's a separate, still-live feature (BI read-replica DB), not the chart's Grafana wiring.

**New opt-in wiring:** `enable_dashboards` (bool, default `false`). When `true`:
- `dashboards.enabled = true`
- `dashboards.jwtSecret` (set_sensitive) - signs the inline JWKS the Envoy JWT SecurityPolicy validates against
- `dozuki-operator.grafana.url = "http://dozuki-dashboards-grafana"` (empty string when disabled, per the chart's own guidance - the operator subchart's static release name + `nameOverride: dashboards-grafana` mean this URL is always correct in-cluster when enabled)

Everything is a no-op when `enable_dashboards = false` (chart default `dashboards.enabled: false`, empty `dashboards.jwtSecret`, empty operator URL).

**Secret plumbing:** the jwt secret and Grafana admin credentials are generated with `random_password` and seeded into the same `"grafana"` Vault (AWS)/Key Vault (Azure) entry the chart's own ESO `ExternalSecret`s already read (`vault/external-secret.yaml` + `azure/external-secret.yaml` in the dozuki chart, remoteRef key `<customer>/<env>/grafana` on AWS, secret name `grafana` on Azure; both use properties `secret`/`adminUser`/`adminPassword`). This follows the exact same pattern as the existing `cache`/`smtp`/`google-translate` secrets - fully automated, **no manual Vault/AKV seeding step required**. No Vault policy changes needed either: the existing `secret/data/<tenant>/<env>/*` wildcard policy already covers the new `.../grafana` path.

**Follow-up required to actually use this on an env:** bump `chart_version` to `1.0.0` in that env's `env.hcl` (infra-live side, not part of this PR) before flipping `enable_dashboards = true` - older chart pins don't have the `dashboards.*` values or `dozuki-operator.grafana.url` wiring at all.

## Test plan
- [x] `tofu fmt -diff -write=false .` on `terraform/logical` - clean
- [x] `tofu init -backend=false` + `VAULT_ADDR=... tofu validate` - succeeds
- [ ] No plan/apply run (not authorized/appropriate for this change - review only)