### PR TITLE
feat(logical): pull the frontegg connectivity images from our own registry

### DIFF
--- a/live/tests/run.sh
+++ b/live/tests/run.sh
@@ -227,25 +227,6 @@ if [ -z "${TF_VAR_tls_cert:-}" ]; then
   echo ">> TLS: generated self-signed cert -> manual TLS (no cert-manager/ACME)."
 fi
 
-# Frontegg Docker Hub credentials for the webhooks tier. The connectivity subcharts
-# pull PRIVATE docker.io/frontegg/* images via an imagePullSecret named "regcred";
-# CPI creates it from these vars. Without them an enable_webhooks run dies in
-# ImagePullBackOff ~15 min in, after the whole physical layer has been built. Read
-# from the same central Vault the run already authenticated to, so nothing is
-# hardcoded here. Only needed for configs with webhooks on; harmless otherwise.
-if [ -z "${TF_VAR_frontegg_docker_username:-}" ] && [ -n "${VAULT_TOKEN:-}" ]; then
-  _fe="$(vault kv get -format=json secret/dozuki/global/frontegg 2>/dev/null)" || _fe=""
-  if [ -n "$_fe" ]; then
-    export TF_VAR_frontegg_docker_username="$(printf '%s' "$_fe" | python3 -c 'import sys,json; print(json.load(sys.stdin)["data"]["data"].get("dockerUsername",""))' 2>/dev/null)"
-    export TF_VAR_frontegg_docker_password="$(printf '%s' "$_fe" | python3 -c 'import sys,json; print(json.load(sys.stdin)["data"]["data"].get("dockerPassword",""))' 2>/dev/null)"
-    [ -n "${TF_VAR_frontegg_docker_username:-}" ] \
-      && echo ">> Frontegg: docker credentials loaded from Vault (regcred will be created)." \
-      || echo ">> Frontegg: WARNING - secret/dozuki/global/frontegg has no dockerUsername; webhooks images will fail to pull." >&2
-  else
-    echo ">> Frontegg: WARNING - could not read secret/dozuki/global/frontegg; webhooks images will fail to pull." >&2
-  fi
-fi
-
 # From here on, the run can create cloud resources — arm the backstop cleanup (see trap).
 STARTED_RUN=1
 

