### PR TITLE
fix(physical): grant dms:DescribeReplicationTasks to the app pod identity

### DIFF
--- a/terraform/physical/eks.tf
+++ b/terraform/physical/eks.tf
@@ -135,6 +135,16 @@ data "aws_iam_policy_document" "eks_worker" {
 
   statement {
     actions = [
+      # DescribeReplicationTasks is required alongside Start: the dms-start Job
+      # (logical/bi.tf) reads the task's current status FIRST and only starts it when
+      # it is ready/stopped/failed, since start-replication-task errors on a task that
+      # is already running. Without Describe the Job dies on AccessDenied before it can
+      # decide, and because it runs with wait_for_completion = false the apply still
+      # reports success while DMS silently never starts.
+      #
+      # This was masked until now: the Job's image shipped a 2019 AWS CLI that could not
+      # use EKS Pod Identity at all, so it never got far enough to be denied.
+      "dms:DescribeReplicationTasks",
       "dms:StartReplicationTask"
     ]
 


### PR DESCRIPTION
The `dms-start` Job (`logical/bi.tf`) reads the replication task's status before deciding whether to start it — `start-replication-task` errors on a task that's already running, so the Job calls `DescribeReplicationTasks` first and only starts on `ready`/`stopped`/`failed`.

But the `eks_worker` policy attached to the app pod identity role only granted `dms:StartReplicationTask`:

```
An error occurred (AccessDeniedException) when calling the DescribeReplicationTasks
operation: User: arn:aws:sts::…:assumed-role/smoke-full-us-east-1-app-pod-identity/…
is not authorized to perform: dms:DescribeReplicationTasks
```

So the Job dies before it can decide anything. And because it runs with `wait_for_completion = false`, **the apply still reports success while DMS silently never starts.**

## Why this surfaced only now

It was masked by a bug on top of it. The Job's image shipped a 2019 AWS CLI (`botocore 1.12.224`) that predates EKS Pod Identity, so every credential lookup failed with `Unsupported host '169.254.170.23'` — it never got far enough to reach the API and be denied.

Fixing the image in v7.17.2 peeled that layer back and exposed the missing permission underneath. Both together are consistent with the note already in `bi.tf`:

> all 5 cutover envs had to be started by hand

## Scope

`resources = ["*"]` matches the existing `StartReplicationTask` statement it sits alongside. Scoping both to the stack's task ARN would be tighter, but I've kept this change minimal and consistent rather than reworking the statement — worth a follow-up if you want it narrowed.

Note `monitoring.tf` already grants both actions to its own role, so this brings the pod identity role in line with what the DMS restart lambda already has.

## Testing

Observed in a real `full`-config deploy in DDVtest, with the fixed image in place. Also note the apply passes either way — this is only caught by the `AssertDMSRunning` validation in the harness.