### PR TITLE
feat(logical): datadog apm + continuous profiler behind enable_datadog

### DIFF
--- a/terraform/logical/README.md
+++ b/terraform/logical/README.md
@@ -44,6 +44,7 @@ No modules.
 | [aws_iam_role_policy.flux_source_ecr_read](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [azurerm_key_vault_secret.app](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret) | resource |
 | [helm_release.cert_manager](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
+| [helm_release.datadog](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 | [helm_release.envoy_gateway](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 | [helm_release.external_dns](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 | [helm_release.external_secrets](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
@@ -74,12 +75,14 @@ No modules.
 | [kubernetes_manifest.nodepool_spot](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/manifest) | resource |
 | [kubernetes_namespace_v1.app](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/namespace_v1) | resource |
 | [kubernetes_namespace_v1.cert_manager](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/namespace_v1) | resource |
+| [kubernetes_namespace_v1.datadog](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/namespace_v1) | resource |
 | [kubernetes_namespace_v1.flux_system](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/namespace_v1) | resource |
 | [kubernetes_namespace_v1.istio_system](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/namespace_v1) | resource |
 | [kubernetes_namespace_v1.ratelimit_redis](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/namespace_v1) | resource |
 | [kubernetes_network_policy_v1.ratelimit_redis](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/network_policy_v1) | resource |
 | [kubernetes_role_binding_v1.dozuki_subsite_role_binding](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/role_binding_v1) | resource |
 | [kubernetes_role_v1.dozuki_subsite_role](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/role_v1) | resource |
+| [kubernetes_secret_v1.datadog_api_key](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret_v1) | resource |
 | [kubernetes_secret_v1.flux_ghcr_pull](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret_v1) | resource |
 | [kubernetes_secret_v1.flux_slack_webhook](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret_v1) | resource |
 | [kubernetes_secret_v1.flux_values](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret_v1) | resource |
@@ -131,6 +134,7 @@ No modules.
 | [external_external.ops_htpasswd_hash](https://registry.terraform.io/providers/hashicorp/external/latest/docs/data-sources/external) | data source |
 | [kubectl_file_documents.envoy_gateway_crds](https://registry.terraform.io/providers/alekc/kubectl/2.1.5/docs/data-sources/file_documents) | data source |
 | [kubernetes_service_v1.envoy_proxy_azure](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/data-sources/service_v1) | data source |
+| [vault_kv_secret_v2.datadog](https://registry.terraform.io/providers/hashicorp/vault/latest/docs/data-sources/kv_secret_v2) | data source |
 
 ## Inputs
 
@@ -163,6 +167,7 @@ No modules.
 | <a name="input_eks_cluster_id"></a> [eks\_cluster\_id](#input\_eks\_cluster\_id) | ID of EKS cluster for app provisioning | `string` | n/a | yes |
 | <a name="input_enable_bi"></a> [enable\_bi](#input\_enable\_bi) | Whether to deploy resources for BI, a replica database, a DMS task, and a Kafka cluster | `bool` | `false` | no |
 | <a name="input_enable_dashboards"></a> [enable\_dashboards](#input\_enable\_dashboards) | Turns on the dozuki chart's shared Grafana dashboards subchart (dashboards.enabled) and the dozuki-operator's per-subsite Grafana-org provisioning (dozuki-operator.grafana.url). Generates and seeds the "grafana" Vault/Key Vault secret (jwt signing secret + admin credentials) this layer's ESO ExternalSecrets read - no manual secret seeding required. Requires chart\_version >= 1.0.0 and the bundled dozuki-operator >= 4.0.0 (older pins silently no-op on dozuki-operator.grafana.url). | `bool` | `false` | no |
+| <a name="input_enable_datadog"></a> [enable\_datadog](#input\_enable\_datadog) | Installs the Datadog agent (lean: APM trace intake + SSI library injection + continuous profiler only) and instruments the monolith PHP pods. Dozuki-internal observability for MPC stacks - never enable on CloudPrem customer installs. AWS only; reads the API key from Vault secret/dozuki/global/datadog. See datadog.tf. | `bool` | `false` | no |
 | <a name="input_enable_webhooks"></a> [enable\_webhooks](#input\_enable\_webhooks) | This option will spin up a managed Kafka & Redis cluster to support private webhooks. | `bool` | `false` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | Environment of the application | `string` | `"dev"` | no |
 | <a name="input_external_dns_sa_name"></a> [external\_dns\_sa\_name](#input\_external\_dns\_sa\_name) | external-dns service account name (must match the AWS role trust subject). | `string` | `"external-dns"` | no |

--- a/terraform/logical/datadog.tf
+++ b/terraform/logical/datadog.tf
@@ -1,0 +1,229 @@
+# ---------------------------------------------------------------------------
+# Datadog agent: APM + Continuous Profiler for the monolith (MPC-internal)
+# ---------------------------------------------------------------------------
+#
+# Gated hard off by default: this is Dozuki-internal observability, never part
+# of the CloudPrem customer product. Only MPC stacks flip enable_datadog, and
+# only on AWS (the flag is folded with var.cloud below so an Azure stack that
+# sets it gets nothing rather than a broken aws_eks_cluster index).
+#
+# Deliberately lean install. Log aggregation and container metrics stay on
+# CloudWatch/Container Insights; Datadog's job here is trace intake, the
+# admission-controller library injection (Single Step Instrumentation), and
+# the continuous profiler. Everything else the chart enables by default is
+# flipped off so we don't ship (and pay for) a second copy of telemetry we
+# already collect. The node agent daemonset itself cannot be disabled - every
+# node bills as a Datadog infra host; that is the floor for SSI.
+#
+# SSI scoping: when instrumentation.targets is non-empty the cluster agent
+# ONLY injects pods matching a target - there is no instrument-everything
+# fallback (that default is synthesized only when targets is empty). So the
+# PHP monolith pods listed below get dd-trace-php and nothing else in the
+# cluster is touched: web-nextjs keeps its Sentry tracing untouched and the
+# subchart workloads (opensearch, seaweedfs, grafana, ...) stay clean.
+# Targets match first-wins and configs do NOT merge across targets, which is
+# why each target repeats the shared DD_* config.
+#
+# The chart must NOT install into the app namespace: SSI never instruments
+# the agent's own namespace, so it gets a dedicated "datadog" one.
+
+locals {
+  # enable_datadog is the per-stack switch; AWS-only for now (agent works on
+  # AKS but nothing Azure-side is wired or tested).
+  datadog_enabled = var.enable_datadog && var.cloud == "aws"
+
+  datadog_chart_version = "3.231.2" # agent + cluster agent 7.80.1
+  datadog_site          = "datadoghq.com"
+
+  # env: is the primary APM dimension; customer-environment matches how we
+  # name stacks everywhere else (dev-min, ...).
+  datadog_env = "${var.customer}-${var.environment}"
+
+  # Shared per-target tracer config. Profiling "auto" is Datadog's
+  # recommended value under SSI (profiles only eligible processes).
+  datadog_php_base_configs = [
+    { name = "DD_ENV", value = local.datadog_env },
+    { name = "DD_PROFILING_ENABLED", value = "auto" },
+  ]
+}
+
+# API key lives at secret/dozuki/global/datadog (field api_key), populated
+# out-of-band with `vault kv put` on 2026-07-15. There is deliberately NO
+# vault-config placeholder resource for it: creating vault_kv_secret_v2 over
+# an already-populated path writes an empty version on top (ignore_changes
+# only protects existing state, not creation).
+data "vault_kv_secret_v2" "datadog" {
+  count = local.datadog_enabled ? 1 : 0
+
+  mount = "secret"
+  name  = "dozuki/global/datadog"
+}
+
+resource "kubernetes_namespace_v1" "datadog" {
+  count = local.datadog_enabled ? 1 : 0
+
+  metadata {
+    name = "datadog"
+  }
+}
+
+# The chart reads the key from an existing secret (key name "api-key" is the
+# chart's contract). Terraform-managed rather than ESO: the agent is infra
+# tooling scoped to this stack, and the secret must exist before the release
+# installs (agent pods mount it at start), which rules out the
+# create_namespace + post-release-secret pattern envoy-gateway uses.
+resource "kubernetes_secret_v1" "datadog_api_key" {
+  count = local.datadog_enabled ? 1 : 0
+
+  metadata {
+    name      = "datadog-api-key"
+    namespace = kubernetes_namespace_v1.datadog[0].metadata[0].name
+  }
+
+  data = {
+    "api-key" = data.vault_kv_secret_v2.datadog[0].data["api_key"]
+  }
+}
+
+resource "helm_release" "datadog" {
+  count = local.datadog_enabled ? 1 : 0
+
+  name       = "datadog"
+  namespace  = kubernetes_namespace_v1.datadog[0].metadata[0].name
+  repository = "https://helm.datadoghq.com"
+  chart      = "datadog"
+  version    = local.datadog_chart_version
+
+  # Same Auto Mode headroom as envoy-gateway: the cluster-agent Deployment can
+  # itself be what triggers node provisioning, and 300s is too tight for a
+  # Karpenter cold start.
+  timeout = 600
+  wait    = true
+
+  values = [yamlencode({
+    # Declarative SSI works with Remote Config off; RC only matters for
+    # UI/Fleet-Automation-driven enablement, which we don't want competing
+    # with terraform.
+    remoteConfiguration = {
+      enabled = false
+    }
+
+    datadog = {
+      site                 = local.datadog_site
+      apiKeyExistingSecret = kubernetes_secret_v1.datadog_api_key[0].metadata[0].name
+
+      # REQUIRED on EKS Auto Mode: pods can't reach IMDS (hop limit locked to
+      # 1), so cluster-name autodetection fails in the cluster agent.
+      clusterName = data.aws_eks_cluster.main[0].name
+
+      tags = ["env:${local.datadog_env}"]
+
+      # ---- lean: flip the chart defaults that are on ----
+      collectEvents = false
+      kubeStateMetricsCore = {
+        enabled = false
+      }
+      clusterChecks = {
+        enabled = false
+      }
+      orchestratorExplorer = {
+        enabled = false
+      }
+      processAgent = {
+        processCollection   = false
+        processDiscovery    = false
+        containerCollection = false
+      }
+      # Already off by default; pinned so a chart bump can't silently start
+      # double-shipping logs we keep in CloudWatch.
+      logs = {
+        enabled             = false
+        containerCollectAll = false
+      }
+      networkMonitoring = {
+        enabled = false
+      }
+      serviceMonitoring = {
+        enabled = false
+      }
+      sbom = {
+        containerImage = { enabled = false }
+        host           = { enabled = false }
+      }
+
+      apm = {
+        socketEnabled = true  # trace + profile intake over UDS
+        portEnabled   = false # no hostPort 8126
+        instrumentation = {
+          enabled = true
+          language_detection = {
+            enabled = false # php is pinned explicitly per target
+          }
+          # queueworker first: first match wins, and it needs the two extra
+          # long-running-CLI settings (one trace per beanstalkd job instead
+          # of one unbounded never-flushed trace per worker process).
+          targets = [
+            {
+              name              = "dozuki-queueworker"
+              namespaceSelector = { matchNames = [local.k8s_namespace_name] }
+              podSelector       = { matchLabels = { app = "queueworker" } }
+              ddTraceVersions   = { php = "1" }
+              ddTraceConfigs = concat(local.datadog_php_base_configs, [
+                { name = "DD_SERVICE", value = "dozuki-queueworker" },
+                { name = "DD_TRACE_GENERATE_ROOT_SPAN", value = "0" },
+                { name = "DD_TRACE_AUTO_FLUSH_ENABLED", value = "1" },
+              ])
+            },
+            {
+              name              = "dozuki-app"
+              namespaceSelector = { matchNames = [local.k8s_namespace_name] }
+              podSelector       = { matchLabels = { app = "app" } }
+              ddTraceVersions   = { php = "1" }
+              ddTraceConfigs = concat(local.datadog_php_base_configs, [
+                { name = "DD_SERVICE", value = "dozuki-app" },
+              ])
+            },
+            {
+              name              = "dozuki-crond"
+              namespaceSelector = { matchNames = [local.k8s_namespace_name] }
+              podSelector       = { matchLabels = { app = "crond" } }
+              ddTraceVersions   = { php = "1" }
+              ddTraceConfigs = concat(local.datadog_php_base_configs, [
+                { name = "DD_SERVICE", value = "dozuki-crond" },
+              ])
+            },
+          ]
+        }
+      }
+    }
+
+    # Both default true and both required for SSI (the chart hard-fails
+    # without them) - pinned so nobody "leans" them off later. The admission
+    # webhook keeps failurePolicy Ignore: on Auto Mode scale-from-zero a pod
+    # racing the webhook starts uninstrumented instead of being blocked.
+    clusterAgent = {
+      enabled = true
+      admissionController = {
+        enabled = true
+      }
+    }
+
+    providers = {
+      eks = {
+        ec2 = {
+          # Must stay false on Auto Mode: it hostPath-mounts cloud-init's
+          # instance-id file, which doesn't exist on Bottlerocket nodes, and
+          # agent pods fail to mount.
+          useHostnameFromFile = false
+        }
+      }
+    }
+  })]
+
+  depends_on = [
+    kubernetes_secret_v1.datadog_api_key,
+    # Nodes exist only after cert-manager forces the first provisioning on a
+    # fresh Auto Mode cluster (same reason the cloudwatch addon waits).
+    helm_release.cert_manager,
+  ]
+}

--- a/terraform/logical/kubernetes.tf
+++ b/terraform/logical/kubernetes.tf
@@ -449,58 +449,31 @@ resource "aws_eks_addon" "cloudwatch_observability" {
   resolve_conflicts_on_create = "OVERWRITE"
   resolve_conflicts_on_update = "OVERWRITE"
 
-  # Keep Application Signals away from workloads it cannot help.
+  # Application Signals "Auto-monitor" defaults ON since addon v5.0.0: the
+  # bundled OTel operator webhook auto-injects ADOT SDKs + instrumentation
+  # annotations into every workload (the reason ratelimit.tf ignores template
+  # annotations, and why web-nextjs/grafana pods carry an ADOT SDK nobody
+  # asked for), and the agent exports the resulting traces to X-Ray, which
+  # nothing reads (no dashboards, alarms, SLOs, or custom groups in any
+  # account). APM is Datadog's job (datadog.tf), so auto-monitor goes off.
+  # Container Insights metrics and Fluent Bit log collection are independent
+  # of this key and keep working. This is the only opt-out valid on BOTH the
+  # 5.x and 6.x addon schemas (the fleet is mixed); once every stack is on
+  # 6.x, add {"applicationSignals":{"enabled":false}} to also strip the
+  # app-signals pipelines from the agent config. Already-injected pods keep
+  # their ADOT SDK until restarted.
   #
-  # autoMonitor.monitorAllServices defaults to TRUE, so the operator's mutating webhook
-  # stamps instrumentation.opentelemetry.io/inject-<lang>="true" onto every pod at
-  # admission — one init container per enabled language, each with CPU/memory requests.
-  #
-  # Excluding here rather than per-pod: one declarative place, no support needed from the
-  # (vendored, third-party) subcharts, and auto-monitoring stays ON for everything else in
-  # the namespace, so the monolith is still instrumented.
-  #
-  # The monitoring stack is excluded for EVERY language, not just nodejs. autoMonitor
-  # injects one init container per enabled language into every pod it matches, each with
-  # CPU and memory requests. prometheus-node-exporter is a single Go binary that can use
-  # none of them, and it is a DAEMONSET: its pod carries a nodeAffinity pinning it to one
-  # specific node, so it cannot be rescheduled elsewhere when that node is full. Four
-  # unusable init containers were enough to make it unschedulable:
-  #
-  #   0/6 nodes are available: 1 Insufficient cpu, 1 Insufficient memory,
-  #   5 node(s) didn't satisfy plugin(s) [NodeAffinity]
-  #
-  # and because the HelmRelease runs with disableWait = false, helm waited on that one
-  # pod for its full 4h30m timeout - the release never reached Ready, on every deploy.
-  # It went unnoticed because a stuck node-exporter fails nothing else: the app serves
-  # fine, and cluster-health checks treat it as non-critical.
-  #
-  # kube-state-metrics and the prometheus operator get the same treatment for the same
-  # reason (Go binaries, nothing to instrument). Application Signals stays ON for the
-  # monolith and anything else in the namespace.
+  # This replaces the per-workload autoMonitor.exclude map that briefly lived
+  # here: injected init containers (one per enabled language, each with
+  # requests) made the node-affinity-pinned prometheus-node-exporter daemonset
+  # unschedulable and stalled every deploy for helm's full 4h30m wait, and the
+  # frontegg Node 12 images crashlooped on the injected SDK's optional
+  # chaining. No injection anywhere is a superset of those excludes.
   configuration_values = jsonencode({
     manager = {
       applicationSignals = {
         autoMonitor = {
-          exclude = {
-            for lang in ["java", "nodejs", "python", "dotnet"] : lang => {
-              daemonsets = ["${local.k8s_namespace_name}/dozuki-prometheus-node-exporter"]
-              deployments = concat(
-                [
-                  "${local.k8s_namespace_name}/dozuki-kube-state-metrics",
-                  "${local.k8s_namespace_name}/dozuki-kube-prometheus-sta-operator",
-                ],
-                # The frontegg connectivity tier is nodejs-only: the injected Node.js SDK
-                # uses optional chaining, which those images' Node 12 cannot parse, so all
-                # five crashloop with "SyntaxError: Unexpected token '?'". Kept scoped to
-                # nodejs so a future JVM/python workload there would still be picked up.
-                lang != "nodejs" ? [] : [
-                  for svc in ["api-gateway", "connectors-worker", "event-service", "integrations-service", "webhook-service"] :
-                  # namespace/deployment; the release is always named "dozuki".
-                  "${local.k8s_namespace_name}/dozuki-${svc}-deployment"
-                ],
-              )
-            }
-          }
+          monitorAllServices = false
         }
       }
     }

--- a/terraform/logical/variables.tf
+++ b/terraform/logical/variables.tf
@@ -65,6 +65,12 @@ variable "subsite_gateway_api_enabled" {
   default     = false
 }
 
+variable "enable_datadog" {
+  description = "Installs the Datadog agent (lean: APM trace intake + SSI library injection + continuous profiler only) and instruments the monolith PHP pods. Dozuki-internal observability for MPC stacks - never enable on CloudPrem customer installs. AWS only; reads the API key from Vault secret/dozuki/global/datadog. See datadog.tf."
+  type        = bool
+  default     = false
+}
+
 variable "istio_mesh_state" {
   description = "Istio ambient mesh lifecycle state. disabled: nothing installed. installed: control plane + node dataplane running, NodePool startup taints active, no namespaces enrolled. permissive: dozuki/envoy-gateway-system/redis-system enrolled (mesh-to-mesh traffic is auto-mTLS, nothing rejected). strict: STRICT PeerAuthentication enforced with documented carve-outs. States are ordered supersets; walk one step per apply, forward or back. Commercial AWS only until gov phase 2."
   type        = string

--- a/terraform/physical/README.md
+++ b/terraform/physical/README.md
@@ -102,7 +102,6 @@
 | [aws_iam_role_policy_attachment.app_pod_identity_worker_kms](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.cert_manager_pod_identity](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.cloudwatch_agent_server](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
-| [aws_iam_role_policy_attachment.cloudwatch_agent_xray](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.dr_s3_replication](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.lambda_basic_execution](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.lambda_iam_alias](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |

--- a/terraform/physical/eks.tf
+++ b/terraform/physical/eks.tf
@@ -388,8 +388,8 @@ resource "aws_eks_pod_identity_association" "cert_manager" {
 # EKS Auto Mode gives nodes a deliberately minimal role (only EKS worker + ECR pull),
 # so the agent must get its CloudWatch permissions via Pod Identity. Without an
 # association the cloudwatch-agent SA falls back to the node role and every publish
-# (cloudwatch:PutMetricData, logs:PutLogEvents, xray:PutTraceSegments) is AccessDenied:
-# the ContainerInsights namespace stays empty and the node_* cluster alarms sit in
+# (cloudwatch:PutMetricData, logs:PutLogEvents) is AccessDenied: the
+# ContainerInsights namespace stays empty and the node_* cluster alarms sit in
 # INSUFFICIENT_DATA. Both the metrics agent and fluent-bit run as the cloudwatch-agent
 # SA, so one association covers metrics and logs.
 resource "aws_iam_role" "cloudwatch_agent_pod_identity" {
@@ -417,13 +417,6 @@ resource "aws_iam_role" "cloudwatch_agent_pod_identity" {
 resource "aws_iam_role_policy_attachment" "cloudwatch_agent_server" {
   role       = aws_iam_role.cloudwatch_agent_pod_identity.name
   policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/CloudWatchAgentServerPolicy"
-}
-
-# The agent's bundled OTel collector exports traces to X-Ray; without this the agent
-# logs a continuous stream of AccessDenied errors for xray:PutTraceSegments.
-resource "aws_iam_role_policy_attachment" "cloudwatch_agent_xray" {
-  role       = aws_iam_role.cloudwatch_agent_pod_identity.name
-  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/AWSXRayDaemonWriteAccess"
 }
 
 # CloudWatch Observability: the EKS ADDON itself is created in the LOGICAL layer,


### PR DESCRIPTION
Adds an opt-in, lean Datadog install for internal stacks and turns off the AWS Application Signals auto-instrumentation that was competing with it.

## What

**`enable_datadog` (default off, AWS only)** installs the datadog chart 3.231.2 into its own `datadog` namespace:

- Trace intake + admission controller + Single Step Instrumentation + continuous profiler only. Logs, events, KSM, cluster checks, orchestrator explorer, process collection and remote config are all disabled: log aggregation and container metrics stay on CloudWatch/Container Insights.
- SSI targets inject dd-trace-php (major 1, profiler on "auto") into the `app`, `queueworker` and `crond` pods and nothing else. Targets are exclusive by design: a pod matching no target is not instrumented, so web-nextjs keeps its existing Sentry tracing and subchart workloads are untouched. The queueworker target adds `DD_TRACE_GENERATE_ROOT_SPAN=0` + `DD_TRACE_AUTO_FLUSH_ENABLED=1` so each beanstalkd job flushes as its own trace.
- API key comes from Vault `secret/dozuki/global/datadog` (populated out-of-band; no vault-config placeholder on purpose, creating one over the populated path would write an empty version on top).
- Auto Mode specifics: explicit `clusterName` (pods can't reach IMDS), `useHostnameFromFile` pinned off (hostPath that doesn't exist on Bottlerocket), webhook keeps `failurePolicy: Ignore` so scale-from-zero races skip injection instead of blocking pods.

**cloudwatch-observability addon**: sets `manager.applicationSignals.autoMonitor.monitorAllServices=false`. Auto-monitor has defaulted on since addon v5.0.0 and its OTel operator webhook was injecting ADOT SDKs into workloads nobody asked to instrument (the reason for the ratelimit.tf annotation workaround), exporting traces to X-Ray that nothing reads (checked: no dashboards, alarms, SLOs, custom groups or OAM links). This key is the only opt-out valid on both the 5.x and 6.x addon schemas running in the fleet. Container Insights metrics and Fluent Bit logs are unaffected.

**physical**: drops the `AWSXRayDaemonWriteAccess` attachment from the cloudwatch-agent pod identity role. With trace export off nothing calls X-Ray, and its actions were a subset of `CloudWatchAgentServerPolicy` anyway.

## Verification

- `tofu validate` clean on logical (physical only validates through the terragrunt harness, pre-existing).
- Rendered the chart with the exact values this module produces: three SSI targets serialize in order (queueworker first), api key read from the existing secret under `api-key`, remote config env renders `false`, no log/process/orchestrator collection in the rendered manifests.
- Addon key validated against the live 5.x and 6.x schemas via `aws eks describe-addon-configuration`.

## Rollout

1. Merge, release, bump `infra_version` on the internal dev stack with `enable_datadog = true`.
2. Restart the monolith deployments (admission mutates at pod creation only); already-ADOT-injected pods also shed their SDK on the same restart.
3. Watch php-fpm memory (70M `memory_limit` headroom) and confirm traces + profiles arrive before enabling anywhere else.

SSI self-disables if PHP JIT or xdebug/pcov is present; prod images are clean (JIT off, no debug extensions).