### PR TITLE
test(harness): ask Flux whether the app is ready, instead of waiting on a timer

### DIFF
--- a/live/tests/harness/run.go
+++ b/live/tests/harness/run.go
@@ -270,6 +270,23 @@ func validateStack(tg TGOptions, p RunParams, region string) (int, string, Capab
 	if len(critical) == 0 {
 		critical = DefaultCriticalWorkloads()
 	}
+	// Since CPI v7.19.0 the app is delivered by a Flux HelmRelease applied with
+	// kubectl_manifest, which returns as soon as the CR exists — the apply no longer
+	// blocks on the install the way helm_release.app's wait=true did. Ask Flux for the
+	// verdict instead of guessing a duration: helm-controller knows both when the
+	// release is genuinely Ready and, on failure, WHY. That fails in seconds on a broken
+	// install (remediation.retries = 0 makes it terminal) instead of waiting out a timer
+	// only to report "still not ready". The timeout here is a backstop for a controller
+	// that never reconciles, not a readiness estimate.
+	//
+	// Skipped when there is no HelmRelease — a pre-v7.19.0 baseline in an upgrade run
+	// installs through the TF helm provider, where the apply already waited.
+	if validation.HelmReleaseManaged(kc, p.Namespace, "dozuki") {
+		step("waiting on Flux HelmRelease dozuki (authoritative readiness)")
+		if herr := validation.AwaitHelmReleaseReady(kc, p.Namespace, "dozuki", 60*time.Minute); herr != nil {
+			return 0, "", caps, herr
+		}
+	}
 	advisory, err := validation.CheckClusterHealth(kc, p.Namespace, critical, 20*time.Minute)
 	if err != nil {
 		return 0, "", caps, err

--- a/live/tests/matrix.yaml
+++ b/live/tests/matrix.yaml
@@ -18,7 +18,7 @@ defaults:
 version_defaults:
   image_tag: "3625f3c7a3fe9bd3fb87b03a23a4cbb683d44ded.4"
   nextjs_tag: "2.23.0"
-  chart_version: "1.22.0"  # Track the current chart so a run validates the pairing a real deploy
+  chart_version: "1.23.0"  # Track the current chart so a run validates the pairing a real deploy
                            # would get. The floor is 1.18.0: v7.17.0 moved the NLB
                            # TargetGroupBindings (#278) and the frontegg DB-create + ztunnel
                            # PodMonitor (#277) out of TF into the chart, and older charts silently

--- a/live/tests/validation/helmrelease.go
+++ b/live/tests/validation/helmrelease.go
@@ -1,0 +1,151 @@
+package validation
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+// Since CPI v7.19.0 the dozuki app is delivered by a Flux HelmRelease applied with
+// kubectl_manifest, which returns as soon as the CR exists — the terragrunt apply no
+// longer blocks on the install the way helm_release.app's wait=true did. So the harness
+// has to establish readiness itself.
+//
+// Ask Flux rather than guessing a duration. helm-controller publishes the authoritative
+// answer on the HelmRelease's status conditions, which beats waiting on a timer in both
+// directions: we wait exactly as long as a slow-but-healthy install needs, and we fail
+// in seconds on a broken one instead of burning the whole budget to reach the same
+// conclusion. Timer-based waiting can only ever report "still not ready", never why.
+
+var helmReleaseGVR = schema.GroupVersionResource{
+	Group:    "helm.toolkit.fluxcd.io",
+	Version:  "v2",
+	Resource: "helmreleases",
+}
+
+// HelmReleaseManaged reports whether a Flux HelmRelease of this name exists. Older refs
+// install the app through the TF helm provider and have no CR, so callers use this to
+// decide whether the Flux-aware wait applies (relevant for upgrade runs from a
+// pre-v7.19.0 baseline).
+func HelmReleaseManaged(kubeconfig, namespace, name string) bool {
+	dc, err := dynamicFor(kubeconfig)
+	if err != nil {
+		return false
+	}
+	_, err = dc.Resource(helmReleaseGVR).Namespace(namespace).Get(context.Background(), name, metav1.GetOptions{})
+	return err == nil
+}
+
+// AwaitHelmReleaseReady blocks until Flux reports the HelmRelease Ready, or returns the
+// failure Flux recorded. timeout bounds only the wait for a verdict — it is a backstop
+// for a controller that never reconciles at all, not a readiness estimate.
+func AwaitHelmReleaseReady(kubeconfig, namespace, name string, timeout time.Duration) error {
+	dc, err := dynamicFor(kubeconfig)
+	if err != nil {
+		return err
+	}
+	ctx := context.Background()
+	started := time.Now()
+	deadline := started.Add(timeout)
+	lastMsg := ""
+
+	for {
+		hr, gerr := dc.Resource(helmReleaseGVR).Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
+		if gerr != nil {
+			if !errors.IsNotFound(gerr) {
+				return fmt.Errorf("get HelmRelease %s/%s: %w", namespace, name, gerr)
+			}
+			// Not created yet — keep waiting rather than failing.
+		} else {
+			ready, reason, msg := condition(hr, "Ready")
+			stalled, sReason, sMsg := condition(hr, "Stalled")
+
+			if ready == "True" {
+				fmt.Fprintf(os.Stderr, ">> [harness %s] HelmRelease %s Ready (%s) — %s\n",
+					time.Now().Format("15:04:05"), name, time.Since(started).Round(time.Second), reason)
+				return nil
+			}
+
+			// Terminal failures. CPI sets remediation.retries = 0, so an install/upgrade
+			// failure is final: waiting longer cannot change it, and the message names the
+			// actual cause (a failed hook, an unready workload, a values error).
+			if stalled == "True" {
+				return fmt.Errorf("HelmRelease %s stalled (%s): %s", name, sReason, firstLine(sMsg))
+			}
+			if ready == "False" && isTerminalReason(reason) {
+				return fmt.Errorf("HelmRelease %s failed (%s): %s", name, reason, firstLine(msg))
+			}
+
+			if m := firstLine(msg); m != "" && m != lastMsg {
+				fmt.Fprintf(os.Stderr, ">> [harness %s] HelmRelease %s: %s — %s\n",
+					time.Now().Format("15:04:05"), name, reason, m)
+				lastMsg = m
+			}
+		}
+
+		if time.Now().After(deadline) {
+			return fmt.Errorf("HelmRelease %s produced no verdict within %s (last: %s)", name, timeout, lastMsg)
+		}
+		time.Sleep(20 * time.Second)
+	}
+}
+
+// isTerminalReason lists the helm-controller reasons that will not resolve on their own
+// under remediation.retries = 0. Anything else (Progressing, ArtifactFailed while the
+// source is still pulling, ...) is treated as in-flight and waited out.
+func isTerminalReason(reason string) bool {
+	switch reason {
+	case "InstallFailed", "UpgradeFailed", "TestFailed", "RollbackFailed", "UninstallFailed", "ChartPullFailed":
+		return true
+	}
+	return false
+}
+
+func condition(hr *unstructured.Unstructured, condType string) (status, reason, message string) {
+	conds, found, err := unstructured.NestedSlice(hr.Object, "status", "conditions")
+	if err != nil || !found {
+		return "", "", ""
+	}
+	for _, c := range conds {
+		cm, ok := c.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if s, _ := cm["type"].(string); s != condType {
+			continue
+		}
+		status, _ = cm["status"].(string)
+		reason, _ = cm["reason"].(string)
+		message, _ = cm["message"].(string)
+		return status, reason, message
+	}
+	return "", "", ""
+}
+
+func firstLine(s string) string {
+	s = strings.TrimSpace(s)
+	if i := strings.IndexByte(s, '\n'); i >= 0 {
+		s = s[:i]
+	}
+	if len(s) > 300 {
+		s = s[:300] + "…"
+	}
+	return s
+}
+
+func dynamicFor(kubeconfig string) (dynamic.Interface, error) {
+	cfg, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
+	if err != nil {
+		return nil, err
+	}
+	return dynamic.NewForConfig(cfg)
+}


### PR DESCRIPTION
#295 moved app delivery to a Flux HelmRelease applied with `kubectl_manifest`, which returns as soon as the CR exists. The terragrunt apply no longer blocks on the install the way `helm_release.app`'s `wait = true` did — the install now runs asynchronously in helm-controller (`install.timeout 4h30m`).

That quietly moved the burden onto the harness: `CheckClusterHealth` became the *first* thing that waits for the app at all, on a 20-minute budget calibrated for a world where 1800s of waiting had already happened. The full config takes 16m+ to converge on a fresh cluster, so that was primed to fail spuriously.

My first instinct was to raise the number. That's the wrong instrument in both directions:

- too short → a slow-but-healthy install fails for no reason
- too long → a broken install burns the whole budget to conclude only *"critical workloads not ready"*, with no cause

**helm-controller already knows the answer**, and publishes it on the HelmRelease's status conditions — including *why* on failure. So ask it:

- `Ready=True` → done, however long that took
- `Stalled`, or a terminal reason (`InstallFailed`, `UpgradeFailed`, `ChartPullFailed`, …) → **fail immediately**, surfacing Flux's own message

CPI sets `remediation.retries = 0`, so those failures are final — waiting cannot change them. A broken install now reports in seconds with the actual cause (a failed hook, an unready workload, a bad values reference) instead of after 45 minutes with none.

The timeout that remains is a backstop for a controller that never reconciles at all, not a readiness estimate.

Gated on the CR existing (`HelmReleaseManaged`), so a pre-v7.19.0 baseline in an **upgrade** run — installed through the TF helm provider, where the apply already waited — is unaffected.

Also pins the matrix chart to 1.23.0 for the current release.

## Testing

`go build ./...` and `go test ./...` pass. The live exercise is the next validation cycle; cycle 10 is currently running the older timer-based binary, since `run.sh` compiles the test binary at launch.