### PR TITLE
feat(logical): envoy gateway 1.8.3, and keep the CRDs out of the run log

### DIFF
--- a/terraform/logical/crds/envoy-gateway-crds-1.8.3.yaml
+++ b/terraform/logical/crds/envoy-gateway-crds-1.8.3.yaml
@@ -32564,7 +32564,6 @@ spec:
                                       procMount denotes the type of proc mount to use for the containers.
                                       The default value is Default which uses the container runtime defaults for
                                       readonly paths and masked paths.
-                                      This requires the ProcMountType feature flag to be enabled.
                                       Note that this field cannot be set when spec.os.name is windows.
                                     type: string
                                   readOnlyRootFilesystem:
@@ -35165,7 +35164,7 @@ spec:
                                         A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.
                                         The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
                                         The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
-                                        The volume will be mounted read-only (ro) and non-executable files (noexec).
+                                        The volume will be mounted read-only (ro).
                                         Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.
                                         The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
                                       properties:
@@ -35339,8 +35338,7 @@ spec:
                                       description: |-
                                         portworxVolume represents a portworx volume attached and mounted on kubelets host machine.
                                         Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type
-                                        are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate
-                                        is on.
+                                        are redirected to the pxd.portworx.com CSI driver.
                                       properties:
                                         fsType:
                                           description: |-
@@ -36573,7 +36571,6 @@ spec:
                                       procMount denotes the type of proc mount to use for the containers.
                                       The default value is Default which uses the container runtime defaults for
                                       readonly paths and masked paths.
-                                      This requires the ProcMountType feature flag to be enabled.
                                       Note that this field cannot be set when spec.os.name is windows.
                                     type: string
                                   readOnlyRootFilesystem:
@@ -37886,7 +37883,6 @@ spec:
                                         procMount denotes the type of proc mount to use for the containers.
                                         The default value is Default which uses the container runtime defaults for
                                         readonly paths and masked paths.
-                                        This requires the ProcMountType feature flag to be enabled.
                                         Note that this field cannot be set when spec.os.name is windows.
                                       type: string
                                     readOnlyRootFilesystem:
@@ -40725,7 +40721,7 @@ spec:
                                         A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.
                                         The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
                                         The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
-                                        The volume will be mounted read-only (ro) and non-executable files (noexec).
+                                        The volume will be mounted read-only (ro).
                                         Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.
                                         The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
                                       properties:
@@ -40899,8 +40895,7 @@ spec:
                                       description: |-
                                         portworxVolume represents a portworx volume attached and mounted on kubelets host machine.
                                         Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type
-                                        are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate
-                                        is on.
+                                        are redirected to the pxd.portworx.com CSI driver.
                                       properties:
                                         fsType:
                                           description: |-
@@ -50136,33 +50131,45 @@ spec:
                     items:
                       description: |-
                         ExtractFrom is where to fetch the key from the coming request.
-                        Only one of header, param or cookie is supposed to be specified.
+                        Only one of headers, params or cookies must be specified.
                       properties:
                         cookies:
                           description: |-
                             Cookies is the names of the cookie to fetch the key from.
                             If multiple cookies are specified, envoy will look for the api key in the order of the list.
-                            This field is optional, but only one of headers, params or cookies is supposed to be specified.
+                            This field is optional, but only one of headers, params or cookies must be specified.
                           items:
+                            minLength: 1
                             type: string
+                          minItems: 1
                           type: array
                         headers:
                           description: |-
                             Headers is the names of the header to fetch the key from.
                             If multiple headers are specified, envoy will look for the api key in the order of the list.
-                            This field is optional, but only one of headers, params or cookies is supposed to be specified.
+                            This field is optional, but only one of headers, params or cookies must be specified.
                           items:
+                            minLength: 1
                             type: string
+                          minItems: 1
                           type: array
                         params:
                           description: |-
                             Params is the names of the query parameter to fetch the key from.
                             If multiple params are specified, envoy will look for the api key in the order of the list.
-                            This field is optional, but only one of headers, params or cookies is supposed to be specified.
+                            This field is optional, but only one of headers, params or cookies must be specified.
                           items:
+                            minLength: 1
                             type: string
+                          minItems: 1
                           type: array
                       type: object
+                      x-kubernetes-validations:
+                      - message: exactly one of headers, params, or cookies must be
+                          specified
+                        rule: '(has(self.headers) ? 1 : 0) + (has(self.params) ? 1
+                          : 0) + (has(self.cookies) ? 1 : 0) == 1'
+                    minItems: 1
                     type: array
                   forwardClientIDHeader:
                     description: |-

--- a/terraform/logical/envoy_gateway_crds.tf
+++ b/terraform/logical/envoy_gateway_crds.tf
@@ -1,12 +1,36 @@
 # Envoy Gateway CRDs — managed here, NOT by the envoy_gateway helm_release.
 #
 # Why: Helm never upgrades CRDs that live in a chart's crds/ dir on `helm upgrade`
