### PR TITLE
feat(logical): add subsite_gateway_api_enabled to flip subsites to Gateway API

### DIFF
--- a/terraform/logical/kubernetes.tf
+++ b/terraform/logical/kubernetes.tf
@@ -732,6 +732,14 @@ resource "helm_release" "app" {
     # empty when disabled — a nonempty URL would point the operator at a Grafana
     # that was never installed.
     { name = "dozuki-operator.grafana.url", value = var.enable_dashboards ? "http://dozuki-dashboards-grafana" : "" },
+    # Subsite routing mode. When true the operator reconciles a Gateway API HTTPRoute per
+    # subsite off the chart's dozuki-gateway (instead of the legacy nginx Ingress), so subsites
+    # route automatically on Envoy Gateway installs - no more hand-created wildcard HTTPRoutes.
+    # Off by default: it flips subsite routing, so enable per-env after validating (min first).
+    # Safe on GovCloud's exact-host gateway layout too (the operator no-ops there; the chart's
+    # own routes already serve every subsite host). Requires an operator subchart >= the version
+    # that ships gatewayAPI.enabled; older subcharts ignore this value.
+    { name = "dozuki-operator.gatewayAPI.enabled", value = var.subsite_gateway_api_enabled ? "true" : "false" },
 
     ],
     # Per-env web-nextjs env vars (service API URLs etc.); merge into the chart's

--- a/terraform/logical/variables.tf
+++ b/terraform/logical/variables.tf
@@ -55,6 +55,12 @@ variable "enable_dashboards" {
   default     = false
 }
 
+variable "subsite_gateway_api_enabled" {
+  description = "Switches subsite routing to Gateway API HTTPRoutes: the dozuki-operator reconciles one HTTPRoute per subsite off the chart's dozuki-gateway instead of the legacy nginx Ingress, so subsites route automatically on Envoy Gateway installs (no hand-created wildcard HTTPRoutes). Off by default - it changes subsite routing behavior, so enable per-env after validating. Requires a bundled dozuki-operator >= the version that ships gatewayAPI.enabled (older pins silently ignore it). Safe on GovCloud's exact-host gateway layout (the operator no-ops there)."
+  type        = bool
+  default     = false
+}
+
 variable "istio_mesh_state" {
   description = "Istio ambient mesh lifecycle state. disabled: nothing installed. installed: control plane + node dataplane running, NodePool startup taints active, no namespaces enrolled. permissive: dozuki/envoy-gateway-system/redis-system enrolled (mesh-to-mesh traffic is auto-mTLS, nothing rejected). strict: STRICT PeerAuthentication enforced with documented carve-outs. States are ordered supersets; walk one step per apply, forward or back. Commercial AWS only until gov phase 2."
   type        = string


### PR DESCRIPTION
## What

Adds `subsite_gateway_api_enabled` (bool, default false), which sets `dozuki-operator.gatewayAPI.enabled` on the app release.

## Why

When on, the dozuki-operator reconciles one Gateway API HTTPRoute per subsite off the chart's `dozuki-gateway`, instead of the legacy nginx Ingress. That retires the **manual wildcard HTTPRoutes** that had to be hand-created on every Envoy Gateway stack for subsites to route (the source of the manual subsite work during the 3M cutover).

## Safety

- **Default false** - it changes subsite routing behavior, so enable **per-env after validating** (min first, then 3M, then fleet).
- **Inert** until the bundled `dozuki-operator` subchart ships `gatewayAPI.enabled` (companion helm subchart bump) and a chart version with it is pinned; older subcharts ignore the value.
- **Safe on GovCloud** (exact-host gateway layout): the operator no-ops there - the chart's own routes already serve every subsite host.

## Companion changes

- Operator #26 (merged) ships the capability, default-off, hardened.
- helm: bump the `dozuki-operator` subchart pin to the release that includes #26 (in progress).