### PR TITLE
fix(logical): carve metrics-server out of namespace-wide STRICT mTLS

### DIFF
--- a/terraform/logical/istio.tf
+++ b/terraform/logical/istio.tf
@@ -228,6 +228,21 @@ locals {
       # external.metrics.k8s.io APIService callback; HPAs break without it.
       ports = [6443]
     }
+    metrics-server = {
+      namespace = "dozuki"
+      selector = {
+        "app.kubernetes.io/name" = "metrics-server"
+      }
+      # metrics.k8s.io APIService callback on the chart's --secure-port. Same class
+      # as prometheus-adapter above, and it arrived with #297/#151: retiring the EKS
+      # addon moved metrics-server out of kube-system (unmeshed) and into the app
+      # namespace, where namespace-wide STRICT rejects the API server's plain-HTTPS
+      # probe. Symptom is `kubectl top` returning "Metrics API not available" and the
+      # APIService going Available=False/FailedDiscoveryCheck, which leaves every
+      # resource-metric HPA reading <unknown> and unable to scale. Custom-metric HPAs
+      # keep working (they go via prometheus-adapter), so this hides well.
+      ports = [10250]
+    }
   }
   mesh_strict_namespaces = ["dozuki", "envoy-gateway-system", "redis-system"]
 }


### PR DESCRIPTION
Blocks rolling chart >= 1.23.0 to any ambient-mesh env with working autoscaling. Found while validating min before promoting to a customer env.

## What breaks

#297 retired the metrics-server EKS addon and #151 gave it to the chart. That moves metrics-server out of `kube-system` (unmeshed) and into the app namespace, which runs namespace-wide STRICT. The API server is outside the mesh, so its plain-HTTPS discovery probe to the pod is rejected:

```
APIService v1beta1.metrics.k8s.io
  Available=False  FailedDiscoveryCheck
  failing or missing response from https://172.16.71.140:10250/apis/metrics.k8s.io/v1beta1
kubectl top nodes -> error: Metrics API not available
```

The pod itself is healthy and serving (`Serving securely on [::]:10250`), so nothing looks wrong from the workload side.

## Measured impact on min (v7.21.0 + chart 1.23.0, mesh STRICT)

| HPA | targets | metric source |
|---|---|---|
| `app-hpa` | `memory: <unknown>/80%, cpu: <unknown>/80%` | metrics-server, **blind** |
| `nextjs-hpa` | `cpu: <unknown>/65%` | metrics-server, **blind** |
| `queueworkerd-hpa` | `0/25 (avg)` | prometheus-adapter, works |

The one that works goes through prometheus-adapter, which already has a carve-out. That asymmetry is why this hides: custom-metric autoscaling keeps functioning while CPU/memory autoscaling silently stops.

## The fix

A fourth entry in the existing carve-out map, same shape and same port as the two webhook entries, keeping STRICT everywhere except the port the API server must reach. `prometheus-adapter`'s entry already carries the comment "HPAs break without it" for the identical failure class.

## Scope

Affects every env at `istio_mesh_state = "strict"` that takes chart >= 1.23.0. Today that is min and gca. gca is deliberately still on chart 1.21.2 and should not be bumped until this is released.