### PR TITLE
fix(logical): DMS endpoint test-connection, and correct the connectivity secret key

### DIFF
--- a/terraform/logical/bi.tf
+++ b/terraform/logical/bi.tf
@@ -56,6 +56,34 @@ resource "kubernetes_job_v1" "dms_start" {
                 creating|modifying|stopping|testing|deleting) echo "transient state '$STATUS' - a later reconcile will act" ;;
                 None|"") echo "replication task not found: $ARN" >&2; exit 1 ;;
                 ready|stopped|failed)
+                  # DMS refuses to start a task whose endpoints have never had a
+                  # successful test-connection:
+                  #   InvalidResourceStateFault: Test connection for replication instance
+                  #   <ri> and endpoint <ep> should be successful for starting the
+                  #   replication task
+                  # On a FRESH stack that is always the case - nothing has ever tested
+                  # them - so this is the normal path, not the rare post-DB-replace edge
+                  # case the old comment assumed. Test both endpoints and wait for
+                  # success before starting. test-connection is idempotent; an
+                  # already-successful endpoint returns successful again.
+                  RI=$(aws dms describe-replication-tasks --region "$REGION" --filters "Name=replication-task-arn,Values=$ARN" --query 'ReplicationTasks[0].ReplicationInstanceArn' --output text)
+                  for EP in $(aws dms describe-replication-tasks --region "$REGION" --filters "Name=replication-task-arn,Values=$ARN" --query 'ReplicationTasks[0].[SourceEndpointArn,TargetEndpointArn]' --output text); do
+                    ST=$(aws dms describe-connections --region "$REGION" --filters "Name=endpoint-arn,Values=$EP" "Name=replication-instance-arn,Values=$RI" --query 'Connections[0].Status' --output text 2>/dev/null)
+                    if [ "$ST" != "successful" ]; then
+                      echo "testing endpoint $EP (current: $ST)"
+                      aws dms test-connection --replication-instance-arn "$RI" --endpoint-arn "$EP" --region "$REGION" >/dev/null 2>&1 || true
+                    fi
+                  done
+                  for i in $(seq 1 30); do
+                    PENDING=0
+                    for EP in $(aws dms describe-replication-tasks --region "$REGION" --filters "Name=replication-task-arn,Values=$ARN" --query 'ReplicationTasks[0].[SourceEndpointArn,TargetEndpointArn]' --output text); do
+                      ST=$(aws dms describe-connections --region "$REGION" --filters "Name=endpoint-arn,Values=$EP" "Name=replication-instance-arn,Values=$RI" --query 'Connections[0].Status' --output text 2>/dev/null)
+                      [ "$ST" = "successful" ] || { PENDING=1; echo "endpoint $EP connection: $ST ($i/30)"; }
+                    done
+                    [ "$PENDING" -eq 0 ] && break
+                    sleep 20
+                  done
+
                   # start-replication redoes a full load - intended for the cutover
                   # restore-from-new-primary path. For a steady-state task known to have
                   # completed its full load, resume-processing (CDC from last stop) is

