### PR TITLE
fix(physical): order the S3 batch replication job after its IAM policy

### DIFF
--- a/terraform/physical/s3.tf
+++ b/terraform/physical/s3.tf
@@ -289,6 +289,18 @@ resource "aws_s3_bucket_replication_configuration" "replication" {
 resource "null_resource" "s3_replication_job_init" {
   for_each = { for k, v in local.existing_bucket_map : v.type => v }
 
+  # The triggers below reference the ROLE, which makes Terraform order this after the role and
+  # nothing else. The batch job is authorised by the POLICY, so without this depends_on the job
+  # can be submitted before the policy exists and S3 fails it asynchronously while the apply
+  # still goes green. Observed on the sharedgov build: all four jobs submitted at 12:20:54-55,
+  # the policy was created at 12:21:02, and every job ended
+  #   AccessDenied: Error occurred when preparing manifest: ...
+  #   s3:PutInventoryConfiguration required for the role.
+  # with 0 tasks run. Since S3ReplicateObject with a generated manifest is what copies the
+  # PRE-EXISTING objects (live replication only carries new writes), the silent result is a
+  # destination bucket holding nothing but post-cutover media.
+  depends_on = [aws_iam_role_policy_attachment.s3_replication]
+
   triggers = {
     aws_account      = data.aws_caller_identity.current.account_id
     aws_profile      = var.aws_profile

--- a/terraform/physical/util/create-s3-batch.sh
+++ b/terraform/physical/util/create-s3-batch.sh
@@ -20,7 +20,12 @@ if [ "${6:-}" != "" ]; then
   AWS_PREFIX="AWS_PROFILE=$6"
 fi
 
-sleep 30 # Cheap insurance against a race condition caused by the batch job being created before the IAM role is ready.
+# IAM propagation slack. This is NOT what orders the job after its permissions: the job is
+# authorised by the replication POLICY, and this sleep was calibrated against the role, which
+# Terraform creates earlier. On the sharedgov build the role existed 40s before the job and the
+# policy appeared 8s AFTER it, so every job failed AccessDenied on the manifest with 0 tasks run.
+# The ordering is enforced by the depends_on in s3.tf; keep both.
+sleep 30
 
 $AWS_PREFIX aws s3control create-job \
   --account-id "$AWS_ACCOUNT" \


### PR DESCRIPTION
## The bug

`null_resource.s3_replication_job_init` referenced the replication **role** in its `triggers`, so
Terraform ordered it after the role and nothing else. The batch job is authorised by the
**policy**, which Terraform was free to create in parallel - and did.

Timings from the sharedgov build:

| event | time |
|---|---|
| role created | 12:20:14 |
| **4 batch jobs submitted** | **12:20:54.7 - 12:20:55.4** |
| **policy created** | **12:21:02** |

All four jobs ended:

```
AccessDenied: Error occurred when preparing manifest: Access denied when accessing
arn:aws-us-gov:s3:::dozuki-prod-obj-... s3:PutInventoryConfiguration required for the role.
```

with **0 tasks run** - while the apply went green.

## Why it matters more than it looks

`S3ReplicateObject` with a generated manifest is what copies the **pre-existing** objects. Live
replication only carries new writes. So the silent outcome is a destination bucket containing
nothing but post-cutover media: on a guide platform, every historical image, PDF and document
missing, discovered after the cut.

The design doc already noted the script is `set -euo pipefail` so a *submission* failure fails the
apply, but that "the asynchronous job's completion and per-object failures" are unmonitored. This
is that gap firing.

## The fix

`depends_on = [aws_iam_role_policy_attachment.s3_replication]`.

The script's existing `sleep 30` did **not** cover this. Its comment says it guards "the batch job
being created before the IAM role is ready", and it was doing exactly that: the role existed 40s
before the job. The policy was the unordered one. The sleep stays as IAM propagation slack now that
ordering is explicit, and its comment now names which resource each mechanism covers, so the
`depends_on` is not later removed as redundant.

## Live stacks

Any stack already built with donor buckets should have its jobs re-checked:

```
aws s3control list-jobs --account-id <acct> --region <region> \
  --query 'Jobs[].[JobId,Status,ProgressSummary.NumberOfTasksSucceeded]'
```

`Failed` with 0 succeeded means the pre-existing objects were never copied. Re-running
`create-s3-batch.sh` by hand with the same arguments recovers it once the policy is in place; no
Terraform change is needed for recovery.