### PR TITLE
fix(physical): wait for the primary before creating the Aurora DR replica

### DIFF
--- a/terraform/physical/dr_aurora.tf
+++ b/terraform/physical/dr_aurora.tf
@@ -136,7 +136,21 @@ resource "aws_rds_cluster" "dr_aurora_secondary" {
     ignore_changes = [replication_source_identifier]
   }
 
-  depends_on = [aws_rds_global_cluster.aurora]
+  # module.aurora, not just the global cluster: RDS rejects the cross-region replica
+  # while the PRIMARY is still settling —
+  #   InvalidDBClusterStateFault: Source cluster: <id> is in a state which is not
+  #   valid for physical replication
+  # The global cluster only needs module.aurora[0].cluster_arn, which terraform has as
+  # soon as the cluster resource returns, so neither it nor this replica waited for the
+  # primary's instances to finish provisioning. That left a race this usually won but
+  # sometimes lost (observed on a fresh full deploy: the replica was attempted while the
+  # writer was still creating). Depending on the whole module makes it wait for the
+  # instances, which is what "available for replication" actually requires.
+  #
+  # This is a resource-level depends_on pointing AT a module, not a depends_on ON a
+  # module block — it does not defer the module's own data sources (see the eks_cluster
+  # warning in this layer's notes).
+  depends_on = [aws_rds_global_cluster.aurora, module.aurora]
 }
 
 # --- Outputs (consumed by the failover runbook) -------------------------------


### PR DESCRIPTION
A fresh `full` deploy failed in the physical layer:

```
Error: creating RDS Cluster (smoke-full-dr): InvalidDBClusterStateFault:
Source cluster: smoke-full is in a state which is not valid for physical replication
```

`aws_rds_cluster.dr_aurora_secondary` depended only on `aws_rds_global_cluster.aurora`, and the global cluster in turn only needs `module.aurora[0].cluster_arn` — which terraform has as soon as the cluster resource returns. **Neither waited for the primary's instances to finish provisioning**, so the cross-region replica could be attempted while the writer was still creating.

## This is a race, not a hard break

Earlier runs created the DR cluster without trouble; this one lost the race. That's worth stating plainly because it means the bug has always been there and simply hadn't surfaced — and it'll keep surfacing intermittently on fresh DR-enabled deploys until the ordering is explicit.

Depending on the whole module makes the replica wait for the instances, which is what RDS actually means by "available for physical replication".

## Two things I checked rather than assumed

**No dependency cycle.** The global cluster sources *from* `module.aurora`; `aurora.tf` never references the global cluster (`grep` count: 0). The graph stays one-directional: module → global → replica, plus module → replica.

**This is not the `depends_on`-on-a-module footgun.** This layer's notes warn that putting `depends_on` **on a module block** defers every data source inside it to apply time and force-replaced EKS access entries during the `default_tags` rollout. This is the other direction — a *resource-level* `depends_on` that happens to point at a module — so no data sources are deferred.

## Testing

`tofu fmt` clean. The failure was observed on a real DDVtest `full` deploy (cycle 10, v7.19.0 + chart 1.23.0); the fix is ordering-only and needs a fresh DR-enabled deploy to confirm, which is the next validation run.