### PR TITLE
feat(tags): Service + Customer tags, one Identifier sentinel, casing advisories

### DIFF
--- a/terraform/physical-azure/checks.tf
+++ b/terraform/physical-azure/checks.tf
@@ -1,0 +1,15 @@
+# Tag-value format advisories. Warnings, not errors, on purpose: existing
+# installs may carry legacy casing, and changing var.customer/var.environment
+# on a live stack renames the identifier, which replaces resources. New stacks
+# should use lowercase tokens so tag queries match across a fleet.
+check "tag_value_format" {
+  assert {
+    condition     = var.environment == lower(var.environment)
+    error_message = "environment '${var.environment}' is not lowercase; fleet tag queries on Environment expect lowercase tokens."
+  }
+
+  assert {
+    condition     = var.customer == lower(var.customer)
+    error_message = "customer '${var.customer}' is not lowercase; fleet tag queries on Customer expect lowercase tokens."
+  }
+}

--- a/terraform/physical-azure/main.tf
+++ b/terraform/physical-azure/main.tf
@@ -44,7 +44,7 @@ locals {
   tags = {
     Terraform   = "true"
     Project     = "mpc"
-    Service     = "cloudprem"
+    Service     = "mpc"
     Customer    = coalesce(var.customer, "dozuki")
     Identifier  = local.identifier
     Environment = var.environment

--- a/terraform/physical-azure/main.tf
+++ b/terraform/physical-azure/main.tf
@@ -44,6 +44,8 @@ locals {
   tags = {
     Terraform   = "true"
     Project     = "mpc"
+    Service     = "cloudprem"
+    Customer    = coalesce(var.customer, "dozuki")
     Identifier  = local.identifier
     Environment = var.environment
   }

--- a/terraform/physical/checks.tf
+++ b/terraform/physical/checks.tf
@@ -1,0 +1,15 @@
+# Tag-value format advisories. Warnings, not errors, on purpose: existing
+# installs may carry legacy casing, and changing var.customer/var.environment
+# on a live stack renames the identifier, which replaces resources. New stacks
+# should use lowercase tokens so tag queries match across a fleet.
+check "tag_value_format" {
+  assert {
+    condition     = var.environment == lower(var.environment)
+    error_message = "environment '${var.environment}' is not lowercase; fleet tag queries on Environment expect lowercase tokens."
+  }
+
+  assert {
+    condition     = var.customer == lower(var.customer)
+    error_message = "customer '${var.customer}' is not lowercase; fleet tag queries on Customer expect lowercase tokens."
+  }
+}

--- a/terraform/physical/main.tf
+++ b/terraform/physical/main.tf
@@ -53,7 +53,7 @@ locals {
     {
       Terraform   = "true"
       Project     = "Dozuki"
-      Service     = "cloudprem"
+      Service     = "mpc"
       Customer    = coalesce(var.customer, "dozuki")
       Identifier  = coalesce(var.customer, "Dozuki")
       Environment = var.environment

--- a/terraform/physical/main.tf
+++ b/terraform/physical/main.tf
@@ -53,6 +53,8 @@ locals {
     {
       Terraform   = "true"
       Project     = "Dozuki"
+      Service     = "cloudprem"
+      Customer    = coalesce(var.customer, "dozuki")
       Identifier  = coalesce(var.customer, "Dozuki")
       Environment = var.environment
     },

--- a/terraform/physical/modules/acm/main.tf
+++ b/terraform/physical/modules/acm/main.tf
@@ -18,7 +18,7 @@ locals {
   tags = {
     Terraform   = "true"
     Project     = "Dozuki"
-    Identifier  = coalesce(var.identifier, "NA")
+    Identifier  = coalesce(var.identifier, "Dozuki")
     Environment = var.environment
   }
 }

--- a/terraform/physical/modules/vpn/main.tf
+++ b/terraform/physical/modules/vpn/main.tf
@@ -15,7 +15,7 @@ locals {
   tags = {
     Terraform   = "true"
     Project     = "Dozuki"
-    Identifier  = coalesce(var.identifier, "NA")
+    Identifier  = coalesce(var.identifier, "Dozuki")
     Environment = var.environment
   }
 }


### PR DESCRIPTION
Tagging additions for both physical layers:

- Every resource gains `Service = "cloudprem"` and `Customer` (the `customer` input, `dozuki` when unset). `Customer`/`Environment` become the queryable attribution keys; `Identifier` stays the composite for naming.
- The `vpn` and `acm` modules used `NA` as the no-customer `Identifier` sentinel while the physical root uses `Dozuki`; they now agree on `Dozuki`. Only rendered when `bi_vpn_access` / the ACM path is enabled, and it is an in-place tag update.
- New `check` blocks warn when `environment` or `customer` is not lowercase. Deliberately warnings, not validation errors: changing either input on an existing stack renames `local.identifier`, which replaces resources, so a hard fail could strand an existing install on upgrade. New installs should use lowercase tokens so tag queries match across environments.

All changes are in-place tag updates; no renames, no replacements. Note: `tofu validate` run standalone in `terraform/physical` fails on the pre-existing aliased-provider layout (`aws.dr`/`aws.dns` are configured by the caller) on master too; `physical-azure` validates clean including the new checks.