--- a/terraform/logical/kubernetes.tf
+++ b/terraform/logical/kubernetes.tf
@@ -741,12 +741,18 @@ resource "helm_release" "app" {
     # secret, and it cannot rotate without an apply.
     #
     # Instead point the env var at dozuki-infra-credentials, which the chart's own
-    # ExternalSecret already syncs from Vault (<customer>/<env>/db -> db_password). The
+    # ExternalSecret already syncs from Vault (<customer>/<env>/db). The
     # subcharts expose configuration.secrets as {secret-name: {ENV_VAR: key}}, rendering a
     # secretKeyRef; explicit env beats envFrom, so this overrides the subchart's own empty
     # value. Only the KEY NAME travels through terraform — never the password.
-    { name = "connectivity.event-service.configuration.secrets.dozuki-infra-credentials.FRONTEGG_EVENTS_MYSQL_DB_PASSWORD", value = "db_password" },
-    { name = "connectivity.webhook-service.configuration.secrets.dozuki-infra-credentials.FRONTEGG_WEBHOOK_MYSQL_DB_PASSWORD", value = "db_password" },
+    # NOTE the key is master_password, NOT db_password. db_password is the ExternalSecret's
+    # INPUT name (spec.data[].secretKey) and never appears in the synced Secret — the
+    # target's template block reshapes those inputs into db.json/memcached.json/... plus a
+    # few flat keys, of which master_password is the plain DB password. Getting this wrong
+    # fails at runtime, not at render: the pods sit in CreateContainerConfigError with
+    # "couldn't find key db_password in Secret dozuki/dozuki-infra-credentials".
+    { name = "connectivity.event-service.configuration.secrets.dozuki-infra-credentials.FRONTEGG_EVENTS_MYSQL_DB_PASSWORD", value = "master_password" },
+    { name = "connectivity.webhook-service.configuration.secrets.dozuki-infra-credentials.FRONTEGG_WEBHOOK_MYSQL_DB_PASSWORD", value = "master_password" },
     { name = "connectivity.event-service.messageBroker.brokerList", value = local.msk_brokers_helm_escaped },
     { name = "connectivity.event-service.redis.host", value = "dozuki-redis-master" },
     # type = "string" (helm --set-string) is REQUIRED here. helm's strvals parser

--- a/terraform/physical/eks.tf
+++ b/terraform/physical/eks.tf
@@ -145,6 +145,11 @@ data "aws_iam_policy_document" "eks_worker" {
       # This was masked until now: the Job's image shipped a 2019 AWS CLI that could not
       # use EKS Pod Identity at all, so it never got far enough to be denied.
       "dms:DescribeReplicationTasks",
+      # DMS will not start a task whose endpoints have never had a successful
+      # test-connection, which is always true on a fresh stack. The Job therefore has to
+      # test both endpoints and poll for the result before starting.
+      "dms:DescribeConnections",
+      "dms:TestConnection",
       "dms:StartReplicationTask"
     ]
 


### PR DESCRIPTION
Two fixes from the first `full` run where the webhook tier actually came up. **Three of the five connectivity services are now healthy** (`api-gateway`, `connectors-worker`, `integrations-service` all `1/1 Running`) — the OTel exclusion in #293 worked. These are the remaining two blockers.

## 1. Wrong secret key in #290 (my bug)

I mapped the env vars to key `db_password`, which doesn't exist in the synced Secret:

```
Error: couldn't find key db_password in Secret dozuki/dozuki-infra-credentials
```

`db_password` is the ExternalSecret's **input** name (`spec.data[].secretKey`). The target's `template:` block reshapes those inputs into `db.json`/`memcached.json`/… plus a few flat keys, of which **`master_password`** is the plain DB password.

Worth noting for anyone reviewing similar changes: this fails at *runtime*, not at render. The `helm template` check I ran on #290 correctly showed the `secretKeyRef` being generated — it just can't know whether the key exists in the live Secret. Both services sat in `CreateContainerConfigError`.

## 2. DMS won't start without a successful endpoint test-connection

```
DMS replication task status: ready
InvalidResourceStateFault: Test connection for replication instance smoke-full and
endpoint smoke-full-source should be successful for starting the replication task
```

The job's own comment dismissed this as a rare edge case:

> Edge case not handled: a source-endpoint connection gone stale after a DB replace needs a test-connection first — see the cutover runbook; rare, and outside this job's inputs.

It isn't rare. On a **fresh** stack the endpoints have never been tested, so DMS refuses to start *every time*. The Job now tests both endpoints and polls for success (bounded, ~10 min) before starting. `test-connection` is idempotent, so an already-successful endpoint just returns successful.

Also grants `dms:DescribeConnections` and `dms:TestConnection` — the Job needs both and the role had neither.

## The pattern here

This is the third layer of one failure, each fix exposing the next:

1. Job couldn't authenticate at all — 2019 AWS CLI, no Pod Identity support (v7.17.2)
2. Missing `dms:DescribeReplicationTasks` (#292)
3. Missing endpoint test-connection (this PR)

All three were invisible to the apply because `wait_for_completion = false`, which is why DMS "silently never started" and cutover envs kept being started by hand. Only the harness's `AssertDMSRunning` catches it.

## Testing

`tofu fmt` clean; the embedded Job script was syntax-checked with `bash -n` after substituting the terraform interpolations. Both failures were observed in a real DDVtest `full` deploy.