### PR TITLE
fix(logical): source connectivity DB passwords from the ESO secret

### DIFF
--- a/terraform/logical/kubernetes.tf
+++ b/terraform/logical/kubernetes.tf
@@ -694,6 +694,23 @@ resource "helm_release" "app" {
     { name = "connectivity.integrations-service.mongo.connectionString", value = "mongodb://dozuki-mongodb/integrations" },
     { name = "connectivity.event-service.database.host", value = local.db_master_host },
     { name = "connectivity.event-service.database.username", value = local.db_master_username },
+
+    # DB passwords for the connectivity services, sourced from the ESO-managed secret
+    # rather than passed as values.
+    #
+    # These were never set at all, so the subcharts fell back to the chart default of ""
+    # and their migrations died with "Access denied for user 'dozuki'" — the webhook tier
+    # could not start. The obvious fix is to pass local.db_master_password like db.password
+    # above, but that writes the credential into Terraform state AND the Helm release
+    # secret, and it cannot rotate without an apply.
+    #
+    # Instead point the env var at dozuki-infra-credentials, which the chart's own
+    # ExternalSecret already syncs from Vault (<customer>/<env>/db -> db_password). The
+    # subcharts expose configuration.secrets as {secret-name: {ENV_VAR: key}}, rendering a
+    # secretKeyRef; explicit env beats envFrom, so this overrides the subchart's own empty
+    # value. Only the KEY NAME travels through terraform — never the password.
+    { name = "connectivity.event-service.configuration.secrets.dozuki-infra-credentials.FRONTEGG_EVENTS_MYSQL_DB_PASSWORD", value = "db_password" },
+    { name = "connectivity.webhook-service.configuration.secrets.dozuki-infra-credentials.FRONTEGG_WEBHOOK_MYSQL_DB_PASSWORD", value = "db_password" },
     { name = "connectivity.event-service.messageBroker.brokerList", value = local.msk_brokers_helm_escaped },
     { name = "connectivity.event-service.redis.host", value = "dozuki-redis-master" },
     # type = "string" (helm --set-string) is REQUIRED here. helm's strvals parser


### PR DESCRIPTION
The `event-service` and `webhook-service` database passwords were **never set**. CPI passes `host` and `username` for both, but not `password`, so the subcharts fell back to the chart default of `""`:

```
ERROR: Access denied for user 'dozuki'@'172.16.80.104' (using password: YES)
npm ERR! event-service@0.0.1 migrate: `npx sequelize-cli db:migrate --url mysql://...`
```

Both services crashloop on their migration, so the webhook tier can't start. Only reachable with `enable_webhooks = true`, which no live stack sets — but `infra-live/_templates/env.hcl` defaults it on, so a new customer stack hits it.

## Why not just pass the password

The obvious fix is `{ name = "...password", value = local.db_master_password }` in `set_sensitive`, matching the app's existing `db.password`. I deliberately didn't:

- `set_sensitive` still writes the value into **Terraform state** and into the **Helm release secret** (`sh.helm.release.v1.*` stores every value)
- it can't rotate — a new value in Vault does nothing until someone runs an apply

## What this does instead

Points the env vars at `dozuki-infra-credentials`, which the chart's own ExternalSecret **already syncs from Vault** (`<customer>/<env>/db` → `db_password`). No new ExternalSecret, no new Vault path, no chart change.

The subcharts expose `configuration.secrets` as `{secret-name: {ENV_VAR: key}}`, which renders a `secretKeyRef`. Since explicit `env` takes precedence over `envFrom`, this overrides the subchart's own empty value. **Only the key name passes through Terraform — never the password.**

## Testing

Verified against chart 1.18.0 with `helm template` that the rendered Deployment sources the env var correctly:

```yaml
- name: FRONTEGG_EVENTS_MYSQL_DB_PASSWORD
  valueFrom:
    secretKeyRef:
      name: dozuki-infra-credentials
      key: db_password
```

Found during a real `full`-config deploy. Note this is **not** sufficient on its own to get the webhook tier healthy — the OTel auto-instrumentation crash (separate helm PR) still takes down four of the five connectivity services.