### PR TITLE
fix(logical): run app migration async (wait=false) so long migrations don't fail the release

### DIFF
--- a/terraform/logical/kubernetes.tf
+++ b/terraform/logical/kubernetes.tf
@@ -510,14 +510,26 @@ resource "helm_release" "app" {
   repository = "oci://${var.image_repository}/charts"
   version    = var.chart_version
 
-  # wait must be true so that on destroy, Helm waits for all resources
-  # (including custom resources with finalizers like Gateway, HTTPRoute,
-  # Certificate, ClusterIssuer) to be fully deleted before Terraform
-  # proceeds to destroy the controllers (cert-manager, envoy-gateway)
-  # that process those finalizers. Without this, controllers are torn
-  # down while custom resources still have pending finalizers, causing
-  # the namespace to hang indefinitely.
-  wait    = true
+  # wait = false: the app pods gate on the DB migration via a wait-for-migrations
+  # init container, and a large migration (a fresh cutover is hundreds of migrations
+  # across many tenant DBs) runs far longer than any apply is allowed to — the
+  # Spacelift public-pool run uses a role-chained AWS session capped at 1h. With
+  # wait = true the release blocked on those never-Ready pods, timed out, and left
+  # tls-secret unreconciled, so the gateway couldn't serve HTTPS (the usac/emea
+  # cutover failures). Not waiting decouples serving (tls-secret + gateway come up
+  # as soon as the manifests apply) from the migration (runs in-cluster on its own
+  # activeDeadlineSeconds, hours if needed). Correctness stays on the init container;
+  # a failed/slow migration leaves the app pods not-Ready and is caught by alerts,
+  # not by a failed apply.
+  #
+  # TRADEOFF (fast-follow): wait = true was previously pinned so destroy waits for
+  # finalizer'd CRs (Gateway, HTTPRoute, Certificate, ClusterIssuer) to delete before
+  # their controllers (cert-manager, envoy-gateway) are torn down. wait = false
+  # reopens that race on teardown — the namespace can hang on pending finalizers
+  # (recoverable by clearing them). The proper fix is to move the finalizer'd platform
+  # resources into their own wait = true release; tracked separately. Teardown is a
+  # rare, recoverable path; the recurring migration failure this replaces is not.
+  wait    = false
   timeout = 900
 
   # A failed install (e.g. a pod that never goes Ready before `timeout`) leaves the


### PR DESCRIPTION
## Problem
The DB migration is a regular Job in `helm_release.app`; the app/nextjs Deployments gate on it via a `wait-for-migrations` init container; and the release ran `wait = true, timeout = 900`. A large migration (a fresh cutover is hundreds of migrations across many tenant DBs) keeps the app pods in Init past the timeout — and past the 1h role-chained AWS session cap on the Spacelift public pool. The release then times out and fails, leaving `tls-secret` unreconciled, so the gateway can't serve HTTPS. This is what failed usac and emea during the cutover; each had to be recovered by running the migration by hand and re-running logical.

## Fix
`wait = false` on `helm_release.app`. The migration runs async in-cluster on its own `activeDeadlineSeconds`; `tls-secret` and the gateway come up as soon as the manifests apply; the app pods still gate on the migration via the existing init container. No apply waits on the migration, so the 1h session cap is no longer a factor. Correctness moves to the init container plus alerting (migration-Job-failed / app-replicas-unavailable) instead of a failed apply.

## Tradeoff (fast-follow)
`wait = true` was pinned so destroy waits for finalizer'd CRs (Gateway, HTTPRoute, Certificate, ClusterIssuer) to delete before their controllers are torn down. `wait = false` reopens that race on teardown — a namespace can hang on pending finalizers (recoverable by clearing them). The proper fix is to move the finalizer'd platform resources into their own `wait = true` release; tracked as a follow-up. Teardown is a rare, recoverable path; the recurring migration failure this replaces is not.

## Rollout
- Validate on 3m/qa first, then a low-risk env, before the rest via the version pin per `env.hcl`.
- Do not hot-apply to the freshly cut-over prod fleet outside the normal gated rollout.