### PR TITLE
fix(logical): make enable_bi actually work on a fresh deploy

### DIFF
--- a/terraform/logical/bi.tf
+++ b/terraform/logical/bi.tf
@@ -158,6 +158,15 @@ resource "kubernetes_job_v1" "grafana_db_create" {
     backoff_limit = 50
   }
   wait_for_completion = true
+
+  # Without this the provider's default create timeout applies, which a fresh
+  # deploy blows through: the pod has to pull mysql:9.3 from Docker Hub onto a
+  # just-provisioned node and then reach Aurora. Existing stacks never saw it —
+  # the job is only created once and isn't recreated on later applies — so it
+  # only bites brand-new BI-enabled deploys.
+  timeouts {
+    create = "15m"
+  }
 }
 
 resource "random_password" "grafana_admin" {

--- a/terraform/logical/bi.tf
+++ b/terraform/logical/bi.tf
@@ -13,9 +13,21 @@ resource "kubernetes_job_v1" "dms_start" {
       spec {
         container {
           name = "dms-start"
-          # TODO: pin to a digest and mirror into the airgap registries. ":latest" is
-          # a supply-chain/reproducibility risk; unchanged here to keep this fix scoped.
-          image = "bearengineer/awscli-kubectl:latest"
+          # Was bearengineer/awscli-kubectl:latest, which ships aws-cli 1.16.234 /
+          # botocore 1.12.224 (2019). That predates EKS Pod Identity, so every
+          # credential lookup died with:
+          #   Unsupported host '169.254.170.23'. Can only retrieve metadata from
+          #   these hosts: 169.254.170.2, localhost, 127.0.0.1
+          # 169.254.170.23 is the Pod Identity agent; 169.254.170.2 is the old ECS
+          # endpoint that botocore knew about. The job therefore could never call
+          # DMS, and because wait_for_completion is false the apply still reported
+          # success — which is why DMS silently never started and cutover envs kept
+          # having to be started by hand.
+          #
+          # alpine/k8s carries both kubectl and aws (botocore 1.35, well past the
+          # ~1.33 that added Pod Identity support) and is pinned, which also retires
+          # the ":latest" supply-chain TODO this line used to carry.
+          image = "alpine/k8s:1.31.0"
           command = [
             "/bin/sh",
             "-c",


### PR DESCRIPTION
Two bugs in the `enable_bi` path, found by running the harness's `full` config. Both only bite a **fresh** BI-enabled deploy, which is why the existing 3M MPC stacks (which do run BI) never hit them — their resources were created long ago and aren't recreated on subsequent applies.

`infra-live/_templates/env.hcl` defaults to `enable_bi = true`, so a new customer stack hits both on its first apply.

## 1. `grafana-db-create` times out at 60s

`kubernetes_job_v1.grafana_db_create` sets `wait_for_completion = true` with **no `timeouts` block**, so it inherits the provider default. The run log shows it failing at exactly `1m0s` while its pod was still pulling `mysql:9.3` from Docker Hub onto a freshly provisioned node.

On EKS Auto Mode a fresh cluster has no nodes until pods schedule, so node provisioning and image pull are both on the critical path. Added `timeouts { create = "15m" }`.

## 2. The dms-start job could never authenticate to AWS

```
Unsupported host '169.254.170.23'. Can only retrieve metadata from these hosts:
169.254.170.2, localhost, 127.0.0.1
```

The job ran `bearengineer/awscli-kubectl:latest`. I pulled that image and checked:

```
aws-cli/1.16.234 Python/2.7.16 botocore/1.12.224
```

That's from 2019 — it predates EKS Pod Identity. `169.254.170.23` is the Pod Identity agent; botocore only knew the older ECS endpoint `169.254.170.2`. So every credential lookup failed and the job never reached DMS.

**This failed silently.** `wait_for_completion = false`, so the apply reported success while DMS never started. That appears to be the root cause of a problem already recorded in this file's own comments:

> all 5 cutover envs had to be started by hand

Repinned to `alpine/k8s:1.31.0`, which carries both `kubectl` and `aws` (botocore 1.35, well past the ~1.33 that added Pod Identity support). I verified both binaries are present in that image. This also retires the `:latest` supply-chain TODO that was sitting on the old line.

## Testing

Both were observed in real deploys into DDVtest. The image's botocore version was confirmed by running the old and new images locally.

Note the DMS bug is invisible to the apply — it is only caught by the `AssertDMSRunning` validation in the companion harness PR.