### PR TITLE
test(harness): track the current chart, and stop retrying unretryable destroys

### DIFF
--- a/live/tests/cleanup-orphans.sh
+++ b/live/tests/cleanup-orphans.sh
@@ -156,14 +156,23 @@ while IFS= read -r pfx; do
       DESTROY_ATTEMPTS="${DESTROY_ATTEMPTS:-4}"
       DESTROY_BACKOFF="${DESTROY_BACKOFF:-120}"
       destroyed_ok=1
+      _dlog="$(mktemp -t cleanup-destroy.XXXXXX)"
       for attempt in $(seq 1 "$DESTROY_ATTEMPTS"); do
         ( cd "$tgt/physical"
           rm -rf .terragrunt-cache
           TG_AWS_ACCT_ID="$ACCT" TG_AWS_PROFILE="$P" TG_AWS_REGION="$region" TG_STATE_PREFIX="$pfx/" \
           TF_VAR_customer="$CUSTOMER" TF_VAR_enable_dr=false \
-            terragrunt destroy --terragrunt-non-interactive -auto-approve -input=false )
-        destroyed_ok=$?
+            terragrunt destroy --terragrunt-non-interactive -auto-approve -input=false ) 2>&1 | tee "$_dlog"
+        destroyed_ok=${PIPESTATUS[0]}
         [ "$destroyed_ok" -eq 0 ] && break
+        # Only retry things that can actually clear on their own. A config-resolution
+        # failure (e.g. falling back to the LIVE tree, where find_in_parent_folders has
+        # no terragrunt.hcl to find) fails identically every time, so retrying burns
+        # DESTROY_ATTEMPTS * DESTROY_BACKOFF for nothing — 8 minutes per pass, observed.
+        if grep -qE "find_in_parent_folders|ParentFileNotFound|Could not find a terragrunt" "$_dlog" 2>/dev/null; then
+          echo "  physical destroy failed to even load a config (no usable tree for $pfx) — not retrying" >&2
+          break
+        fi
         if [ "$attempt" -lt "$DESTROY_ATTEMPTS" ]; then
           echo "  physical destroy attempt $attempt/$DESTROY_ATTEMPTS failed — waiting ${DESTROY_BACKOFF}s for in-flight deletions to drain, then retrying" >&2
           sleep "$DESTROY_BACKOFF"

--- a/live/tests/matrix.yaml
+++ b/live/tests/matrix.yaml
@@ -18,12 +18,14 @@ defaults:
 version_defaults:
   image_tag: "3625f3c7a3fe9bd3fb87b03a23a4cbb683d44ded.4"
   nextjs_tag: "2.23.0"
-  chart_version: "1.18.0"  # v7.17.0 moved the NLB TargetGroupBindings (#278) and the frontegg
-                           # DB-create + ztunnel PodMonitor (#277) out of TF and into the chart;
-                           # 1.18.0 is the release that carries those templates. Older charts
-                           # silently drop all three resources. The TGB template is gated on
-                           # gateway.stableProxyService.targetGroupBindings.httpsArn, which only
-                           # CPI >= 7.17.0 passes, so 1.18.0 is safe on pre-7.17 baseline refs too.
+  chart_version: "1.22.0"  # Track the current chart so a run validates the pairing a real deploy
+                           # would get. The floor is 1.18.0: v7.17.0 moved the NLB
+                           # TargetGroupBindings (#278) and the frontegg DB-create + ztunnel
+                           # PodMonitor (#277) out of TF into the chart, and older charts silently
+                           # drop all three. Those templates are gated on values only CPI >= 7.17.0
+                           # passes, so a newer chart stays safe on pre-7.17 baseline refs.
+                           # Bump this when the chart releases, or the harness quietly tests a
+                           # pairing nobody actually runs.
   image_repository: "069174876992.dkr.ecr.us-east-1.amazonaws.com"
 
 # Per-ref OVERRIDES — only keys that DIFFER from version_defaults need to be here.


### PR DESCRIPTION
Two harness fixes from the last few validation cycles.

## Chart pin was four releases stale

`matrix.yaml` pinned `chart_version: 1.18.0` while the chart is at 1.22.0, so runs were validating a pairing no real deploy would ever get. Bumped to 1.22.0.

1.18.0 stays the **floor** — v7.17.0 moved the NLB TargetGroupBindings and the frontegg DB-create/ztunnel PodMonitor into the chart, and older charts silently drop them. I've added a note in-file that this wants bumping on each chart release, since the pin had drifted silently once already.

## Retry loop retried things that can never succeed

I added the physical-destroy retry earlier for transient `DependencyViolation` (ENIs still draining after a killed run pin subnets and security groups). That part is correct and has since torn down 274 resources in one pass.

But it retried *every* failure, including deterministic ones. Concretely: when a teardown **succeeds** it removes its worktree, which takes the marker with it. A later cleanup pass then falls back to the live tree, where `find_in_parent_folders` has no `terragrunt.hcl` to find and fails identically every time. The loop sat through `DESTROY_ATTEMPTS * DESTROY_BACKOFF` — 8 minutes per pass, 3 passes — before giving up, and blocked the next cycle from starting.

Now it breaks immediately when the destroy couldn't even load a config, and keeps retrying only the transient class.

## Known follow-up (not in this PR)

The underlying nuisance is that a successful teardown leaves its state objects behind with no marker to destroy against. The resources are gone, so it's cosmetic — but every following cycle then does futile work on a prefix that has nothing left to destroy. Cleanest fix is probably to purge the state prefix when the account verifies clean, rather than gating the purge solely on destroy exit status. Left out here to keep this change small.

## Testing

Both exercised across cycles 8 and 9: chart 1.22.0 was used for the v7.18.0 validation run, and the retry guard was written after watching the old behaviour burn ~24 minutes.