### PR TITLE
feat(logical): enable the in-cluster site-FQDN redirect on meshed envs

### DIFF
--- a/terraform/logical/kubernetes.tf
+++ b/terraform/logical/kubernetes.tf
@@ -679,6 +679,11 @@ resource "helm_release" "app" {
 
     # --- Monitoring ---
     { name = "monitoring.enabled", value = "true" },
+    # Redirect in-cluster fetches of the app's own site FQDN to the in-cluster gateway (chart
+    # ServiceEntry) instead of hairpinning out to the public NLB. Needs the workload in the mesh,
+    # so gate on mesh enrollment; the chart's proxyProtocol.optional lets the gateway accept the
+    # header-less in-cluster connection.
+    { name = "istio.fqdnRedirect.enabled", value = local.mesh_enrolled ? "true" : "false" },
 
     # --- In-cluster services ---
     # Deliberately still set, and hardcoded true. helm #136 removes memcached.enabled from


### PR DESCRIPTION
Sets `istio.fqdnRedirect.enabled` from `local.mesh_enrolled` so the chart renders the ServiceEntry that keeps in-cluster fetches of the app's own site FQDN off the public NLB (wkhtmltopdf PDF generation otherwise hairpins out to the internet-facing LB and back). Off on non-meshed envs.

Pairs with the chart's `proxyProtocol.optional` (accepts the header-less in-cluster connection) - Dozuki/helm#140. Requires a chart version carrying both.

Adjacent to the `istio.ztunnelMonitor` set line from #277 - trivial rebase if that lands first.