### PR TITLE
fix(logical): exclude the frontegg services from otel auto-instrumentation

### DIFF
--- a/terraform/logical/kubernetes.tf
+++ b/terraform/logical/kubernetes.tf
@@ -446,6 +446,42 @@ resource "aws_eks_addon" "cloudwatch_observability" {
   resolve_conflicts_on_create = "OVERWRITE"
   resolve_conflicts_on_update = "OVERWRITE"
 
+  # Keep Application Signals away from the frontegg (connectivity) services.
+  #
+  # autoMonitor.monitorAllServices defaults to TRUE, so the operator's mutating webhook
+  # stamps instrumentation.opentelemetry.io/inject-<lang>="true" onto every pod at
+  # admission. The injected Node.js SDK uses optional chaining, which the frontegg
+  # images' Node 12 cannot parse — so all five connectivity services crashloop on
+  # startup with:
+  #   SyntaxError: Unexpected token '?'
+  #     at .../@opentelemetry/auto-instrumentations-node/build/src/index.js:8
+  # and helm_release.app never goes Ready. Only reachable with enable_webhooks = true,
+  # which is why no live stack has hit it.
+  #
+  # Excluding here rather than per-pod: this is one declarative place, it needs no
+  # support from the (vendored, third-party) subcharts, and it leaves auto-monitoring
+  # ON for everything else in the namespace — the monolith still gets instrumented.
+  # Scoped to nodejs so a future JVM/python workload in these deployments would still
+  # be picked up. The cost is no Application Signals for the frontegg tier, forced by
+  # the vendor's runtime being too old.
+  configuration_values = jsonencode({
+    manager = {
+      applicationSignals = {
+        autoMonitor = {
+          exclude = {
+            nodejs = {
+              deployments = [
+                for svc in ["api-gateway", "connectors-worker", "event-service", "integrations-service", "webhook-service"] :
+                # namespace/deployment; the release is always named "dozuki".
+                "${local.k8s_namespace_name}/dozuki-${svc}-deployment"
+              ]
+            }
+          }
+        }
+      }
+    }
+  })
+
   tags = merge(
     {},
     var.delete_after != "" ? { deleteAfter = var.delete_after } : {},


### PR DESCRIPTION
`applicationSignals.autoMonitor.monitorAllServices` defaults to **true**, so the CloudWatch Observability operator's mutating webhook stamps `instrumentation.opentelemetry.io/inject-<lang>="true"` onto every pod at admission. The injected Node.js SDK uses optional chaining, which the frontegg images' Node 12 can't parse:

```
SyntaxError: Unexpected token '?'
  at /otel-auto-instrumentation-nodejs/node_modules/@opentelemetry/auto-instrumentations-node/build/src/index.js:8
  at internal/modules/cjs/loader.js:915
```

All five connectivity services crashloop on startup (10 restarts each in the run I caught it on), so `helm_release.app` never goes Ready and the whole apply times out. Only reachable with `enable_webhooks = true`, which is why no live stack has hit it — but `_templates/env.hcl` defaults it on.

## Why the addon rather than pod annotations

I originally fixed this per-pod ([helm#149](https://github.com/Dozuki/helm/pull/149), merged) — but **three of the five subcharts render no pod annotations at all**, so that route needed a chart change *and* a chart release before it could be tested.

Excluding at the addon is better regardless:

- one declarative place instead of five values overrides
- needs nothing from the vendored third-party subcharts
- auto-monitoring stays **on** for the rest of the namespace, so the monolith is still instrumented
- scoped to `nodejs`, so a future JVM/python workload in these deployments would still be picked up

helm#149 stays useful as an escape hatch (and carries the unrelated `regcred` ExternalSecret), but this supersedes it for the crash.

## Tradeoff

No Application Signals for the frontegg tier. That's forced by the vendor shipping Node 12 — the alternative is the pods not starting. Confirmed acceptable.

## Testing

The `configuration_values` payload was validated against the addon's published configuration schema (`aws eks describe-addon-configuration`), including a negative control confirming the schema rejects an unknown key — worth doing since `additionalProperties: false` means a typo fails at apply time:

```
ok manager.applicationSignals.autoMonitor.exclude.nodejs.deployments -> array[5]
VALID: every key resolves against the addon schema
negative control OK: REJECTED: unknown key ...excludeX
```

The crash itself was observed across two full-config deploys in DDVtest.