### PR TITLE
fix(physical): drop the eks_cluster module-level depends_on

### DIFF
--- a/terraform/physical/eks.tf
+++ b/terraform/physical/eks.tf
@@ -198,7 +198,13 @@ module "eks_cluster" {
   source  = "terraform-aws-modules/eks/aws"
   version = "~> 21.0"
 
-  depends_on = [aws_iam_policy.cluster_access, aws_iam_policy.eks_worker]
+  # NO module-level depends_on here, ever. It defers EVERY data source inside
+  # the module to apply time whenever a dependency has ANY pending diff, which
+  # turns partition/caller-identity-derived attributes into (known after apply)
+  # and force-replaces the cluster's access entries and IAM policy attachments.
+  # The 2026-07-15 fleet default_tags rollout tripped exactly this on every EKS
+  # stack (the old depends_on pointed at two IAM policies that are not even
+  # module inputs - they attach to other roles, so no ordering was ever needed).
 
   # The default 15m cluster-delete timeout can be exceeded when the cluster still has
   # load-balancer/ENI resources to clean up (e.g. an automated teardown after a failed


### PR DESCRIPTION
Mechanism: module-level `depends_on` defers EVERY data source inside terraform-aws-eks to apply time whenever a dependency has any pending diff. The tag sweep put a `tags_all` diff on `aws_iam_policy.cluster_access` / `aws_iam_policy.eks_worker`, so the module's partition/caller-identity lookups went `(known after apply)`, force-replacing the cluster_creator access entry and all IAM policy attachments on every EKS stack's first post-tagging plan. On m3-qa the apply detached/reattached the policies (sub-second, recovered) and then 409'd on the access entry's create-before-destroy - the entry was never destroyed, cluster access is intact.

The two policies are not module inputs (they attach to the assumable access role and the app pod identity), so the depends_on provided no real ordering and its removal changes nothing else. Plans on a stack pinned to this release show the tag sweep as pure in-place updates.

Rollout: every EKS stack should bump to the release carrying this BEFORE confirming any post-#114 physical plan; the currently parked UNCONFIRMED plans (min, parker, sharedgov, latam...) should be discarded, not confirmed.