-# (a deliberate Helm limitation), and EG's separate gateway-crds-helm chart can't
-# be a helm_release because its rendered CRDs exceed Helm's 1MB release-secret
-# limit. So on an EG version bump the chart's NEW CRDs never apply, the 1.8.x
-# controller can't reconcile, and the release's `wait` times out (the failure that
-# hit mpc-dev-min-logical). EG's own docs say: apply the CRDs first, then upgrade
-# the gateway. We do exactly that, in-band, so there's no out-of-band manual step.
+# (a deliberate Helm limitation, unchanged in Helm 4 — its --skip-crds help still
+# reads "installed if not already present"). So on an EG version bump the chart's NEW
+# CRDs never apply, the 1.8.x controller can't reconcile, and the release's `wait`
+# times out (the failure that hit mpc-dev-min-logical). EG's own docs say: apply the
+# CRDs first, then upgrade the gateway. We do exactly that, in-band, so there's no
+# out-of-band manual step.
+#
+# Upstream's answer to the same problem is the separate gateway-crds-helm chart, which
+# holds the CRDs as TEMPLATES rather than in a crds/ dir, so Helm does upgrade them.
+# We cannot use it, and neither can anyone else on the default storage driver: Helm
+# stores a release as base64(gzip(json)) in a Secret, and Kubernetes hard-rejects Secret
+# data over 1048576 DECODED bytes ("data: Too long: may not be more than 1048576
+# bytes"). Because gateway-crds-helm's CRDs are templates they are stored twice, as
+# base64 template source in the chart record AND as the rendered manifest, which lands
+# at roughly 1.6 to 1.85MB decoded, 1.5x to 1.8x over the ceiling. That is a Helm
+# storage limit, not a Terraform one: installing it by hand fails the same way. Only
+# HELM_DRIVER=sql escapes it, which is not worth a Postgres dependency for CRDs.
+#
+# This is upstream envoyproxy/gateway#6105, open since 2025-05 and still live. The
+# maintainer's own recommendation there is `helm template` plus an apply, which is
+# exactly what this file does, wired in-band so there is no manual step. Note that the
+# chart's crds.gatewayAPI.enabled=false escape hatch does NOT get you under the limit
+# (reported against 1.8.1 in that issue): Helm stores every template file in the chart
+# whether it rendered or not, so the payload is there regardless of the toggles.
+# Flux users have no workaround at all, having no templating step.
+#
+# skip_crds below is also what keeps THIS release's record small, which is a second
+# reason to keep it. Measured on mpc-dev-min-logical: the pre-#201 revisions carry the
+# 4.4MB crds/ payload in the chart record and sit at 1,035,308 decoded bytes (98.7% of
+# the limit), while every revision since is 27,276 bytes (2.6%).
 #
 # Mechanism: the kubectl provider server-side-applies the vendored CRD set before
 # the helm_release (depends_on). Server-side apply is REQUIRED — these CRDs are too

--- a/terraform/logical/envoy_gateway_crds.tf
+++ b/terraform/logical/envoy_gateway_crds.tf
@@ -21,10 +21,17 @@
 #     | awk 'BEGIN{RS="\n---\n"} /kind: CustomResourceDefinition/{print "---"; print}' \
 #     > crds/envoy-gateway-crds-<ver>.yaml
 # (experimental channel matches what gateway-helm bundles — 20 CRDs; the
