### PR TITLE
feat(logical): pass the db resource id to the chart for migration keying

### DIFF
--- a/terraform/logical/kubernetes.tf
+++ b/terraform/logical/kubernetes.tf
@@ -557,6 +557,9 @@ resource "helm_release" "app" {
     # --- Database ---
     { name = "db.host", value = local.db_master_host },
     { name = "db.user", value = local.db_master_username },
+    # Physical db identifier -> chart's migration Job name hash, so a DB replace (new
+    # identifier at the same image tag) re-runs migrations. Empty until infra-live wires it.
+    { name = "db.resourceId", value = var.db_resource_id },
     { name = "db.rdsCaCert", value = base64encode(file(local.ca_cert_pem_file)) },
     # The chart default (900s) is fine for small DBs but the Q1->Q2 forward
     # migration on a large snapshot-restored DB (3M emea/gca/usac, ~100 GB)

--- a/terraform/logical/variables.tf
+++ b/terraform/logical/variables.tf
@@ -275,6 +275,12 @@ variable "nlb_http_target_group_arn" {
   type        = string
 }
 
+variable "db_resource_id" {
+  description = "Stable identifier of the primary database (physical db_resource_id output). Passed to the chart as db.resourceId so a DB replace re-runs migrations. Defaults empty; wired from physical via infra-live. Empty keeps the migration Job name tag-only (unchanged)."
+  type        = string
+  default     = ""
+}
+
 # --- END Physical Module Passthrough Configuration (do not set or modify) --- #
 variable "cloud" {
   description = "Cloud the physical layer runs on."

--- a/terraform/physical/outputs.tf
+++ b/terraform/physical/outputs.tf
@@ -94,6 +94,11 @@ output "nlb_http_target_group_arn" {
   value       = module.nlb.target_groups["acme"].arn
 }
 
+output "db_resource_id" {
+  description = "Stable identifier of the primary database (Aurora cluster_resource_id / RDS db_instance_resource_id). Changes on every DB replace; the chart folds it into the migration Job name so a same-image DB replace re-runs migrations."
+  value       = local.db_resource_id
+}
+
 output "dr_region" {
   description = "Region the DR replication layer targets (empty when DR disabled)."
   value       = var.enable_dr ? var.dr_region : ""


### PR DESCRIPTION
## What

Plumb the primary database's stable identifier through to the chart:
- **physical** outputs `db_resource_id` (Aurora `cluster_resource_id` / RDS `db_instance_resource_id` - already computed in `db.tf`).
- **logical** takes it as a passthrough var `db_resource_id` (default `""`) and sets `db.resourceId` on `helm_release.app`.

## Why

The chart (companion helm PR #127) now folds `db.resourceId` into the db-migrations Job name, so a **database replace at the same image tag** (a snapshot-restore to a new cluster - the 3M cutover shape) re-runs migrations instead of Helm reusing the old completed Job.

## Safety

- Defaults `""`, so this is a **no-op** until infra-live wires `db_resource_id` from physical (separate PR, uses `try()` for incremental rollout) **and** a chart version with `db.resourceId` support is pinned. Empty keeps the migration Job name tag-only (byte-identical to today); an old chart just ignores the value.
- Adding `db.resourceId` to the `set` list records one Helm revision on the next apply, but with an empty value the rendered manifests are unchanged, so no Job/pod churn.
- The first time infra-live supplies a real id (unset→set), the migration Job re-runs once. Safe - migrations are idempotent.

## Test

`tofu fmt` clean; `tofu validate` clean on both modules (only the pre-existing provider-config errors from validating without terragrunt). Codex-reviewed: `local.db_resource_id` is always validly selected (db_engine ∈ {aurora, rds}); empty default and Azure (empty) paths safe.

_Note: generated module READMEs (new output/var) may need a terraform-docs regen; the tool currently errors on a pre-existing provider-alias issue in these modules._