### PR TITLE
fix(logical): give event-service real frontegg credentials

### DIFF
--- a/terraform/logical/flux.tf
+++ b/terraform/logical/flux.tf
@@ -206,9 +206,22 @@ locals {
         appVersion       = local.frontegg_event_service_tag
         imagePullSecrets = []
         database         = { host = local.db_master_host, username = local.db_master_username, useSSL = "true" }
-        configuration    = { secrets = { "dozuki-infra-credentials" = { FRONTEGG_EVENTS_MYSQL_DB_PASSWORD = "master_password" } } }
-        messageBroker    = { brokerList = var.msk_bootstrap_brokers }
-        redis            = { host = "dozuki-redis-master", tls = "false" } # tls stays STRING (was --set-string)
+        # event-service is the only connectivity service that calls api.frontegg.com itself
+        # (FronteggAuthenticator.onModuleInit), so it is the only one that needs the vendor
+        # credentials. Left unmapped it inherits the chart's literal placeholders
+        # ("frontegg_client_id" / "frontegg_api_key") from its own subchart Secret, frontegg
+        # 401s, and the process exits: "Failed to authenticate 3 times. Shutting down..."
+        #
+        # These come from the flat keys on dozuki-infra-credentials (helm #158) rather than
+        # frontegg.json — configuration.secrets maps an env var to one secret KEY and cannot
+        # index into a JSON document. Explicit env beats the subchart's envFrom secretRef.
+        configuration = { secrets = { "dozuki-infra-credentials" = {
+          FRONTEGG_EVENTS_MYSQL_DB_PASSWORD = "master_password"
+          FRONTEGG_CLIENT_ID                = "frontegg_client_id"
+          FRONTEGG_API_KEY                  = "frontegg_api_key"
+        } } }
+        messageBroker = { brokerList = var.msk_bootstrap_brokers }
+        redis         = { host = "dozuki-redis-master", tls = "false" } # tls stays STRING (was --set-string)
       }
       "connectors-worker" = {
         image            = { repository = "${var.image_repository}/hybrid-connectors-worker" }


### PR DESCRIPTION
## What

Maps `FRONTEGG_CLIENT_ID` / `FRONTEGG_API_KEY` for event-service to the flat keys on `dozuki-infra-credentials`, alongside the existing `FRONTEGG_EVENTS_MYSQL_DB_PASSWORD` mapping.

## Why

event-service is the only connectivity service that authenticates against api.frontegg.com itself. With nothing mapped, it fell through to the chart's literal placeholders (`"frontegg_client_id"` / `"frontegg_api_key"`) from its own subchart Secret and exited on boot:

```
module: FronteggAuthenticator.onModuleInit
error: Request failed with status code 401
message: Failed to authenticate 3 times. Shutting down...
```

Not `frontegg.json` (which the monolith reads): `configuration.secrets` maps an env var to a single secret KEY and can't index into a JSON document. Explicit `env` beats the subchart's `envFrom` secretRef, so the mapping wins over the placeholder.

## Depends on

Dozuki/helm#158, which adds `frontegg_client_id` / `frontegg_api_key` as flat keys on the ExternalSecret. This lands with that chart bump.

## Exposure

Only reachable with `enable_webhooks`. No live stack sets it today, but `infra-live/_templates/env.hcl` defaults it on for new customer stacks, so this would have hit the next one. Found on a full-matrix harness run against 7.21.2 / chart 1.25.0 where api-gateway, connectors-worker, integrations-service and webhook-service all came up healthy and event-service was the last pod crashlooping.