--- a/terraform/logical/flux.tf
+++ b/terraform/logical/flux.tf
@@ -9,6 +9,14 @@
 # referenced by the HelmRelease `valuesFrom`.
 
 locals {
+  # Tags for the frontegg connectivity images in our registry. Two tags because two
+  # kinds of artifact: -mirror is upstream byte-for-byte, -mysql-tls is our fork with
+  # the migration TLS fix. Both pin the upstream digest they were built from (recorded
+  # with the images), so what we shipped is always traceable. Immutable tags, never
+  # :latest — the upstream tag moved under us historically.
+  frontegg_mirror_tag = "20260726-mirror"
+  frontegg_fork_tag   = "20260726-mysql-tls"
+
   # deployments.webNextjs.env came from two sources on helm_release.app: the values-block
   # (var.webnextjs_env) and appended set entries (var.nextjs_extra_env). Merge them (nextjs_extra_env
   # wins on key collisions, matching the old later-set-overrides-earlier-value order).
@@ -151,28 +159,62 @@ locals {
       jwtSecret = local.dashboards_jwt_secret # (was set_sensitive)
     }
 
+    # The frontegg connectivity images come from OUR registry, not Docker Hub.
+    #
+    # They are mirrored into the dozukicloud ECR (and follow var.image_repository, so gov
+    # and airgapped envs resolve their own registry the same way dozuki-operator does).
+    # That removes the private Docker Hub pull entirely: no regcred, no frontegg docker
+    # credentials in values, and no dependency on a vendor registry for a product
+    # frontegg no longer maintains.
+    #
+    # event-service and webhook-service are FORKS, not straight mirrors: their migration
+    # path ignored TLS. Aurora MySQL 8.4 defaults require_secure_transport ON and refuses
+    # the plaintext connection outright, so both crashlooped on migrate and the webhook
+    # tier could never start. The forks add dialectOptions.ssl, verified against the RDS
+    # CA baked into the image. Hence the different tag: -mysql-tls vs -mirror.
     connectivity = {
       "webhook-service" = {
-        messageBroker = { brokerList = var.msk_bootstrap_brokers }
-        mysql         = { host = local.db_master_host, username = local.db_master_username }
+        image            = { repository = "${var.image_repository}/hybrid-webhook-service" }
+        appVersion       = local.frontegg_fork_tag
+        imagePullSecrets = []
+        messageBroker    = { brokerList = var.msk_bootstrap_brokers }
+        # useSSL is a STRING: helm coerces a bare true to a bool and the chart b64encs it.
+        mysql         = { host = local.db_master_host, username = local.db_master_username, useSSL = "true" }
         mongo         = { connectionString = "mongodb://dozuki-mongodb/webhooks" }
         configuration = { secrets = { "dozuki-infra-credentials" = { FRONTEGG_WEBHOOK_MYSQL_DB_PASSWORD = "master_password" } } }
       }
       "integrations-service" = {
-        messageBroker = { brokerList = var.msk_bootstrap_brokers }
-        mongo         = { connectionString = "mongodb://dozuki-mongodb/integrations" }
+        image            = { repository = "${var.image_repository}/hybrid-integrations-service" }
+        appVersion       = local.frontegg_mirror_tag
+        imagePullSecrets = []
+        messageBroker    = { brokerList = var.msk_bootstrap_brokers }
+        mongo            = { connectionString = "mongodb://dozuki-mongodb/integrations" }
       }
       "event-service" = {
-        database      = { host = local.db_master_host, username = local.db_master_username }
-        configuration = { secrets = { "dozuki-infra-credentials" = { FRONTEGG_EVENTS_MYSQL_DB_PASSWORD = "master_password" } } }
-        messageBroker = { brokerList = var.msk_bootstrap_brokers }
-        redis         = { host = "dozuki-redis-master", tls = "false" } # tls stays STRING (was --set-string)
+        image            = { repository = "${var.image_repository}/hybrid-event-service" }
+        appVersion       = local.frontegg_fork_tag
+        imagePullSecrets = []
+        database         = { host = local.db_master_host, username = local.db_master_username, useSSL = "true" }
+        configuration    = { secrets = { "dozuki-infra-credentials" = { FRONTEGG_EVENTS_MYSQL_DB_PASSWORD = "master_password" } } }
+        messageBroker    = { brokerList = var.msk_bootstrap_brokers }
+        redis            = { host = "dozuki-redis-master", tls = "false" } # tls stays STRING (was --set-string)
       }
       "connectors-worker" = {
-        messageBroker = { brokerList = var.msk_bootstrap_brokers }
-        redis         = { host = "dozuki-redis-master", tls = "false" } # tls stays STRING
+        image            = { repository = "${var.image_repository}/hybrid-connectors-worker" }
+        appVersion       = local.frontegg_mirror_tag
+        imagePullSecrets = []
+        messageBroker    = { brokerList = var.msk_bootstrap_brokers }
+        redis            = { host = "dozuki-redis-master", tls = "false" } # tls stays STRING
       }
-      frontegg = { images = { username = var.frontegg_docker_username, password = var.frontegg_docker_password } } # (was set_sensitive)
+      "api-gateway" = {
+        image            = { repository = "${var.image_repository}/hybrid-api-gateway" }
+        appVersion       = local.frontegg_mirror_tag
+        imagePullSecrets = []
+      }
+      # Stops the subchart rendering its regcred Secret. Nothing pulls from Docker Hub
+      # now, and the chart's default credentials were literal placeholders that Docker
+      # Hub rejected anyway.
+      frontegg = { images = { enabled = false } }
     }
 
     "dozuki-operator" = {

--- a/terraform/logical/variables.tf
+++ b/terraform/logical/variables.tf
@@ -442,20 +442,6 @@ variable "frontegg_api_token" {
   default     = ""
 }
 
-variable "frontegg_docker_username" {
-  description = "Docker Hub username for frontegg's private images (secret/dozuki/global/frontegg -> dockerUsername). Required when enable_webhooks is true: the connectivity subcharts pull docker.io/frontegg/* via an imagePullSecret named regcred. Empty disables creation of that secret."
-  type        = string
-  sensitive   = true
-  default     = ""
-}
-
-variable "frontegg_docker_password" {
-  description = "Docker Hub password/token paired with frontegg_docker_username (secret/dozuki/global/frontegg -> dockerPassword)."
-  type        = string
-  sensitive   = true
-  default     = ""
-}
-
 variable "surveyjs_license_key" {
   description = "SurveyJS license key (Azure only; AWS reads Vault)."
   type        = string


### PR DESCRIPTION
All five frontegg connectivity images now come from `var.image_repository` instead of Docker Hub, so gov and airgapped envs resolve their own registry exactly the way `dozuki-operator` already does.

**This removes the private Docker Hub pull entirely** — no `regcred` Secret, no frontegg docker credentials in values or Terraform state, and no runtime dependency on a vendor registry for a product frontegg no longer maintains.

## Why this fixes enable_webhooks

The chart shipped **literal placeholder credentials** (`username: "frontegg_docker_username"`). Being non-empty they satisfied the chart's `required` guard, so `regcred` rendered happily with credentials Docker Hub rejects — every `enable_webhooks` deploy died on `ImagePullBackOff` / 401. Mirroring to our registry deletes that whole failure class rather than working around it.

## Two of the five are forks, not mirrors

`event-service` and `webhook-service` had a real vendor bug: their **migration** path ignored TLS.

- event-service: `src/config/mysql.config.js` never set `dialectOptions`
- webhook-service: `configToSequelizeOptions()` **read** the ssl flag and then destructured it away

Aurora MySQL 8.4 defaults `require_secure_transport` **ON** and refuses the plaintext connection:

```
ERROR: Connections using insecure transport are prohibited while --require_secure_transport=ON.
```

So both crashlooped on their migrate step and the webhook tier could never start. The forks add `dialectOptions.ssl` verified against the **RDS CA baked into the image** (not `rejectUnauthorized: false`). Hence the separate tag: `-mysql-tls` vs `-mirror`.

`useSSL` is now set so the **runtime** path uses TLS too — the images already honoured that env var, the chart just never exposed it (companion helm PR).

## Details worth noting on review

**`useSSL` is passed as a string, deliberately.** Helm coerces a bare `true` to a bool and the chart `b64enc`s it — the exact trap that produced `wrong type for value; expected string; got bool` on `redis.tls`. The chart also guards with `toString`, verified against string, bool and unset.

**Immutable tags, never `:latest`.** Both tags pin the upstream digest they were built from, recorded with the images, so what shipped is traceable.

**Removes now-dead code:** the `frontegg_docker_username`/`password` variables and the harness's Vault fetch for them.

## Dependencies

Needs the companion chart change (`feat/connectivity-mysql-usessl`, exposes the USE_SSL env vars) released and pinned, plus [infra-tf#61](https://github.com/Dozuki/infra-tf/pull/61) for the cross-account pull policies — **without those policies the deploying account cannot pull the mirror at all.**

Not yet validated end to end; the next `full` harness run is the test.