### PR TITLE
fix(logical): make enable_webhooks actually work

### DIFF
--- a/terraform/logical/kubernetes.tf
+++ b/terraform/logical/kubernetes.tf
@@ -754,6 +754,21 @@ resource "helm_release" "app" {
     # seeded into the "grafana" Vault/Key Vault secret's "secret" property, since
     # ESO syncs that same value into grafana.json for the app to mint tokens with.
     { name = "dashboards.jwtSecret", value = local.dashboards_jwt_secret },
+
+    # Frontegg's private Docker Hub credentials for the webhooks tier. The connectivity
+    # subchart renders the "regcred" imagePullSecret from these two values, but the
+    # chart ships LITERAL PLACEHOLDERS for them ("frontegg_docker_username" /
+    # "frontegg_docker_password" in the parent values.yaml). They are non-empty, so the
+    # chart's `required` guard passes and the secret renders — with credentials Docker
+    # Hub rejects. Every enable_webhooks deploy therefore got ImagePullBackOff / 401 on
+    # docker.io/frontegg/*, and helm_release.app never went Ready.
+    #
+    # Real values live in Vault at secret/dozuki/global/frontegg (dockerUsername /
+    # dockerPassword). Empty vars leave the chart placeholders in place, which fails at
+    # image pull exactly as before rather than changing behaviour for callers that do
+    # not set them.
+    { name = "connectivity.frontegg.images.username", value = var.frontegg_docker_username },
+    { name = "connectivity.frontegg.images.password", value = var.frontegg_docker_password },
   ]
 
   lifecycle {

--- a/terraform/logical/kubernetes.tf
+++ b/terraform/logical/kubernetes.tf
@@ -688,10 +688,14 @@ resource "helm_release" "app" {
     { name = "connectivity.event-service.database.username", value = local.db_master_username },
     { name = "connectivity.event-service.messageBroker.brokerList", value = local.msk_brokers_helm_escaped },
     { name = "connectivity.event-service.redis.host", value = "dozuki-redis-master" },
-    { name = "connectivity.event-service.redis.tls", value = "false" },
+    # type = "string" (helm --set-string) is REQUIRED here. helm's strvals parser
+    # coerces a bare false into a real boolean, and both subcharts render this through
+    # b64enc, which rejects a non-string: "wrong type for value; expected string; got
+    # bool". The chart's own default is a quoted string; only this override broke it.
+    { name = "connectivity.event-service.redis.tls", value = "false", type = "string" },
     { name = "connectivity.connectors-worker.messageBroker.brokerList", value = local.msk_brokers_helm_escaped },
     { name = "connectivity.connectors-worker.redis.host", value = "dozuki-redis-master" },
-    { name = "connectivity.connectors-worker.redis.tls", value = "false" },
+    { name = "connectivity.connectors-worker.redis.tls", value = "false", type = "string" },
 
     # --- Operator ---
     # Redirect the operator subchart to the env's registry. Its default repo is the

--- a/terraform/logical/kubernetes.tf
+++ b/terraform/logical/kubernetes.tf
@@ -466,6 +466,11 @@ locals {
   # OVERRIDES the chart config map) — all three must agree or the app reads an
   # empty/invalid host.
   memcached_host = "dozuki-memcached.${local.k8s_namespace_name}.svc.cluster.local"
+
+  # MSK bootstrap brokers, comma-escaped for helm's strvals parser (see the
+  # connectivity brokerList entries below). Empty when webhooks are off, in which
+  # case replace() is a no-op and this stays "".
+  msk_brokers_helm_escaped = replace(var.msk_bootstrap_brokers, ",", "\\,")
 }
 
 resource "helm_release" "app" {
@@ -668,18 +673,23 @@ resource "helm_release" "app" {
     { name = "dashboards.enabled", value = var.enable_dashboards ? "true" : "false" },
 
     # --- Connectivity (sunset planned) ---
-    { name = "connectivity.webhook-service.messageBroker.brokerList", value = var.msk_bootstrap_brokers },
+    # brokerList goes through helm's strvals parser, which reads a comma as the
+    # separator between key=value pairs. MSK hands back a multi-broker string
+    # ("b-1...:9092,b-2...:9092,..."), so an unescaped value makes the whole apply
+    # fail with 'key "com:9092" has no value'. Escape the commas so strvals treats
+    # them as literals. Single-broker values are unaffected.
+    { name = "connectivity.webhook-service.messageBroker.brokerList", value = local.msk_brokers_helm_escaped },
     { name = "connectivity.webhook-service.mysql.host", value = local.db_master_host },
     { name = "connectivity.webhook-service.mysql.username", value = local.db_master_username },
     { name = "connectivity.webhook-service.mongo.connectionString", value = "mongodb://dozuki-mongodb/webhooks" },
-    { name = "connectivity.integrations-service.messageBroker.brokerList", value = var.msk_bootstrap_brokers },
+    { name = "connectivity.integrations-service.messageBroker.brokerList", value = local.msk_brokers_helm_escaped },
     { name = "connectivity.integrations-service.mongo.connectionString", value = "mongodb://dozuki-mongodb/integrations" },
     { name = "connectivity.event-service.database.host", value = local.db_master_host },
     { name = "connectivity.event-service.database.username", value = local.db_master_username },
-    { name = "connectivity.event-service.messageBroker.brokerList", value = var.msk_bootstrap_brokers },
+    { name = "connectivity.event-service.messageBroker.brokerList", value = local.msk_brokers_helm_escaped },
     { name = "connectivity.event-service.redis.host", value = "dozuki-redis-master" },
     { name = "connectivity.event-service.redis.tls", value = "false" },
-    { name = "connectivity.connectors-worker.messageBroker.brokerList", value = var.msk_bootstrap_brokers },
+    { name = "connectivity.connectors-worker.messageBroker.brokerList", value = local.msk_brokers_helm_escaped },
     { name = "connectivity.connectors-worker.redis.host", value = "dozuki-redis-master" },
     { name = "connectivity.connectors-worker.redis.tls", value = "false" },
 

--- a/terraform/logical/variables.tf
+++ b/terraform/logical/variables.tf
@@ -451,6 +451,20 @@ variable "frontegg_api_token" {
   default     = ""
 }
 
+variable "frontegg_docker_username" {
+  description = "Docker Hub username for frontegg's private images (secret/dozuki/global/frontegg -> dockerUsername). Required when enable_webhooks is true: the connectivity subcharts pull docker.io/frontegg/* via an imagePullSecret named regcred. Empty disables creation of that secret."
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+variable "frontegg_docker_password" {
+  description = "Docker Hub password/token paired with frontegg_docker_username (secret/dozuki/global/frontegg -> dockerPassword)."
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
 variable "surveyjs_license_key" {
   description = "SurveyJS license key (Azure only; AWS reads Vault)."
   type        = string


### PR DESCRIPTION
Three independent bugs, each of which alone prevents `enable_webhooks = true` from deploying. Found by running the test harness's `full` config, which had never been exercised — every live stack has `enable_webhooks = false`, so none of this was reachable in practice.

Worth noting **`infra-live/_templates/env.hcl` defaults to `enable_webhooks = true`**, so a brand-new customer stack built from the template would hit all three on its first apply.

## 1. MSK broker list breaks Helm's `--set` parser

```
Failed parsing key "connectivity.webhook-service.messageBroker.brokerList"
with value b-1...:9092,b-2...:9092,b-3...:9092
key "com:9092" has no value (cannot end with ,)
```

Helm's strvals parser reads a comma as the separator between key=value pairs, so a multi-broker MSK string is unparseable. Escaped for all four `brokerList` values (`webhook-service`, `integrations-service`, `event-service`, `connectors-worker`). Single-broker values are unaffected.

## 2. `redis.tls` is coerced to a bool, then base64'd

```
event-service/templates/secret.yaml:39: at <b64enc>:
wrong type for value; expected string; got bool
```

strvals type-coerces a bare `false` into a real boolean, and both `event-service` and `connectors-worker` render `redis.tls` through `b64enc`, which rejects non-strings. The chart's own default is a quoted string — only the CPI override broke it. Fixed with `type = "string"` (`--set-string`).

Note this is the *opposite* of what you want for the 13 other bool-ish values (`aws.enabled`, `dns_validation`, …): those feed `{{ if }}` conditionals where coercion is correct. The bug only fires where a coerced bool meets `b64enc`.

## 3. The frontegg image pull secret carries placeholder credentials

The connectivity subchart renders `regcred` from `connectivity.frontegg.images.{username,password}`, but the chart ships **literal placeholder strings**:

```yaml
connectivity:
  frontegg:
    images:
      username: "frontegg_docker_username"
      password: "frontegg_docker_password"
```

Being non-empty they satisfy the chart's `required` guard, so `regcred` renders with credentials Docker Hub rejects — `ImagePullBackOff` / 401 on `docker.io/frontegg/*`, and `helm_release.app` never goes Ready.

Real credentials were already in Vault at `secret/dozuki/global/frontegg` (`dockerUsername` / `dockerPassword`); CPI simply never passed them. Now wired through `set_sensitive` as new optional variables. **Empty vars leave the chart placeholders untouched**, so behaviour is unchanged for callers that don't set them.

## Testing

Bugs 1 and 2 were reproduced and their fixes verified against chart 1.18.0 with `helm template` — `--set` reproduces the exact failure, `--set-string` renders clean, as does the full 78-entry set list. Bug 3's credentials were verified to mint a valid pull token for `frontegg/hybrid-api-gateway` before committing.

All three were found across successive real deploys into the DDVtest account.