### PR TITLE
fix(physical): finops remediation (gp3, graviton lambdas, s3 lifecycle)

### DIFF
--- a/terraform/physical/README.md
+++ b/terraform/physical/README.md
@@ -15,11 +15,11 @@
 | Name | Version |
 |------|---------|
 | <a name="provider_archive"></a> [archive](#provider\_archive) | 2.8.0 |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 6.0 |
-| <a name="provider_aws.dns"></a> [aws.dns](#provider\_aws.dns) | ~> 6.0 |
-| <a name="provider_aws.dr"></a> [aws.dr](#provider\_aws.dr) | ~> 6.0 |
-| <a name="provider_null"></a> [null](#provider\_null) | ~> 3.0 |
-| <a name="provider_random"></a> [random](#provider\_random) | ~> 3.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.54.0 |
+| <a name="provider_aws.dns"></a> [aws.dns](#provider\_aws.dns) | 6.54.0 |
+| <a name="provider_aws.dr"></a> [aws.dr](#provider\_aws.dr) | 6.54.0 |
+| <a name="provider_null"></a> [null](#provider\_null) | 3.3.0 |
+| <a name="provider_random"></a> [random](#provider\_random) | 3.9.0 |
 
 ## Modules
 
@@ -131,6 +131,8 @@
 | [aws_s3_bucket_acl.logging_bucket_acl](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_acl) | resource |
 | [aws_s3_bucket_cors_configuration.guide_documents](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_cors_configuration) | resource |
 | [aws_s3_bucket_cors_configuration.guide_images](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_cors_configuration) | resource |
+| [aws_s3_bucket_lifecycle_configuration.guide_buckets](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_lifecycle_configuration) | resource |
+| [aws_s3_bucket_lifecycle_configuration.logging_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_lifecycle_configuration) | resource |
 | [aws_s3_bucket_logging.guide_buckets_logging](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_logging) | resource |
 | [aws_s3_bucket_ownership_controls.logging_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_ownership_controls) | resource |
 | [aws_s3_bucket_policy.logging_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |

--- a/terraform/physical/bi.tf
+++ b/terraform/physical/bi.tf
@@ -187,6 +187,7 @@ module "rds_replica_database" {
   port                        = 3306
   instance_class              = data.aws_rds_orderable_db_instance.default.instance_class
   max_allocated_storage       = var.rds_max_allocated_storage
+  storage_type                = "gp3"
   replicate_source_db         = module.primary_database[0].db_instance_id
   storage_encrypted           = true
   kms_key_id                  = data.aws_kms_key.rds.arn
@@ -231,6 +232,7 @@ module "dms_replica_database" {
   instance_class        = data.aws_rds_orderable_db_instance.default.instance_class
   allocated_storage     = var.rds_allocated_storage
   max_allocated_storage = var.rds_max_allocated_storage
+  storage_type          = "gp3"
   storage_encrypted     = true
   kms_key_id            = data.aws_kms_key.rds.arn
   apply_immediately     = !var.protect_resources

--- a/terraform/physical/monitoring.tf
+++ b/terraform/physical/monitoring.tf
@@ -430,7 +430,9 @@ resource "aws_lambda_function" "sns_to_slack" {
   filename      = data.archive_file.slack_sns_lambda[0].output_path
   function_name = "${local.identifier}-sns_to_slack"
   handler       = "sns_to_slack.lambda_handler"
-  runtime       = "python3.8"
+  # Same treatment as dms_restart below: arm64 + off the deprecated python3.8.
+  runtime       = "python3.12"
+  architectures = ["arm64"]
   role          = aws_iam_role.lambda_execution[0].arn
 
   source_code_hash = data.archive_file.slack_sns_lambda[0].output_base64sha256
@@ -482,7 +484,11 @@ resource "aws_lambda_function" "dms_restart" {
   filename      = data.archive_file.dms_restart_lambda[0].output_path
   function_name = "${local.identifier}-dms_restart"
   handler       = "dms_restart.lambda_handler"
-  runtime       = "python3.8"
+  # arm64: 20% cheaper, and the script is pure boto3. python3.8 was a deprecated
+  # runtime (AWS refuses new function creation on it), so fresh stacks would
+  # have failed here anyway.
+  runtime       = "python3.12"
+  architectures = ["arm64"]
   role          = aws_iam_role.lambda_execution[0].arn
 
   source_code_hash = data.archive_file.dms_restart_lambda[0].output_base64sha256

--- a/terraform/physical/rds.tf
+++ b/terraform/physical/rds.tf
@@ -133,6 +133,7 @@ module "primary_database" {
   instance_class               = data.aws_rds_orderable_db_instance.default.instance_class
   allocated_storage            = var.rds_allocated_storage
   max_allocated_storage        = var.rds_max_allocated_storage
+  storage_type                 = "gp3"
   storage_encrypted            = true
   kms_key_id                   = local.rds_kms_key_arn
   apply_immediately            = !var.protect_resources

--- a/terraform/physical/s3.tf
+++ b/terraform/physical/s3.tf
@@ -486,3 +486,47 @@ resource "aws_s3_bucket_cors_configuration" "guide_images" {
 }
 
 # - End dynamic S3 resource creation
+# FinOps hygiene on the stack-created buckets (Infracost policy): incomplete
+# multipart uploads are invisible billable storage, and both bucket families
+# are versioned, so noncurrent versions accumulate forever without a rule.
+# Guide buckets keep 90 days of noncurrent versions (customer-data oops
+# window); the access-log bucket keeps 30. Current versions are untouched.
+resource "aws_s3_bucket_lifecycle_configuration" "guide_buckets" {
+  for_each = toset(local.create_s3_bucket_names)
+
+  bucket = aws_s3_bucket.guide_buckets[each.key].id
+
+  rule {
+    id     = "finops-hygiene"
+    status = "Enabled"
+
+    filter {}
+
+    abort_incomplete_multipart_upload {
+      days_after_initiation = 7
+    }
+
+    noncurrent_version_expiration {
+      noncurrent_days = 90
+    }
+  }
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "logging_bucket" {
+  bucket = aws_s3_bucket.logging_bucket.id
+
+  rule {
+    id     = "finops-hygiene"
+    status = "Enabled"
+
+    filter {}
+
+    abort_incomplete_multipart_upload {
+      days_after_initiation = 7
+    }
+
+    noncurrent_version_expiration {
+      noncurrent_days = 30
+    }
+  }
+}


### PR DESCRIPTION
Remediates the Infracost FinOps policy failures that surfaced on infra-live#113 (first full-plan evaluation of a v7.7.x stack):

- **RDS gp2 -> gp3** on the primary and both BI replica module calls. Online, in-place storage modification; ~20% cheaper per GB.
- **Lambdas to arm64 + python3.12**: both inline functions are pure stdlib+boto3. Bonus fix: python3.8 is a deprecated runtime AWS refuses to CREATE new functions on, so any fresh stack would have failed at these resources.
- **S3 lifecycle rules** on stack-created buckets: abort incomplete multipart uploads after 7 days; expire noncurrent object versions after 90 days (guide buckets, customer-data oops window) / 30 days (access-log bucket). Current versions untouched. The four adopted 3M donor buckets are not TF-managed here and are unaffected.

Deliberately NOT remediated: the "mysql 8.0 extended support" violation - the honest fix is per-env (3m gets it via the planned Aurora migration; other RDS envs need their own 8.4/aurora decision), not a module default flip that would surprise-major-upgrade the fleet.

Fleet impact: every env picks these up on its next infra_version bump; all three changes are in-place/non-disruptive.