### PR TITLE
fix(logical): raise the app helm timeout so a full deploy can converge

### DIFF
--- a/terraform/logical/kubernetes.tf
+++ b/terraform/logical/kubernetes.tf
@@ -490,8 +490,16 @@ resource "helm_release" "app" {
   # that process those finalizers. Without this, controllers are torn
   # down while custom resources still have pending finalizers, causing
   # the namespace to hang indefinitely.
-  wait    = true
-  timeout = 900
+  wait = true
+  # 900s covers a minimal deploy but not a full-featured one. With webhooks + BI the
+  # release carries roughly half again as many workloads — the five connectivity
+  # services plus mongodb, redis, opensearch and grafana — and on EKS Auto Mode a
+  # fresh cluster has no nodes until these pods schedule, so node provisioning and
+  # image pulls are on the critical path. A fresh `full` install was still converging
+  # at 16m when the old limit tripped, leaving the release in a failed state. Raising
+  # the ceiling does not slow a small deploy down: wait returns as soon as everything
+  # is Ready, so this only changes how long we allow a legitimately slow install.
+  timeout = 1800
 
   # A failed install (e.g. a pod that never goes Ready before `timeout`) leaves the
   # release in a "failed" state that Terraform does NOT record, so the next apply plans


### PR DESCRIPTION
`helm_release.app` used `timeout = 900` with `wait = true`. That covers a minimal deploy but not a full-featured one.

With webhooks + BI the release carries roughly half again as many workloads — the five connectivity services plus mongodb, redis, opensearch and grafana. On EKS Auto Mode a fresh cluster has **no nodes** until those pods schedule, so node provisioning and image pulls are both on the critical path.

Observed on a fresh `full` deploy: the install was still converging at **16m** when the 900s limit tripped, leaving the release in a `failed` state.

That failure state is more annoying than it looks — the resource comment right below the timeout explains that a failed install isn't recorded by Terraform, so the next apply plans a fresh install and Helm rejects it with "cannot re-use a name that is still in use". (`replace = true` handles that, but only after the wasted cycle.)

Raised to 1800s. This does **not** slow down a small deploy: `wait` returns as soon as everything is Ready, so the only thing that changes is how long we allow a legitimately slow install before declaring failure.

Split out from the other `full`-config fixes because it is not specific to webhooks or BI — it affects any sufficiently large deploy.

## Testing

Observed against real fresh deploys in DDVtest: 900s tripped at 16m with pods still coming up; the run that followed got past install and into the app tier.