### PR TITLE
feat(logical): values diff view ConfigMap for per-key plan diffs

### DIFF
--- a/terraform/logical/README.md
+++ b/terraform/logical/README.md
@@ -60,6 +60,7 @@ No modules.
 | [kubernetes_cluster_role_binding_v1.dozuki_list_role_binding](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/cluster_role_binding_v1) | resource |
 | [kubernetes_cluster_role_binding_v1.vault_auth_delegator](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/cluster_role_binding_v1) | resource |
 | [kubernetes_cluster_role_v1.dozuki_list_role](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/cluster_role_v1) | resource |
+| [kubernetes_config_map_v1.flux_values_diff](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/config_map_v1) | resource |
 | [kubernetes_config_map_v1.grafana_create_db_script](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/config_map_v1) | resource |
 | [kubernetes_deployment_v1.ratelimit_redis](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/deployment_v1) | resource |
 | [kubernetes_job_v1.dms_start](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/job_v1) | resource |
@@ -165,8 +166,6 @@ No modules.
 | <a name="input_flux_chart_version"></a> [flux\_chart\_version](#input\_flux\_chart\_version) | fluxcd-community/flux2 chart version for the app-delivery controllers. 2.19.0 = Flux 2.9.1 (helm-controller v1.6.2, Helm 4/SSA line), validated adopting the release cleanly on min under Helm 3 and 4. | `string` | `"2.19.0"` | no |
 | <a name="input_frontegg_api_token"></a> [frontegg\_api\_token](#input\_frontegg\_api\_token) | Frontegg API token (Azure only; AWS reads Vault). | `string` | `""` | no |
 | <a name="input_frontegg_client_id"></a> [frontegg\_client\_id](#input\_frontegg\_client\_id) | Frontegg client ID (Azure only; AWS reads Vault). | `string` | `""` | no |
-| <a name="input_frontegg_docker_password"></a> [frontegg\_docker\_password](#input\_frontegg\_docker\_password) | Docker Hub password/token paired with frontegg\_docker\_username (secret/dozuki/global/frontegg -> dockerPassword). | `string` | `""` | no |
-| <a name="input_frontegg_docker_username"></a> [frontegg\_docker\_username](#input\_frontegg\_docker\_username) | Docker Hub username for frontegg's private images (secret/dozuki/global/frontegg -> dockerUsername). Required when enable\_webhooks is true: the connectivity subcharts pull docker.io/frontegg/* via an imagePullSecret named regcred. Empty disables creation of that secret. | `string` | `""` | no |
 | <a name="input_gateway_dns_label"></a> [gateway\_dns\_label](#input\_gateway\_dns\_label) | Azure DNS label for the gateway LoadBalancer (azure). Yields <label>.<region>.cloudapp.azure.com. Empty = LB public IP with no DNS label. | `string` | `""` | no |
 | <a name="input_ghcr_pull_token"></a> [ghcr\_pull\_token](#input\_ghcr\_pull\_token) | GitHub token (read:packages) for pulling MPC images from GHCR (Azure only). | `string` | `""` | no |
 | <a name="input_ghcr_pull_username"></a> [ghcr\_pull\_username](#input\_ghcr\_pull\_username) | GitHub username for pulling MPC images from GHCR (Azure only). | `string` | `""` | no |

--- a/terraform/logical/flux_values_diff.tf
+++ b/terraform/logical/flux_values_diff.tf
@@ -1,0 +1,95 @@
+# ---------------------------------------------------------------------------
+# Values diff view: the dozuki-flux-values-diff ConfigMap
+#
+# The app values ship to Flux inside a Secret (flux.tf), so any values change
+# plans as one opaque "(sensitive value)" line - the per-key diffs we had from
+# helm_release set blocks disappeared in the Flux move. This ConfigMap restores
+# them: the same values tree flattened to one dotted-path entry per leaf, so a
+# plan renders exactly the keys that changed:
+#
+#   ~ "webhooks.enabled" = "false" -> "true"
+#
+# NOTHING consumes it - it exists purely so plans (and the PR diff comments
+# built from them) show what changed in the values. Leaves are jsonencoded
+# (strings keep their quotes) so string-vs-bool stays visible; helm type
+# coercion has bitten before (useSSL, redis.tls).
+#
+# Leaves carrying a tofu sensitivity mark are stored as a short sha256, so a
+# rotation is visible without the value. That protection rides entirely on the
+# marks: keep secret-bearing variables declared sensitive = true.
+#
+# HCL has no recursion, so the flatten is an unrolled chain sized for the
+# values tree (10 levels; the deepest real path today is 6). A deeper leaf
+# degrades to a JSON-blob entry, which still diffs.
+# ---------------------------------------------------------------------------
+
+locals {
+  vd0 = local.app_values
+  vd1 = merge(
+    merge([for k, v in local.vd0 : { for k2, v2 in v : "${k}.${k2}" => v2 } if can(keys(v))]...),
+    { for k, v in local.vd0 : k => v if !can(keys(v)) },
+  )
+  vd2 = merge(
+    merge([for k, v in local.vd1 : { for k2, v2 in v : "${k}.${k2}" => v2 } if can(keys(v))]...),
+    { for k, v in local.vd1 : k => v if !can(keys(v)) },
+  )
+  vd3 = merge(
+    merge([for k, v in local.vd2 : { for k2, v2 in v : "${k}.${k2}" => v2 } if can(keys(v))]...),
+    { for k, v in local.vd2 : k => v if !can(keys(v)) },
+  )
+  vd4 = merge(
+    merge([for k, v in local.vd3 : { for k2, v2 in v : "${k}.${k2}" => v2 } if can(keys(v))]...),
+    { for k, v in local.vd3 : k => v if !can(keys(v)) },
+  )
+  vd5 = merge(
+    merge([for k, v in local.vd4 : { for k2, v2 in v : "${k}.${k2}" => v2 } if can(keys(v))]...),
+    { for k, v in local.vd4 : k => v if !can(keys(v)) },
+  )
+  vd6 = merge(
+    merge([for k, v in local.vd5 : { for k2, v2 in v : "${k}.${k2}" => v2 } if can(keys(v))]...),
+    { for k, v in local.vd5 : k => v if !can(keys(v)) },
+  )
+  vd7 = merge(
+    merge([for k, v in local.vd6 : { for k2, v2 in v : "${k}.${k2}" => v2 } if can(keys(v))]...),
+    { for k, v in local.vd6 : k => v if !can(keys(v)) },
+  )
+  vd8 = merge(
+    merge([for k, v in local.vd7 : { for k2, v2 in v : "${k}.${k2}" => v2 } if can(keys(v))]...),
+    { for k, v in local.vd7 : k => v if !can(keys(v)) },
+  )
+  vd9 = merge(
+    merge([for k, v in local.vd8 : { for k2, v2 in v : "${k}.${k2}" => v2 } if can(keys(v))]...),
+    { for k, v in local.vd8 : k => v if !can(keys(v)) },
+  )
+  vd10 = merge(
+    merge([for k, v in local.vd9 : { for k2, v2 in v : "${k}.${k2}" => v2 } if can(keys(v))]...),
+    { for k, v in local.vd9 : k => v if !can(keys(v)) },
+  )
+
+  # Leaves as strings. jsonencode on purpose (not tostring): quoted strings
+  # keep scalar types distinguishable.
+  vd_encoded = { for k, v in local.vd10 : k => jsonencode(v) }
+
+  # Sensitivity-marked leaves become short hashes. if-filtered comprehensions
+  # on purpose: a ternary whose condition touches a sensitive value re-marks
+  # its result, and the entry renders "(sensitive value)" again.
+  vd_redacted = merge(
+    { for k, v in local.vd_encoded : k => "sha256:${substr(sha256(nonsensitive(v)), 0, 12)}" if issensitive(v) },
+    { for k, v in local.vd_encoded : k => v if !issensitive(v) },
+  )
+
+  # ConfigMap keys only allow [-._a-zA-Z0-9]. Sanitize, and tolerate a
+  # post-sanitize collision by keeping the first entry (view-only data).
+  vd_grouped       = { for k, v in local.vd_redacted : replace(k, "/[^-._a-zA-Z0-9]/", "_") => v... }
+  values_diff_view = { for k, vl in local.vd_grouped : k => vl[0] }
+}
+
+resource "kubernetes_config_map_v1" "flux_values_diff" {
+  metadata {
+    name      = "dozuki-flux-values-diff"
+    namespace = kubernetes_namespace_v1.flux_system.metadata[0].name
+    labels    = { "app.kubernetes.io/managed-by" = "terraform" }
+  }
+
+  data = local.values_diff_view
+}

--- a/terraform/logical/tls.tf
+++ b/terraform/logical/tls.tf
@@ -14,7 +14,10 @@
 
 locals {
   # Operator-supplied cert/key via tls_cert/tls_key (env.hcl or stack TF_VARs).
-  tls_supplied = var.tls_cert != "" && var.tls_key != ""
+  # nonsensitive: tls_key is a sensitive variable, and a comparison against a
+  # sensitive value yields a sensitive bool, which would poison the whole
+  # tls_manual/count chain. Whether a key was supplied is not a secret.
+  tls_supplied = var.tls_cert != "" && nonsensitive(var.tls_key != "")
   # Generated self-signed cert (dev). Azure-only for now; follow-up to generalize.
   tls_selfsigned = var.cloud == "azure" && var.azure_tls_mode == "self-signed"
   # On AWS (Vault always enabled), supplied certs are seeded into Vault by TF and

--- a/terraform/logical/variables.tf
+++ b/terraform/logical/variables.tf
@@ -492,6 +492,7 @@ variable "tls_key" {
   description = "Base64-encoded PEM TLS private key matching tls_cert. Required when tls_cert is set. Set as a masked Spacelift TF_VAR on the env's logical stack, not in git."
   type        = string
   default     = ""
+  sensitive   = true
 }
 
 variable "customer_tls_externally_managed" {

--- a/terraform/physical/README.md
+++ b/terraform/physical/README.md
@@ -15,11 +15,11 @@
 | Name | Version |
 |------|---------|
 | <a name="provider_archive"></a> [archive](#provider\_archive) | 2.8.0 |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.56.0 |
-| <a name="provider_aws.dns"></a> [aws.dns](#provider\_aws.dns) | 6.56.0 |
-| <a name="provider_aws.dr"></a> [aws.dr](#provider\_aws.dr) | 6.56.0 |
-| <a name="provider_null"></a> [null](#provider\_null) | 3.3.0 |
-| <a name="provider_random"></a> [random](#provider\_random) | 3.9.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 6.0 |
+| <a name="provider_aws.dns"></a> [aws.dns](#provider\_aws.dns) | ~> 6.0 |
+| <a name="provider_aws.dr"></a> [aws.dr](#provider\_aws.dr) | ~> 6.0 |
+| <a name="provider_null"></a> [null](#provider\_null) | ~> 3.0 |
+| <a name="provider_random"></a> [random](#provider\_random) | ~> 3.0 |
 
 ## Modules
 


### PR DESCRIPTION
The Flux move put the app values in a Secret, so a values change plans as one opaque `(sensitive value)` line. This adds a view-only `dozuki-flux-values-diff` ConfigMap in flux-system: `local.app_values` flattened to one dotted-path entry per leaf, so plans (and the PR diff comments generated from them) render exactly the keys that changed:

```
~ "webhooks.enabled" = "false" -> "true"
```

Nothing consumes the ConfigMap; it exists for diff visibility only. Design points:

- Leaves are jsonencoded so string-vs-bool stays visible (the useSSL/redis.tls helm-coercion class of bug shows up in the diff).
- Sensitivity-marked leaves store as short sha256 hashes: rotations visible, values not. `tls_key` gains `sensitive = true` so its leaf redacts like the rest (smtp password and the translate token already were); `tls_supplied` wraps the key-presence check in `nonsensitive()` so the tls_manual/count chain stays legal.
- Flatten is a 10-level unrolled comprehension chain (HCL has no recursion; deepest real path today is 6). ConfigMap-illegal key chars sanitize to `_`.
- Redaction uses if-filtered comprehensions, not a ternary: a ternary whose condition touches a sensitive value re-marks its result and the entry renders opaque again (verified empirically on tofu).

Validated: module `tofu validate` matches master's baseline (only the pre-existing terragrunt-supplied vault address error); the flatten/redaction pipeline was proven in an isolated tofu harness (per-key rendering, hash redaction, key sanitize, list/deep-path handling). Canary: bump min after release and check the ConfigMap create renders per-key, then the next values change shows the one-line diff.