### PR TITLE
refactor(logical): move envoy proxy Service and TLS ExternalSecret to the chart

### DIFF
--- a/terraform/logical/README.md
+++ b/terraform/logical/README.md
@@ -46,7 +46,6 @@ No modules.
 | [helm_release.external_dns](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 | [helm_release.external_secrets](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 | [kubectl_manifest.envoy_gateway_crds](https://registry.terraform.io/providers/alekc/kubectl/2.1.5/docs/resources/manifest) | resource |
-| [kubectl_manifest.tls_external_secret](https://registry.terraform.io/providers/alekc/kubectl/2.1.5/docs/resources/manifest) | resource |
 | [kubernetes_cluster_role_binding_v1.dozuki_list_role_binding](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/cluster_role_binding_v1) | resource |
 | [kubernetes_cluster_role_binding_v1.vault_auth_delegator](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/cluster_role_binding_v1) | resource |
 | [kubernetes_cluster_role_v1.dozuki_list_role](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/cluster_role_v1) | resource |
@@ -76,8 +75,6 @@ No modules.
 | [kubernetes_secret_v1.vault_auth_token](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret_v1) | resource |
 | [kubernetes_service_account_v1.eso_vault_auth](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/service_account_v1) | resource |
 | [kubernetes_service_account_v1.vault_auth](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/service_account_v1) | resource |
-| [kubernetes_service_v1.envoy_proxy](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/service_v1) | resource |
-| [kubernetes_service_v1.envoy_proxy_azure](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/service_v1) | resource |
 | [kubernetes_service_v1.ratelimit_redis](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/service_v1) | resource |
 | [kubernetes_storage_class_v1.ebs_gp3](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/storage_class_v1) | resource |
 | [random_password.dashboards_admin](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
@@ -117,6 +114,7 @@ No modules.
 | [external_external.ops_htpasswd_hash](https://registry.terraform.io/providers/hashicorp/external/latest/docs/data-sources/external) | data source |
 | [kubectl_file_documents.envoy_gateway_crds](https://registry.terraform.io/providers/alekc/kubectl/2.1.5/docs/data-sources/file_documents) | data source |
 | [kubernetes_resources.envoy_gateway_svc](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/data-sources/resources) | data source |
+| [kubernetes_service_v1.envoy_proxy_azure](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/data-sources/service_v1) | data source |
 
 ## Inputs
 

--- a/terraform/logical/kubernetes.tf
+++ b/terraform/logical/kubernetes.tf
@@ -576,7 +576,7 @@ resource "helm_release" "app" {
     { name = "tls.cert", value = local.tls_chart_rendered ? var.tls_cert : "" },
     # The chart now renders these (moved out of this layer). See the removed
     # kubernetes_service_v1.envoy_proxy above and kubectl_manifest.tls_external_secret in
-    # tls.tf. Requires a chart_version that ships these templates (>= 1.13.0); on an older
+    # tls.tf. Requires a chart_version that ships these templates (>= 1.14.0); on an older
     # chart the flags are ignored and neither renders, so bump the chart pin in the same
     # change. The proxy Service tracks the old resources' cloud gate (aws OR azure only, never
     # on-prem); the Vault TLS ExternalSecret follows the same tls_from_vault condition the

--- a/terraform/logical/kubernetes.tf
+++ b/terraform/logical/kubernetes.tf
@@ -199,75 +199,28 @@ resource "helm_release" "envoy_gateway" {
   ]
 }
 
-# Stable Service in envoy-gateway-system targeting Envoy proxy pods.
-# Proxy pods are deployed in the controller namespace, not the Gateway namespace.
-resource "kubernetes_service_v1" "envoy_proxy" {
-  count      = var.cloud == "aws" ? 1 : 0
-  depends_on = [helm_release.app]
+# The stable dozuki-envoy-proxy Service (AWS ClusterIP / Azure LoadBalancer, in
+# envoy-gateway-system) now ships in the chart (gateway.stableProxyService, set below), so
+# it renders in-release next to the Gateway it fronts. It stayed in Terraform only for
+# historical ordering; nothing here needed a physical input. The AWS TargetGroupBindings
+# below stay in Terraform - they bind to the physical NLB target-group ARN.
 
-  metadata {
-    name      = "dozuki-envoy-proxy"
-    namespace = "envoy-gateway-system"
-  }
-  spec {
-    type = "ClusterIP"
-    selector = {
-      "gateway.envoyproxy.io/owning-gateway-name"      = "dozuki-gateway"
-      "gateway.envoyproxy.io/owning-gateway-namespace" = kubernetes_namespace_v1.app.metadata[0].name
-    }
-    port {
-      name        = "https"
-      port        = 443
-      target_port = 10443
-      protocol    = "TCP"
-    }
-    port {
-      name        = "http"
-      port        = 80
-      target_port = 10080
-      protocol    = "TCP"
-    }
-  }
-}
-
-# Azure twin of the Envoy proxy Service: exposes the proxy pods directly via an
-# Azure Load Balancer instead of NLB target group bindings.
-resource "kubernetes_service_v1" "envoy_proxy_azure" {
+# Azure only: the ingress_ip output needs the LoadBalancer IP the chart's Service is assigned.
+# Read it back rather than owning the Service. depends_on the release so the read happens after
+# the Service exists; try() in the output tolerates the brief window before the LB IP lands.
+data "kubernetes_service_v1" "envoy_proxy_azure" {
   count      = var.cloud == "azure" ? 1 : 0
   depends_on = [helm_release.app]
 
-  # Azure LB uses its default TCP health probe. Do not set an HTTP
-  # health-probe-request-path annotation unless the Envoy proxy is verified to
-  # serve 200 on that path on the data ports (10443/10080) — a failing HTTP
-  # probe blackholes ingress.
   metadata {
     name      = "dozuki-envoy-proxy"
     namespace = "envoy-gateway-system"
-  }
-  spec {
-    type = "LoadBalancer"
-    selector = {
-      "gateway.envoyproxy.io/owning-gateway-name"      = "dozuki-gateway"
-      "gateway.envoyproxy.io/owning-gateway-namespace" = kubernetes_namespace_v1.app.metadata[0].name
-    }
-    port {
-      name        = "https"
-      port        = 443
-      target_port = 10443
-      protocol    = "TCP"
-    }
-    port {
-      name        = "http"
-      port        = 80
-      target_port = 10080
-      protocol    = "TCP"
-    }
   }
 }
 
 resource "kubernetes_manifest" "tgb_https" {
   count      = var.cloud == "aws" ? 1 : 0
-  depends_on = [kubernetes_service_v1.envoy_proxy]
+  depends_on = [helm_release.app] # chart creates the Service in-release; wait=true guarantees it before the binding
 
   manifest = {
     apiVersion = "eks.amazonaws.com/v1"
@@ -289,7 +242,7 @@ resource "kubernetes_manifest" "tgb_https" {
 
 resource "kubernetes_manifest" "tgb_http" {
   count      = var.cloud == "aws" ? 1 : 0
-  depends_on = [kubernetes_service_v1.envoy_proxy]
+  depends_on = [helm_release.app] # chart creates the Service in-release; wait=true guarantees it before the binding
 
   manifest = {
     apiVersion = "eks.amazonaws.com/v1"
@@ -504,7 +457,10 @@ locals {
 }
 
 resource "helm_release" "app" {
-  depends_on = [helm_release.cert_manager, helm_release.envoy_gateway, helm_release.external_secrets, kubernetes_service_account_v1.eso_vault_auth, kubernetes_secret_v1.ghcr_pull, aws_eks_addon.cloudwatch_observability, kubernetes_secret_v1.gateway_tls, helm_release.external_dns, kubernetes_secret_v1.redis_auth_eg, azurerm_key_vault_secret.app]
+  # vault_kv_secret_v2.tls: the chart now renders the tls-secret ExternalSecret (moved from
+  # tls.tf); keep the ordering the deleted resource had so a fresh seeded-Vault install seeds
+  # the cert before ESO tries to read it.
+  depends_on = [helm_release.cert_manager, helm_release.envoy_gateway, helm_release.external_secrets, kubernetes_service_account_v1.eso_vault_auth, kubernetes_secret_v1.ghcr_pull, aws_eks_addon.cloudwatch_observability, kubernetes_secret_v1.gateway_tls, helm_release.external_dns, kubernetes_secret_v1.redis_auth_eg, azurerm_key_vault_secret.app, vault_kv_secret_v2.tls]
 
   name      = "dozuki"
   namespace = kubernetes_namespace_v1.app.metadata[0].name
@@ -618,6 +574,15 @@ resource "helm_release" "app" {
     { name = "tls.enabled", value = local.tls_manual ? "true" : "false" },
     { name = "tls.externallyManaged", value = local.tls_externally_managed ? "true" : "false" },
     { name = "tls.cert", value = local.tls_chart_rendered ? var.tls_cert : "" },
+    # The chart now renders these (moved out of this layer). See the removed
+    # kubernetes_service_v1.envoy_proxy above and kubectl_manifest.tls_external_secret in
+    # tls.tf. Requires a chart_version that ships these templates (>= 1.13.0); on an older
+    # chart the flags are ignored and neither renders, so bump the chart pin in the same
+    # change. The proxy Service tracks the old resources' cloud gate (aws OR azure only, never
+    # on-prem); the Vault TLS ExternalSecret follows the same tls_from_vault condition the
+    # deleted resource used.
+    { name = "gateway.stableProxyService.enabled", value = contains(["aws", "azure"], var.cloud) ? "true" : "false" },
+    { name = "tls.vaultExternalSecret.enabled", value = local.tls_from_vault ? "true" : "false" },
 
     # --- Webhooks ---
     { name = "webhooks.enabled", value = var.enable_webhooks ? "true" : "false" },
@@ -741,10 +706,6 @@ moved {
   to   = kubernetes_storage_class_v1.ebs_gp3[0]
 }
 
-moved {
-  from = kubernetes_service_v1.envoy_proxy
-  to   = kubernetes_service_v1.envoy_proxy[0]
-}
 
 moved {
   from = kubernetes_manifest.tgb_https

--- a/terraform/logical/outputs.tf
+++ b/terraform/logical/outputs.tf
@@ -22,5 +22,5 @@ output "replicate_instructions" {
 }
 output "ingress_ip" {
   description = "Public IP of the ingress load balancer (Azure only; point DNS here)."
-  value       = var.cloud == "azure" ? try(kubernetes_service_v1.envoy_proxy_azure[0].status[0].load_balancer[0].ingress[0].ip, "") : ""
+  value       = var.cloud == "azure" ? try(data.kubernetes_service_v1.envoy_proxy_azure[0].status[0].load_balancer[0].ingress[0].ip, "") : ""
 }

--- a/terraform/logical/tls.tf
+++ b/terraform/logical/tls.tf
@@ -95,61 +95,11 @@ resource "vault_kv_secret_v2" "tls" {
   })
 }
 
-# Customer-provided TLS: sync the cert+key from Vault (secret/<tenant>/<env>/tls,
-# keys cert/key) into the tls-secret K8s Secret via ESO. The Vault entry is either
-# TF-seeded (above) or, legacy, hand-seeded (customer_tls_externally_managed). The
-# chart skips rendering tls-secret (tls.externallyManaged) and drops the
-# cert-manager Gateway annotation, leaving ESO as the sole owner. References the
-# chart-created SecretStore vault-<stack_label>; depends on the app release so
-# that SecretStore exists first.
-# kubectl_manifest, not kubernetes_manifest: the latter validates the kind
-# against the API at plan time, and on a fresh cluster the ExternalSecret CRD
-# only arrives when this same apply installs ESO, so the first plan can never
-# succeed. kubectl_manifest validates at apply, after the CRDs exist (same
-# reason the envoy gateway CRDs use it).
-resource "kubectl_manifest" "tls_external_secret" {
-  count = local.tls_from_vault ? 1 : 0
-
-  depends_on = [helm_release.external_secrets, helm_release.app, vault_kv_secret_v2.tls]
-
-  server_side_apply = true
-  force_conflicts   = true
-
-  yaml_body = yamlencode({
-    apiVersion = "external-secrets.io/v1"
-    kind       = "ExternalSecret"
-    metadata = {
-      name      = "tls-secret"
-      namespace = kubernetes_namespace_v1.app.metadata[0].name
-    }
-    spec = {
-      refreshInterval = "5m"
-      secretStoreRef = {
-        name = "vault-${local.vault_stack_label}"
-        kind = "SecretStore"
-      }
-      target = {
-        name           = "tls-secret"
-        creationPolicy = "Owner"
-        deletionPolicy = "Retain"
-        template = {
-          type = "kubernetes.io/tls"
-          data = {
-            "tls.crt" = "{{ .cert }}"
-            "tls.key" = "{{ .key }}"
-          }
-        }
-      }
-      data = [
-        {
-          secretKey = "cert"
-          remoteRef = { key = "${local.vault_env_prefix}/tls", property = "cert" }
-        },
-        {
-          secretKey = "key"
-          remoteRef = { key = "${local.vault_env_prefix}/tls", property = "key" }
-        },
-      ]
-    }
-  })
-}
+# Customer-provided TLS: the ExternalSecret that syncs cert+key from Vault into the
+# tls-secret Secret now ships in the chart (tls.vaultExternalSecret, gated on the same
+# tls_from_vault condition, set in kubernetes.tf). The chart already owns the SecretStore it
+# references, and the Vault path (<customer>/<environment>/tls) and SecretStore name
+# (vault-<customer>-<environment>) are the chart's existing ESO convention, so it reproduces
+# this exactly. The Vault entry is still seeded here (vault_kv_secret_v2.tls above) or, legacy,
+# hand-seeded. tls.externallyManaged (set in kubernetes.tf) still suppresses the chart's own
+# tls-secret and the cert-manager annotation, leaving ESO the sole owner.


### PR DESCRIPTION
> **Draft / merge-gated.** Merging this to `master` does nothing on its own - the live stacks pin `infra_version`, so it only lands when an env's `env.hcl` bumps `infra_version` + `chart_version` (>= 1.14.0). When it does land, the logical stack autodeploys (it runs behind the human-gated physical run, but a logical-only bump can no-op physical and let logical proceed). Once logical applies, it would **destroy** the live Service and TLS ExternalSecret unless the ownership handoff below is done first. Do not adopt this on any stack without that handoff.

## What

Move two app-layer resources out of `logical` and into the dozuki chart (companion helm PR #125), enabled here via `set` flags:

- Delete `kubernetes_service_v1.envoy_proxy` / `envoy_proxy_azure` → chart's `gateway.stableProxyService` (gated to aws/azure, matching the deleted resources).
- Delete `kubectl_manifest.tls_external_secret` → chart's `tls.vaultExternalSecret` (same `tls_from_vault` gate, same Vault path/SecretStore convention).
- Re-anchor the AWS `TargetGroupBinding` `depends_on` from the deleted Service onto `helm_release.app` (the chart creates the Service in-release; `wait=true` guarantees it before the binding). **The TGBs stay in Terraform** - they bind to the physical NLB target-group ARN, which does not belong in a cross-platform chart.
- The Azure `ingress_ip` output now reads the chart-created Service via a new `data.kubernetes_service_v1.envoy_proxy_azure`.
- Keep `vault_kv_secret_v2.tls` in `helm_release.app.depends_on` so a fresh seeded-Vault install seeds the cert before ESO reads it.

Net −91 lines. `tofu fmt` + `validate` clean.

## Ownership handoff (per stack, before adoption)

`state rm` does not touch Kubernetes; a plain apply here would **destroy** the live objects (and `creationPolicy: Owner` means deleting the ExternalSecret can GC `tls-secret`, the gateway cert). So adopt, don't recreate:

1. Verify the pinned chart renders byte-compatible Service + ExternalSecret. Back up `tls-secret`; record UIDs.
2. Annotate/label the **existing Service and ExternalSecret** (not `tls-secret`) with Helm ownership metadata: `app.kubernetes.io/managed-by=Helm`, `meta.helm.sh/release-name=dozuki`, `meta.helm.sh/release-namespace=<app ns>`.
3. `tofu state rm` the three resources (confirm addresses with `tofu state list`; older stacks may be pre-`count`): `kubernetes_service_v1.envoy_proxy[0]`, `kubernetes_service_v1.envoy_proxy_azure[0]`, `kubectl_manifest.tls_external_secret[0]`.
4. Apply this diff + the chart bump. Verify Helm now records both manifests, UIDs unchanged, ExternalSecret Ready, `tls-secret` intact, Service endpoints present, TGBs healthy.