-# ValidatingAdmissionPolicy is templated by gateway-helm itself, so we keep only CRDs.)
+# ValidatingAdmissionPolicy is templated by gateway-helm itself, so we keep only CRDs.
+# It lives in the chart's crds SUBCHART templates/ dir, not in a crds/ dir, which is
+# why skip_crds on the release does not suppress it — see the crds.enabled note below.)
+#
+# Do NOT set the chart's crds.enabled=false (added in EG 1.8.2). It looks like the
+# right switch for "CRDs are managed separately", but it disables the whole crds
+# subchart, which also renders the Gateway API safe-upgrade ValidatingAdmissionPolicy
+# and its Binding. skip_crds already skips the CRD payload while keeping that policy.
 
 locals {
-  envoy_gateway_version = "1.8.1"
+  envoy_gateway_version = "1.8.3"
 }
 
 data "kubectl_file_documents" "envoy_gateway_crds" {
@@ -37,4 +44,19 @@ resource "kubectl_manifest" "envoy_gateway_crds" {
 
   server_side_apply = true
   force_conflicts   = true
+
+  # Keeps the CRD schemas out of the run log. yaml_body is already sensitive in the
+  # provider schema, but the computed yaml_body_parsed is not, so on any create or
+  # update of these 20 resources it printed each CRD in full: the first gov logical
+  # build was 120k lines / 16MB of plan output, against 1.9k lines for the same stack
+  # once the CRDs were unchanged. sensitive_fields obfuscates the named subtree in
+  # yaml_body_parsed, so the plan shows which CRD is changing (apiVersion, kind,
+  # metadata) without the schema body. spec is masked as a whole because the provider
+  # only supports masking map values, not list members, and the schemas hang off
+  # spec.versions[].schema.
+  #
+  # This is display-only: it does not change what is applied (that is ignore_fields)
+  # and drift detection still works off yaml_body/yaml_incluster, which both change
+  # normally. Review CRD content in the git diff of the vendored file, not the plan.
+  sensitive_fields = ["spec"]
 }


### PR DESCRIPTION
Bumps Envoy Gateway 1.8.1 to 1.8.3 (latest stable, released 2026-07-22) and stops the
vendored CRDs flooding the run log.

## The version bump

Two patch releases inside the 1.8 line, not a minor. The surface is small and I checked
it rather than trusting the release notes:

- **CRDs: 3 of 20 changed.** `backendtrafficpolicies` int32 to int64 (widening).
  `envoyproxies` upstream podspec doc-strings only. `securitypolicies` tightened
  validation (`minItems: 1` plus a CEL rule) landing **only** on
  `apiKeyAuth.extractFrom`, which we do not use. `jwt.providers.extractFrom`, which the
  dashboards SecurityPolicy does use, is byte-identical between versions.
- **Chart templates: two lines**, both image fallback tags in `_helpers.tpl`.
- **Values: two image tags** plus the new `crds.enabled` key.
- Regenerated with the command already in the file header, unmodified: 20 CRDs, same
  set of names, 8 bytes larger.

Worth having:

- 1.8.2 separates listener-programmed state from route acceptance, so an HTTPRoute no
  longer reports `Accepted: False` purely because its listener has no TLS cert yet.
  That is the state a stack sits in mid-cutover, before the DNS flip, which previously
  made the pre-flip route validation read as failure-shaped noise.
- 1.8.3 stops unreferenced Secret writes triggering a full reconcile whenever the
  HTTPRouteFilter CRD is installed. Every Secret write in the cluster used to enqueue
  one, and we run ESO plus cert-manager, both frequent Secret writers.

## The run-log fix

`yaml_body` is already `sensitive` in the provider schema, but the computed
`yaml_body_parsed` is not, so any create or update of these 20 resources printed each
CRD in full as a heredoc. Measured on real runs of the same stack:

| run | lines | bytes |
|---|---|---|
| first build, CRDs created | 120,352 | 16 MB |
| later run, CRDs unchanged | 1,872 | 238 KB |

`sensitive_fields = ["spec"]` obfuscates that subtree in `yaml_body_parsed`, so the plan
still shows which CRD is changing (apiVersion, kind, metadata) without the schema body.
`spec` is masked whole because the provider only supports masking map values, not list
members, and the schemas hang off `spec.versions[].schema`.

Display only: it is not `ignore_fields`, so what gets applied is unchanged, and drift
detection still works off `yaml_body` / `yaml_incluster`. CRD content stays reviewable in
the git diff of the vendored file, which is the right place for it.

This matters now because bumping the version rewrites all 20 CRDs, so without it every
env's next apply would produce the 16 MB variant.

## Also documented, not changed

`crds.enabled` (new in 1.8.2) looks like the switch for "CRDs are managed separately",
but it disables the whole `crds` subchart, which also renders the Gateway API
safe-upgrade ValidatingAdmissionPolicy and its Binding. `skip_crds` already skips the CRD
payload while keeping that policy, so the flag is a trap here. Noted in the file header.

I also re-measured the "why not a helm_release of gateway-crds-helm" claim in the header,
and it still holds: rendered manifest gzips to 484 KB and the chart tarball is 644 KB, so
about 1.5 MB after base64 against the 1 MB Secret limit.

## Before rolling out

Check each env's gateway TLS secret. 1.8.3 now rejects, during translation, a serving
chain containing an expired or malformed certificate (previously the expired member was
silently dropped, corrupting the chain) and a secret whose certificate and private key do
not match. Failures are isolated to the referencing listener, but a listener that works on
1.8.1 can go dark on 1.8.3.

One inert risk worth knowing: 1.8.3's only breaking change moves EnvoyExtensionPolicy Lua
to listener-level filters and warns that EnvoyPatchPolicies keyed on
`envoy.filters.http.lua/<index>` need updating. The chart's GeoIP EnvoyPatchPolicy inserts
filters at absolute `http_filters/0,1,2` indices, so it is brittle to any baseline change,
but we use no EnvoyExtensionPolicy-with-Lua and `gateway.geoip.enabled` is false
everywhere, so exposure today is zero. If GeoIP is ever enabled, re-verify filter order by
config_dump rather than trusting the 1.8.1 note in that template.

Rollout order: min, then one customer env, then the rest. The shared gov stack stays on
v7.17.0 through its cutover.

Companion: Dozuki/helm#149 corrects the airgap prereq image list, which had been pinned to
gateway v1.7.0 while the fleet ran 1.8.1.
