### PR TITLE
feat(metrics-server): retire the EKS addon, let the chart own it

### DIFF
--- a/terraform/logical/README.md
+++ b/terraform/logical/README.md
@@ -56,7 +56,6 @@ No modules.
 | [kubernetes_cluster_role_binding_v1.vault_auth_delegator](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/cluster_role_binding_v1) | resource |
 | [kubernetes_cluster_role_v1.dozuki_list_role](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/cluster_role_v1) | resource |
 | [kubernetes_config_map_v1.grafana_create_db_script](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/config_map_v1) | resource |
-| [kubernetes_config_map_v1_data.coredns_objects](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/config_map_v1_data) | resource |
 | [kubernetes_deployment_v1.ratelimit_redis](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/deployment_v1) | resource |
 | [kubernetes_job_v1.dms_start](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/job_v1) | resource |
 | [kubernetes_job_v1.grafana_db_create](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/job_v1) | resource |
@@ -118,7 +117,6 @@ No modules.
 | [azurerm_kubernetes_cluster.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/kubernetes_cluster) | data source |
 | [external_external.ops_htpasswd_hash](https://registry.terraform.io/providers/hashicorp/external/latest/docs/data-sources/external) | data source |
 | [kubectl_file_documents.envoy_gateway_crds](https://registry.terraform.io/providers/alekc/kubectl/2.1.5/docs/data-sources/file_documents) | data source |
-| [kubernetes_resources.envoy_gateway_svc](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/data-sources/resources) | data source |
 | [kubernetes_service_v1.envoy_proxy_azure](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/data-sources/service_v1) | data source |
 
 ## Inputs
@@ -157,6 +155,8 @@ No modules.
 | <a name="input_external_dns_sa_name"></a> [external\_dns\_sa\_name](#input\_external\_dns\_sa\_name) | external-dns service account name (must match the AWS role trust subject). | `string` | `"external-dns"` | no |
 | <a name="input_frontegg_api_token"></a> [frontegg\_api\_token](#input\_frontegg\_api\_token) | Frontegg API token (Azure only; AWS reads Vault). | `string` | `""` | no |
 | <a name="input_frontegg_client_id"></a> [frontegg\_client\_id](#input\_frontegg\_client\_id) | Frontegg client ID (Azure only; AWS reads Vault). | `string` | `""` | no |
+| <a name="input_frontegg_docker_password"></a> [frontegg\_docker\_password](#input\_frontegg\_docker\_password) | Docker Hub password/token paired with frontegg\_docker\_username (secret/dozuki/global/frontegg -> dockerPassword). | `string` | `""` | no |
+| <a name="input_frontegg_docker_username"></a> [frontegg\_docker\_username](#input\_frontegg\_docker\_username) | Docker Hub username for frontegg's private images (secret/dozuki/global/frontegg -> dockerUsername). Required when enable\_webhooks is true: the connectivity subcharts pull docker.io/frontegg/* via an imagePullSecret named regcred. Empty disables creation of that secret. | `string` | `""` | no |
 | <a name="input_gateway_dns_label"></a> [gateway\_dns\_label](#input\_gateway\_dns\_label) | Azure DNS label for the gateway LoadBalancer (azure). Yields <label>.<region>.cloudapp.azure.com. Empty = LB public IP with no DNS label. | `string` | `""` | no |
 | <a name="input_gateway_name"></a> [gateway\_name](#input\_gateway\_name) | Envoy Gateway resource name (matches the chart gateway.name); used to discover its in-cluster data-plane Service for the object-host CoreDNS split-horizon. | `string` | `"dozuki-gateway"` | no |
 | <a name="input_ghcr_pull_token"></a> [ghcr\_pull\_token](#input\_ghcr\_pull\_token) | GitHub token (read:packages) for pulling MPC images from GHCR (Azure only). | `string` | `""` | no |

--- a/terraform/logical/kubernetes.tf
+++ b/terraform/logical/kubernetes.tf
@@ -564,25 +564,33 @@ resource "helm_release" "app" {
   # passed it, so these URLs had to be hand-patched onto every stack (nextjs BFF 500s
   # without them). Wire it here. Empty map is a no-op — the chart's env defaults
   # (SERVER_SIDE_MONOLITH_API_URL) are preserved by the merge.
-  values = concat([yamlencode({ deployments = { webNextjs = { env = var.webnextjs_env } } })], var.cloud == "azure" ? [yamlencode(merge({
-    global = {
-      imagePullSecrets = [{ name = "ghcr-pull" }]
-      # SeaweedFS subchart replication: keep a second copy of every volume so a
-      # single PVC loss does not lose data (matches the old standalone posture).
-      seaweedfs = {
-        enableReplication    = true
-        replicationPlacement = "001"
+  values = concat([yamlencode({
+    deployments = { webNextjs = { env = var.webnextjs_env } }
+    # metrics-server ships in the chart (default on) as the single source of truth
+    # across onprem+cloud; the EKS addon was retired (see physical/eks.tf). Cloud
+    # kubelets present proper serving certs, so drop the chart's onprem-oriented
+    # --kubelet-insecure-tls default here (args=[] leaves the subchart's secure
+    # defaultArgs). Ignored harmlessly on chart versions predating the dependency.
+    "metrics-server" = { args = [] }
+    })], var.cloud == "azure" ? [yamlencode(merge({
+      global = {
+        imagePullSecrets = [{ name = "ghcr-pull" }]
+        # SeaweedFS subchart replication: keep a second copy of every volume so a
+        # single PVC loss does not lose data (matches the old standalone posture).
+        seaweedfs = {
+          enableReplication    = true
+          replicationPlacement = "001"
+        }
       }
-    }
-    gateway = {
-      service = {
-        type        = "LoadBalancer"
-        annotations = var.gateway_dns_label != "" ? { "service.beta.kubernetes.io/azure-dns-label-name" = var.gateway_dns_label } : {}
+      gateway = {
+        service = {
+          type        = "LoadBalancer"
+          annotations = var.gateway_dns_label != "" ? { "service.beta.kubernetes.io/azure-dns-label-name" = var.gateway_dns_label } : {}
+        }
+        dnsTarget = local.lb_fqdn
       }
-      dnsTarget = local.lb_fqdn
-    }
-    }, local.seaweedfs_values, var.azure_acme_server != "" ? {
-    cert_manager = { acmeServer = var.azure_acme_server }
+      }, local.seaweedfs_values, var.azure_acme_server != "" ? {
+      cert_manager = { acmeServer = var.azure_acme_server }
   } : {}))] : [])
 
   # helm provider 3.x: set/set_sensitive are list-of-object attributes, not

--- a/terraform/physical/README.md
+++ b/terraform/physical/README.md
@@ -15,11 +15,11 @@
 | Name | Version |
 |------|---------|
 | <a name="provider_archive"></a> [archive](#provider\_archive) | 2.8.0 |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.56.0 |
-| <a name="provider_aws.dns"></a> [aws.dns](#provider\_aws.dns) | 6.56.0 |
-| <a name="provider_aws.dr"></a> [aws.dr](#provider\_aws.dr) | 6.56.0 |
-| <a name="provider_null"></a> [null](#provider\_null) | 3.3.0 |
-| <a name="provider_random"></a> [random](#provider\_random) | 3.9.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 6.0 |
+| <a name="provider_aws.dns"></a> [aws.dns](#provider\_aws.dns) | ~> 6.0 |
+| <a name="provider_aws.dr"></a> [aws.dr](#provider\_aws.dr) | ~> 6.0 |
+| <a name="provider_null"></a> [null](#provider\_null) | ~> 3.0 |
+| <a name="provider_random"></a> [random](#provider\_random) | ~> 3.0 |
 
 ## Modules
 
@@ -72,7 +72,6 @@
 | [aws_dms_replication_instance.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dms_replication_instance) | resource |
 | [aws_dms_replication_subnet_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dms_replication_subnet_group) | resource |
 | [aws_dms_replication_task.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dms_replication_task) | resource |
-| [aws_eks_addon.metrics_server](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_addon) | resource |
 | [aws_eks_pod_identity_association.app_default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_pod_identity_association) | resource |
 | [aws_eks_pod_identity_association.app_migration_wait](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_pod_identity_association) | resource |
 | [aws_eks_pod_identity_association.cert_manager](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_pod_identity_association) | resource |

--- a/terraform/physical/eks.tf
+++ b/terraform/physical/eks.tf
@@ -443,19 +443,9 @@ resource "aws_eks_pod_identity_association" "cloudwatch_agent" {
   tags = local.tags
 }
 
-# Managed metrics-server addon. Provides the Kubernetes Metrics API (metrics.k8s.io) that
-# HorizontalPodAutoscalers read for their CPU/memory targets. EKS Auto Mode does NOT bundle
-# metrics-server, so without this every HPA reads <unknown> and never scales — the app stays
-# pinned at minReplicas under load. No IAM is needed: metrics-server reads kubelet metrics via
-# the Kubernetes API, not the AWS API. addon_version is left unset so EKS selects the default
-# compatible with the cluster's Kubernetes version. As with the addon above, a cluster that
-# already has metrics-server installed out-of-band must have it removed once before first apply.
-resource "aws_eks_addon" "metrics_server" {
-  cluster_name = module.eks_cluster.cluster_name
-  addon_name   = "metrics-server"
-
-  resolve_conflicts_on_create = "OVERWRITE"
-  resolve_conflicts_on_update = "OVERWRITE"
-
-  tags = local.tags
-}
+# metrics-server is now provided by the dozuki chart (metrics-server.enabled, default
+# on) so it's a single source of truth across onprem and cloud - see the chart's
+# values.yaml. The EKS managed addon was retired here; the chart install carries
+# metrics-server on every platform, and this layer drops the chart's onprem-oriented
+# --kubelet-insecure-tls arg for cloud (EKS kubelets present proper serving certs) via
+# the app release's metrics-server.args override in logical/kubernetes.tf.


### PR DESCRIPTION
Companion to Dozuki/helm#151.

## What
metrics-server moves from a platform concern into the dozuki chart (single source of truth across onprem + cloud). This PR retires the EKS side:
- `physical/eks.tf`: remove `aws_eks_addon.metrics_server`.
- `logical/kubernetes.tf`: on the app release, set `metrics-server.args = []` so cloud drops the chart's onprem-oriented `--kubelet-insecure-tls` default (EKS/AKS kubelets present proper serving certs). metrics-server itself stays enabled - the chart provides it on every platform.
- READMEs regenerated by terraform-docs.

## Why
The chart creates the resource-metric HPAs but shipped no metrics provider, so a bare/onprem cluster's HPAs read `<unknown>` and never scale. Rather than special-case onprem, the chart now owns metrics-server everywhere and the platform stops providing its own.

## ⚠️ Rollout ordering (do not merge/apply standalone)
metrics-server must never have a gap. Land this **per env together with a `chart_version` bump** (in infra-live) to the first chart release that carries the metrics-server dependency (helm#151 → next release). Applying this against an older chart pin removes the addon with nothing replacing it.

- Verify on EKS Auto Mode (metrics-server is a schedulable workload - fine, but confirm nodes provision).
- GovCloud: mirror `registry.k8s.io/metrics-server/metrics-server` into the gov ECR before its env bumps.

Validated the chart side end-to-end on the onprem analog (see helm#151).