### PR TITLE
test(harness): pin chart 1.25.0 and sweep dms-tasks log groups

### DIFF
--- a/live/tests/cleanup-orphans.sh
+++ b/live/tests/cleanup-orphans.sh
@@ -225,7 +225,7 @@ EOF
 # leaves them behind). Two families: the containerinsights groups the CloudWatch addon
 # creates, and /aws/lambda/<identifier>-* which Lambda creates on first invocation —
 # the latter outlived every teardown and was the last straggler on each run.
-for prefix in "/aws/containerinsights/${CUSTOMER}-" "/aws/lambda/${CUSTOMER}-"; do
+for prefix in "/aws/containerinsights/${CUSTOMER}-" "/aws/lambda/${CUSTOMER}-" "dms-tasks-${CUSTOMER}-"; do
   for lg in $(aws logs describe-log-groups --region "$R" --profile "$P" \
         --query "logGroups[?starts_with(logGroupName,'${prefix}')].logGroupName" --output text 2>/dev/null); do
     aws logs delete-log-group --log-group-name "$lg" --region "$R" --profile "$P" 2>/dev/null && echo "  deleted log group: $lg"

--- a/live/tests/matrix.yaml
+++ b/live/tests/matrix.yaml
@@ -18,7 +18,7 @@ defaults:
 version_defaults:
   image_tag: "3625f3c7a3fe9bd3fb87b03a23a4cbb683d44ded.4"
   nextjs_tag: "2.23.0"
-  chart_version: "1.23.0"  # Track the current chart so a run validates the pairing a real deploy
+  chart_version: "1.25.0"  # Track the current chart so a run validates the pairing a real deploy
                            # would get. The floor is 1.18.0: v7.17.0 moved the NLB
                            # TargetGroupBindings (#278) and the frontegg DB-create + ztunnel
                            # PodMonitor (#277) out of TF into the chart, and older charts silently


### PR DESCRIPTION
Two small harness fixes from the full-matrix runs.

**matrix.yaml** — `chart_version` moves to 1.25.0 so runs pick up the connectivity image repointing and the mysql-tls forks.

**cleanup-orphans.sh** — adds `dms-tasks-${CUSTOMER}-` to the log-group sweep. BI runs create a DMS task log group that outlives the destroy, so it accumulated across cycles.