### PR TITLE
test(harness): verify the greenfield schema matches the image's dumps

### DIFF
--- a/live/tests/harness/phases.go
+++ b/live/tests/harness/phases.go
@@ -256,6 +256,17 @@ func (p PhaseParams) Validate(ctx context.Context) (err error) {
 		}
 	}
 
+	// Greenfield only: compare each seeded database against the schema dump in the
+	// deployed image. The migration Job reporting Complete does not mean the schema is
+	// complete — a rejected statement truncates the import and the retry then skips the
+	// whole block and exits 0. Nothing else in this run asks that question.
+	if rm.Scenario == "fresh" {
+		step("verifying greenfield schema matches the image's dumps")
+		if serr := validation.AssertFreshSchemaComplete(kc, rm.Namespace); serr != nil {
+			return fmt.Errorf("schema validation: %w", serr)
+		}
+	}
+
 	if rm.Scenario == "upgrade" {
 		wantChart, _ := p.Matrix.VersionVar(rm.ToRef, "chart_version").(string)
 		step("verifying upgrade proof (advanced from rev %d; chart %q)", rm.BaselineRev, wantChart)

--- a/live/tests/validation/schema.go
+++ b/live/tests/validation/schema.go
@@ -1,0 +1,190 @@
+package validation
+
+import (
+	"fmt"
+	"os/exec"
+	"sort"
+	"strings"
+)
+
+// Schema drift check for FRESH installs.
+//
+// The greenfield bootstrap pipes the schema dumps straight into the mysql client, which
+// stops at the first error. A statement that the engine rejects therefore truncates
+// everything after it — and the failure does not survive to be noticed: the Job retries,
+// db_initialize.sh sees the `sites` database already exists, skips the whole greenfield
+// block, exits 0, and the Job reports Complete. Nothing downstream can tell the
+// difference between "migrated" and "migrated 2% of the way and gave up".
+//
+// That is exactly how the MySQL 8.4 restrict_fk_on_non_standard_key breakage shipped: a
+// fresh 8.4 stack applied green with 4 of 225 guide tables and only announced itself
+// hours later as a 500 on /Login (`Table 'password_requirements_revisions' does not
+// exist`). Cluster health, HelmRelease readiness and Job status were all green
+// throughout, because every one of them was asking a question this failure does not
+// answer.
+//
+// So ask the direct question instead: does the database contain every table the dump it
+// was built from declares? The dump is read out of the RUNNING pod rather than from this
+// repo, so the comparison is always against the schema of the image actually deployed.
+//
+// Fresh-only on purpose. An upgraded stack's tables come from years of accumulated
+// migrations, not from these dumps — drops and renames are legitimate there, so the same
+// comparison would be noise. On a greenfield install the dump is the whole story.
+
+// schemaExpectation pairs a dump in the app image with the database it seeds.
+// Paths are relative to /home/ifixit/Code, matching db_initialize.sh's own `cd`.
+type schemaExpectation struct {
+	dump     string
+	database string
+}
+
+// The greenfield set. onprem_guide is the tenant the deploy FQDN routes to (the one that
+// served the 500s), dozuki_guide is the platform tenant; both are built from the same
+// guide dump. sites/metrics are seeded directly by db_initialize.sh.
+func greenfieldSchemas() []schemaExpectation {
+	return []schemaExpectation{
+		{dump: "Migrations/SchemaSQL/sites.sql", database: "sites"},
+		{dump: "Migrations/SchemaSQL/metrics.sql", database: "metrics"},
+		{dump: "Migrations/SchemaSQL/ifixit_guide.sql", database: "onprem_guide"},
+		{dump: "Migrations/SchemaSQL/ifixit_guide.sql", database: "dozuki_guide"},
+	}
+}
+
+// AssertFreshSchemaComplete fails if any table declared by a greenfield dump is missing
+// from the database that dump seeds. Extra tables are ignored: migrations legitimately
+// add tables the dump predates, and the failure mode being guarded against is truncation.
+func AssertFreshSchemaComplete(kubeconfig, namespace string) error {
+	pod, err := appPod(kubeconfig, namespace)
+	if err != nil {
+		return err
+	}
+
+	var problems []string
+	for _, s := range greenfieldSchemas() {
+		want, got, err := schemaTables(kubeconfig, namespace, pod, s)
+		if err != nil {
+			return fmt.Errorf("%s: %w", s.database, err)
+		}
+		if len(want) == 0 {
+			return fmt.Errorf("%s: parsed 0 tables from %s in the image — the dump moved or the parse broke, so this check is not actually verifying anything", s.database, s.dump)
+		}
+		if len(got) == 0 {
+			problems = append(problems, fmt.Sprintf("%s: database is empty or absent (expected %d tables from %s)", s.database, len(want), s.dump))
+			continue
+		}
+		if missing := missingFrom(want, got); len(missing) > 0 {
+			problems = append(problems, fmt.Sprintf("%s: %d/%d tables missing, e.g. %s",
+				s.database, len(missing), len(want), strings.Join(sample(missing, 8), ", ")))
+		}
+	}
+
+	if len(problems) > 0 {
+		return fmt.Errorf("greenfield schema incomplete (the migration Job reports success but the schema is truncated):\n  %s",
+			strings.Join(problems, "\n  "))
+	}
+	return nil
+}
+
+// schemaTables returns the table names the dump declares and the table names the database
+// actually has. Both come out of the pod in a single exec: the dump is read from the
+// image, and the credentials come from the image's own db_helpers.sh rather than being
+// threaded in from Terraform, so this reads the same database the migrations wrote to by
+// construction.
+func schemaTables(kubeconfig, namespace, pod string, s schemaExpectation) (want, got []string, err error) {
+	// db_helpers.sh opens with `set -exou pipefail`; turn xtrace and nounset back off
+	// after sourcing or the traces land in stdout and unset vars abort the shell.
+	script := fmt.Sprintf(`
+cd /home/ifixit/Code || exit 90
+[ -f %[1]q ] || exit 91
+. /bootstrap/helpers/db_helpers.sh >/dev/null 2>&1 || exit 92
+set +exu
+echo "---WANT---"
+sed -n 's/^CREATE TABLE `+"`"+`\([^`+"`"+`]*\)`+"`"+`.*/\1/p' %[1]q
+echo "---GOT---"
+$mysqlcmd -sN -e "SELECT TABLE_NAME FROM information_schema.tables WHERE TABLE_SCHEMA='%[2]s'" 2>/dev/null
+`, s.dump, s.database)
+
+	out, err := exec.Command("kubectl", "--kubeconfig", kubeconfig, "-n", namespace,
+		"exec", pod, "-c", appContainer, "--", "bash", "-c", script).Output()
+	if err != nil {
+		if ee, ok := err.(*exec.ExitError); ok {
+			switch ee.ExitCode() {
+			case 90:
+				return nil, nil, fmt.Errorf("/home/ifixit/Code missing in the app image")
+			case 91:
+				return nil, nil, fmt.Errorf("schema dump %s missing in the app image (it moved — update greenfieldSchemas)", s.dump)
+			case 92:
+				return nil, nil, fmt.Errorf("could not source /bootstrap/helpers/db_helpers.sh in the app image")
+			}
+			return nil, nil, fmt.Errorf("exec in %s: %v: %s", pod, err, strings.TrimSpace(string(ee.Stderr)))
+		}
+		return nil, nil, fmt.Errorf("exec in %s: %w", pod, err)
+	}
+
+	want, got = parseSchemaOutput(string(out))
+	return want, got, nil
+}
+
+// parseSchemaOutput splits the exec output on its two markers. Anything before the first
+// marker is discarded: the app image's shell profile and db_helpers.sh's own tracing can
+// print before our first echo, and treating that as table names would silently invent
+// expectations.
+func parseSchemaOutput(out string) (want, got []string) {
+	section := ""
+	for _, line := range strings.Split(out, "\n") {
+		line = strings.TrimSpace(line)
+		switch {
+		case line == "---WANT---" || line == "---GOT---":
+			section = line
+		case line == "":
+		case section == "---WANT---":
+			want = append(want, line)
+		case section == "---GOT---":
+			got = append(got, line)
+		}
+	}
+	return want, got
+}
+
+// The chart labels the app deployment app=app and names its container app
+// (deployments.app.name); the pod is dozuki-app-deployment-*. Confirmed against a live
+// cluster, not inferred from the template — the obvious guesses (app=dozuki-app,
+// container dozuki-app) are both wrong and would fail at exec time, deep into a run.
+const (
+	appSelector  = "app=app"
+	appContainer = "app"
+)
+
+// appPod returns a running app pod to exec into. The migration pods would be the
+// more obvious choice but they are Completed, and exec needs Running.
+func appPod(kubeconfig, namespace string) (string, error) {
+	out, err := exec.Command("kubectl", "--kubeconfig", kubeconfig, "-n", namespace,
+		"get", "pods", "-l", appSelector, "--field-selector=status.phase=Running",
+		"-o", "jsonpath={.items[0].metadata.name}").Output()
+	if err != nil || strings.TrimSpace(string(out)) == "" {
+		return "", fmt.Errorf("no running app pod (%s) in %s to inspect the schema from", appSelector, namespace)
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+func missingFrom(want, got []string) []string {
+	have := make(map[string]struct{}, len(got))
+	for _, g := range got {
+		have[strings.ToLower(g)] = struct{}{}
+	}
+	var missing []string
+	for _, w := range want {
+		if _, ok := have[strings.ToLower(w)]; !ok {
+			missing = append(missing, w)
+		}
+	}
+	sort.Strings(missing)
+	return missing
+}
+
+func sample(s []string, n int) []string {
+	if len(s) <= n {
+		return s
+	}
+	return append(append([]string{}, s[:n]...), fmt.Sprintf("… (+%d more)", len(s)-n))
+}

--- a/live/tests/validation/schema_test.go
+++ b/live/tests/validation/schema_test.go
@@ -1,0 +1,95 @@
+package validation
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseSchemaOutputIgnoresPreamble(t *testing.T) {
+	// Leading noise is the realistic case: the app image's profile and db_helpers.sh's
+	// `set -x` can both write before our first marker.
+	out := strings.Join([]string{
+		"+ cd /home/ifixit/Code",
+		"some shell noise",
+		"---WANT---",
+		"users",
+		"password_requirements_revisions",
+		"",
+		"---GOT---",
+		"users",
+	}, "\n")
+
+	want, got := parseSchemaOutput(out)
+	if len(want) != 2 || want[0] != "users" || want[1] != "password_requirements_revisions" {
+		t.Errorf("want = %v, expected the two declared tables and no preamble", want)
+	}
+	if len(got) != 1 || got[0] != "users" {
+		t.Errorf("got = %v, expected just [users]", got)
+	}
+}
+
+func TestParseSchemaOutputEmptyDatabase(t *testing.T) {
+	// An absent database yields a WANT list and no GOT rows. That must parse as empty
+	// rather than erroring, so the caller can report it as the truncation it is.
+	want, got := parseSchemaOutput("---WANT---\nusers\n---GOT---\n")
+	if len(want) != 1 {
+		t.Errorf("want = %v, expected 1 table", want)
+	}
+	if len(got) != 0 {
+		t.Errorf("got = %v, expected none", got)
+	}
+}
+
+func TestMissingFromIsCaseInsensitive(t *testing.T) {
+	// information_schema casing does not always match the dump's; a case difference is
+	// not a missing table and must not be reported as one.
+	if m := missingFrom([]string{"Users"}, []string{"users"}); len(m) != 0 {
+		t.Errorf("missingFrom = %v, expected no missing tables for a case difference", m)
+	}
+}
+
+func TestMissingFromReportsTruncation(t *testing.T) {
+	// The real failure shape: the import died early, so only the first few tables exist.
+	want := []string{"a", "b", "password_requirements_revisions", "z"}
+	missing := missingFrom(want, []string{"a", "b"})
+	if len(missing) != 2 {
+		t.Fatalf("missingFrom = %v, expected 2 missing", missing)
+	}
+	if missing[0] != "password_requirements_revisions" || missing[1] != "z" {
+		t.Errorf("missingFrom = %v, expected sorted missing names", missing)
+	}
+}
+
+func TestMissingFromExtraTablesAreNotFailures(t *testing.T) {
+	// Migrations add tables the dump predates. Only absence matters.
+	if m := missingFrom([]string{"a"}, []string{"a", "added_later"}); len(m) != 0 {
+		t.Errorf("missingFrom = %v, expected extras to be ignored", m)
+	}
+}
+
+func TestSampleTruncatesWithCount(t *testing.T) {
+	s := sample([]string{"a", "b", "c", "d"}, 2)
+	if len(s) != 3 || s[2] != "… (+2 more)" {
+		t.Errorf("sample = %v, expected 2 names plus a remainder count", s)
+	}
+	if full := sample([]string{"a"}, 2); len(full) != 1 {
+		t.Errorf("sample = %v, expected a short list to pass through unchanged", full)
+	}
+}
+
+func TestGreenfieldSchemasCoverTheGuideDatabases(t *testing.T) {
+	// The guide DBs are where the 8.4 FK truncation landed; a refactor that drops them
+	// would leave this check green against the exact bug it exists for.
+	seen := map[string]bool{}
+	for _, s := range greenfieldSchemas() {
+		if s.dump == "" || s.database == "" {
+			t.Errorf("incomplete expectation: %+v", s)
+		}
+		seen[s.database] = true
+	}
+	for _, db := range []string{"sites", "metrics", "onprem_guide", "dozuki_guide"} {
+		if !seen[db] {
+			t.Errorf("greenfieldSchemas is missing %s", db)
+		}
+	}
+}


### PR DESCRIPTION
## The gap

Nothing in a fresh run could distinguish "migrated" from "migrated 2% of the way and gave up".

The greenfield bootstrap pipes the schema dumps into the `mysql` client, which stops at the first error — so one rejected statement truncates everything after it. Then the evidence erases itself: the Job retries, `db_initialize.sh` sees the `sites` DB already exists, skips the entire greenfield block, exits 0, and the Job reports `Complete`.

That's how the MySQL 8.4 `restrict_fk_on_non_standard_key` breakage shipped. A fresh 8.4 stack applied **green** with 4 of 225 guide tables and only announced itself hours later as a 500 on `/Login` (`Table 'password_requirements_revisions' does not exist`). Cluster health, HelmRelease readiness and Job status were green the entire time — each was asking a question this failure doesn't answer.

## The check

For every database the greenfield bootstrap seeds, assert that every table its dump declares is present:

| dump | database |
|---|---|
| `Migrations/SchemaSQL/sites.sql` | `sites` |
| `Migrations/SchemaSQL/metrics.sql` | `metrics` |
| `Migrations/SchemaSQL/ifixit_guide.sql` | `onprem_guide`, `dozuki_guide` |

The dump is read out of the **running pod**, not this repo, so the comparison always tracks the image actually deployed. Credentials come from the image's own `db_helpers.sh` rather than being threaded in from Terraform, so it reads the same database the migrations wrote to by construction.

Failure names the count and a sample:

```
schema validation: greenfield schema incomplete (the migration Job reports success
but the schema is truncated):
  onprem_guide: 215/219 tables missing, e.g. api_guide_watch, … (+207 more)
```

Extra tables are ignored — migrations legitimately add tables the dump predates, and truncation is the failure being guarded against.

**Fresh-only.** An upgraded stack's tables come from years of accumulated migrations rather than these dumps, where drops and renames are expected; the same comparison would be noise.

## Verified

- The `sed` extraction pulls **219/219** `CREATE TABLE` names out of the real `ifixit_guide.sql`, including `password_requirements_revisions`.
- Pod selector and container name confirmed against a live cluster capture, not inferred from the chart: the app deployment is `app=app` with container `app`. The obvious guesses (`app=dozuki-app` / container `dozuki-app`) are both wrong and would have failed at exec time deep into a two-hour run.
- Unit tests cover preamble stripping (shell tracing before the first marker), empty-database parsing, case-insensitive comparison, the truncation shape, extras-are-not-failures, and that the guide DBs stay in the expectation set.