### PR TITLE
fix(physical): archive noncurrent guide-bucket versions instead of deleting

### DIFF
--- a/terraform/physical/s3.tf
+++ b/terraform/physical/s3.tf
@@ -489,8 +489,12 @@ resource "aws_s3_bucket_cors_configuration" "guide_images" {
 # FinOps hygiene on the stack-created buckets (Infracost policy): incomplete
 # multipart uploads are invisible billable storage, and both bucket families
 # are versioned, so noncurrent versions accumulate forever without a rule.
-# Guide buckets keep 90 days of noncurrent versions (customer-data oops
-# window); the access-log bucket keeps 30. Current versions are untouched.
+# Guide buckets hold customer content, so superseded/deleted versions are
+# NEVER expired - they move to Deep Archive after 30 noncurrent days and stay
+# recoverable indefinitely (~$1/TB-mo; MPC customers store <1TB, so the undo
+# outweighs the pennies). Objects under the 128K transition minimum just stay
+# on standard storage, which is cheaper than archiving them anyway. The
+# access-log bucket keeps hard deletion. Current versions are untouched.
 resource "aws_s3_bucket_lifecycle_configuration" "guide_buckets" {
   for_each = toset(local.create_s3_bucket_names)
 
@@ -506,8 +510,9 @@ resource "aws_s3_bucket_lifecycle_configuration" "guide_buckets" {
       days_after_initiation = 7
     }
 
-    noncurrent_version_expiration {
-      noncurrent_days = 90
+    noncurrent_version_transition {
+      noncurrent_days = 30
+      storage_class   = "DEEP_ARCHIVE"
     }
   }
 }


### PR DESCRIPTION
Amends #247 per review: the guide buckets hold long-lived customer assets, so the 90-day noncurrent-version hard delete becomes a 30-day transition to Deep Archive with NO expiration. Recovery from late-discovered overwrites/deletes stays possible indefinitely at ~$1/TB-month; MPC customers store well under 1TB. Sub-128K noncurrent objects stay on standard storage (transition minimum), which is cheaper than archiving them anyway. The access-log bucket keeps its 30-day hard delete.