### PR TITLE
feat(physical): aurora_migration_state - RDS to Aurora alongside-migration rig

### DIFF
--- a/terraform/physical/README.md
+++ b/terraform/physical/README.md
@@ -15,17 +15,19 @@
 | Name | Version |
 |------|---------|
 | <a name="provider_archive"></a> [archive](#provider\_archive) | 2.8.0 |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 6.0 |
-| <a name="provider_aws.dns"></a> [aws.dns](#provider\_aws.dns) | ~> 6.0 |
-| <a name="provider_aws.dr"></a> [aws.dr](#provider\_aws.dr) | ~> 6.0 |
-| <a name="provider_null"></a> [null](#provider\_null) | ~> 3.0 |
-| <a name="provider_random"></a> [random](#provider\_random) | ~> 3.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.56.0 |
+| <a name="provider_aws.dns"></a> [aws.dns](#provider\_aws.dns) | 6.56.0 |
+| <a name="provider_aws.dr"></a> [aws.dr](#provider\_aws.dr) | 6.56.0 |
+| <a name="provider_null"></a> [null](#provider\_null) | 3.3.0 |
+| <a name="provider_random"></a> [random](#provider\_random) | 3.9.0 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_aurora"></a> [aurora](#module\_aurora) | terraform-aws-modules/rds-aurora/aws | 10.2.0 |
+| <a name="module_aurora_migration_dms_sg"></a> [aurora\_migration\_dms\_sg](#module\_aurora\_migration\_dms\_sg) | terraform-aws-modules/security-group/aws | ~> 5.0 |
+| <a name="module_aurora_migration_guard_sg"></a> [aurora\_migration\_guard\_sg](#module\_aurora\_migration\_guard\_sg) | terraform-aws-modules/security-group/aws | ~> 5.0 |
 | <a name="module_bastion"></a> [bastion](#module\_bastion) | terraform-aws-modules/autoscaling/aws | ~> 9.0 |
 | <a name="module_bastion_sg"></a> [bastion\_sg](#module\_bastion\_sg) | terraform-aws-modules/security-group/aws | ~> 5.0 |
 | <a name="module_bi_database_sg"></a> [bi\_database\_sg](#module\_bi\_database\_sg) | terraform-aws-modules/security-group/aws | ~> 5.0 |
@@ -66,11 +68,17 @@
 | [aws_db_parameter_group.bi_replica](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_parameter_group) | resource |
 | [aws_db_parameter_group.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_parameter_group) | resource |
 | [aws_db_subnet_group.dr_aurora](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_subnet_group) | resource |
+| [aws_dms_certificate.aurora_migration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dms_certificate) | resource |
 | [aws_dms_certificate.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dms_certificate) | resource |
+| [aws_dms_endpoint.aurora_migration_source](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dms_endpoint) | resource |
+| [aws_dms_endpoint.aurora_migration_target](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dms_endpoint) | resource |
 | [aws_dms_endpoint.source](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dms_endpoint) | resource |
 | [aws_dms_endpoint.target](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dms_endpoint) | resource |
+| [aws_dms_replication_instance.aurora_migration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dms_replication_instance) | resource |
 | [aws_dms_replication_instance.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dms_replication_instance) | resource |
+| [aws_dms_replication_subnet_group.aurora_migration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dms_replication_subnet_group) | resource |
 | [aws_dms_replication_subnet_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dms_replication_subnet_group) | resource |
+| [aws_dms_replication_task.aurora_migration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dms_replication_task) | resource |
 | [aws_dms_replication_task.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dms_replication_task) | resource |
 | [aws_eks_pod_identity_association.app_default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_pod_identity_association) | resource |
 | [aws_eks_pod_identity_association.app_migration_wait](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_pod_identity_association) | resource |
@@ -152,6 +160,7 @@
 | [aws_security_group.dr_aurora](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_security_group.kafka](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_security_group.vault_endpoint](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
+| [aws_security_group_rule.aurora_migration_dms_to_rds](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.kafka_egress](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.kafka_ingress_cidr_blocks](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.kafka_ingress_security_groups](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
@@ -170,6 +179,7 @@
 | [aws_vpc.dr_aurora](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc) | resource |
 | [aws_vpc_endpoint.s3](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_endpoint) | resource |
 | [aws_vpc_endpoint.vault](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_endpoint) | resource |
+| [null_resource.create_dms_access_for_tasks_role](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [null_resource.create_dms_cloudwatch_role](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [null_resource.create_dms_vpc_role](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [null_resource.replication_control](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
@@ -193,6 +203,7 @@
 | [aws_iam_policy_document.s3_replication_assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_role.dms-cloudwatch-role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_role) | data source |
 | [aws_iam_role.dms-vpc-role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_role) | data source |
+| [aws_iam_roles.dms-access-for-tasks](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_roles) | data source |
 | [aws_iam_roles.dms-cloudwatch-roles](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_roles) | data source |
 | [aws_iam_roles.dms-vpc-roles](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_roles) | data source |
 | [aws_kms_key.eks](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/kms_key) | data source |
@@ -219,6 +230,10 @@
 | <a name="input_app_public_access"></a> [app\_public\_access](#input\_app\_public\_access) | Should the app and dashboard be accessible via a publicly routable IP and domain? | `bool` | `true` | no |
 | <a name="input_aurora_engine_version"></a> [aurora\_engine\_version](#input\_aurora\_engine\_version) | Aurora MySQL engine version, full aws RDS format (e.g. 8.4.mysql\_aurora.8.4.7 — the bare 8.4.7 is rejected with 'Cannot find version'). Fresh cluster: an 8.4 version. Snapshot-restore migration: an 8.0-compatible version first, then upgrade. | `string` | `"8.4.mysql_aurora.8.4.7"` | no |
 | <a name="input_aurora_max_acu"></a> [aurora\_max\_acu](#input\_aurora\_max\_acu) | Aurora Serverless v2 maximum capacity (ACUs). | `number` | `16` | no |
+| <a name="input_aurora_migration_dms_engine_version"></a> [aurora\_migration\_dms\_engine\_version](#input\_aurora\_migration\_dms\_engine\_version) | Pinned DMS engine version for the migration rig (run-to-run reproducibility; 3.6.1 = the rehearsal-proven version). | `string` | `"3.6.1"` | no |
+| <a name="input_aurora_migration_dms_instance_type"></a> [aurora\_migration\_dms\_instance\_type](#input\_aurora\_migration\_dms\_instance\_type) | Replication instance class for the Aurora migration DMS rig. | `string` | `"dms.c5.large"` | no |
+| <a name="input_aurora_migration_dms_storage"></a> [aurora\_migration\_dms\_storage](#input\_aurora\_migration\_dms\_storage) | Allocated storage (GB) for the Aurora migration DMS replication instance. | `number` | `100` | no |
+| <a name="input_aurora_migration_state"></a> [aurora\_migration\_state](#input\_aurora\_migration\_state) | RDS -> Aurora DMS migration state machine (aurora-migration.tf). off = no<br>migration (default). provision = Aurora comes up empty alongside the live RDS,<br>guarded to DMS+bastion, with the DMS rig created but not started. cutover =<br>connection facts (secret/outputs/BI DMS/bastion) flip to Aurora and the app SG<br>path opens - apply only at the migration runner's go-live gate. cleanup = the<br>DMS rig is removed; Aurora stays primary, the RDS survives as the fail-forward<br>net until the env's final db\_engine="aurora" flip. Only meaningful while<br>db\_engine="rds". | `string` | `"off"` | no |
 | <a name="input_aurora_min_acu"></a> [aurora\_min\_acu](#input\_aurora\_min\_acu) | Aurora Serverless v2 minimum capacity (ACUs). | `number` | `0.5` | no |
 | <a name="input_aurora_snapshot_identifier"></a> [aurora\_snapshot\_identifier](#input\_aurora\_snapshot\_identifier) | Optional RDS DB snapshot ARN to restore the Aurora cluster from (migration path). Empty = fresh cluster. | `string` | `""` | no |
 | <a name="input_aws_profile"></a> [aws\_profile](#input\_aws\_profile) | If running terraform from a workstation, which AWS CLI profile should we use for asset provisioning. | `string` | `""` | no |
@@ -278,6 +293,8 @@
 |------|-------------|
 | <a name="output_aurora_dr_global_cluster_id"></a> [aurora\_dr\_global\_cluster\_id](#output\_aurora\_dr\_global\_cluster\_id) | Aurora global cluster id (empty unless the Aurora DR secondary is enabled). |
 | <a name="output_aurora_dr_secondary_endpoint"></a> [aurora\_dr\_secondary\_endpoint](#output\_aurora\_dr\_secondary\_endpoint) | Reader endpoint of the headless DR secondary (populated once instances exist post-failover). |
+| <a name="output_aurora_migration_target_endpoint"></a> [aurora\_migration\_target\_endpoint](#output\_aurora\_migration\_target\_endpoint) | Aurora cluster writer endpoint during a migration (empty otherwise). Runner/runbook convenience; the app only ever sees it through the credentials secret after cutover. |
+| <a name="output_aurora_migration_task_arn"></a> [aurora\_migration\_task\_arn](#output\_aurora\_migration\_task\_arn) | ARN of the Aurora migration DMS task (empty when no migration is active). Consumed by the migration runner. |
 | <a name="output_azs_count"></a> [azs\_count](#output\_azs\_count) | n/a |
 | <a name="output_bastion_asg_name"></a> [bastion\_asg\_name](#output\_bastion\_asg\_name) | n/a |
 | <a name="output_bi_database_credential_secret"></a> [bi\_database\_credential\_secret](#output\_bi\_database\_credential\_secret) | If BI is enabled, this is the ARN to the AWS SecretsManager secret that contains the connection information for the BI database. |

--- a/terraform/physical/aurora-migration.tf
+++ b/terraform/physical/aurora-migration.tf
@@ -1,0 +1,224 @@
+# RDS -> Aurora Serverless v2 migration rig (DMS), driven by var.aurora_migration_state.
+# The state machine (each transition one env.hcl change + one gated Spacelift apply):
+#
+#   off       - nothing here exists; normal single-engine behavior.
+#   provision - Aurora (aurora.tf, count widened by local.aurora_present) comes up EMPTY
+#               alongside the live RDS, reachable ONLY through the guard SG (DMS + bastion;
+#               the app must never boot against an empty 8.4 - the fresh-install sharp
+#               edge). This file's DMS rig is created but the task is NOT started; the
+#               migration runner (schema pre-load, task orchestration, validation, fence)
+#               drives everything DB-side from the env bastion via SSM.
+#   cutover   - db.tf's locals flip every consumer (credentials secret, outputs, BI DMS
+#               source, bastion mysql config) to Aurora and aurora.tf swaps the cluster
+#               onto the primary DB SG. Applied only at the runner's go-live gate.
+#   cleanup   - this rig (DMS instance/endpoints/task, guard SG, subnet group) is
+#               destroyed. Aurora stays primary; the RDS survives read_only as the
+#               fail-forward net until the env's final db_engine="aurora" flip retires it
+#               (a deliberate apply that trips the db-replace-guard OPA label on purpose).
+#
+# The task settings/mappings are the values proven by the 2026-07-26 gca rehearsal
+# (docs: 3m-aurora-dms-migration-design): DO_NOTHING prep (schema is pre-loaded natively),
+# BatchApplyEnabled=false + target FK-checks-off Initstmt during load (MySQL does not
+# binlog cascaded child rows - the runner removes the Initstmt, while stopped, after
+# deferred FKs are active), auto-stop after cached changes, limited LOB @128KB, row
+# validation, fail-fast error policy.
+
+locals {
+  # The DMS rig lives through provision + cutover and is removed at cleanup.
+  aurora_migration_dms = contains(["provision", "cutover"], var.aurora_migration_state)
+}
+
+# --- network guard -----------------------------------------------------------
+
+# The migration DMS instance's own SG (egress-only; DMS dials out to both DBs).
+module "aurora_migration_dms_sg" {
+  source  = "terraform-aws-modules/security-group/aws"
+  version = "~> 5.0"
+  count   = local.aurora_migration_dms ? 1 : 0
+
+  name            = "${local.identifier}-aurora-migration-dms"
+  use_name_prefix = false
+  description     = "Aurora migration DMS instance"
+  vpc_id          = local.vpc_id
+
+  egress_rules = ["all-tcp"]
+
+  tags = local.tags
+}
+
+# Guard SG: the ONLY SG on the Aurora cluster while state="provision". Admits the
+# migration DMS instance and the bastion - nothing else, most importantly not the
+# EKS cluster SG, so no app pod can reach the target before cutover.
+module "aurora_migration_guard_sg" {
+  source  = "terraform-aws-modules/security-group/aws"
+  version = "~> 5.0"
+  count   = local.aurora_migration_dms ? 1 : 0
+
+  name            = "${local.identifier}-aurora-migration-guard"
+  use_name_prefix = false
+  description     = "Aurora migration target guard (DMS + bastion only)"
+  vpc_id          = local.vpc_id
+
+  ingress_with_source_security_group_id = [
+    {
+      rule                     = "mysql-tcp"
+      source_security_group_id = module.aurora_migration_dms_sg[0].security_group_id
+    },
+    {
+      rule                     = "mysql-tcp"
+      source_security_group_id = module.bastion_sg.security_group_id
+    },
+  ]
+
+  tags = local.tags
+}
+
+# The migration DMS instance must also read the live RDS (full load + CDC). The
+# primary DB SG's ingress is authored in rds.tf; this standalone rule appends to
+# it without touching the module (append-only - no recreate risk on that SG).
+resource "aws_security_group_rule" "aurora_migration_dms_to_rds" {
+  count = local.aurora_migration_dms ? 1 : 0
+
+  type                     = "ingress"
+  from_port                = 3306
+  to_port                  = 3306
+  protocol                 = "tcp"
+  security_group_id        = module.primary_database_sg.security_group_id
+  source_security_group_id = module.aurora_migration_dms_sg[0].security_group_id
+  description              = "Aurora migration DMS source reads"
+}
+
+# --- IAM: dms-access-for-tasks -----------------------------------------------
+
+# Account-wide role the DMS premigration assessment requires (absent from this
+# account today - the rehearsal had to skip the assessment API without it). Same
+# keep-out-of-state pattern as the dms-vpc/cloudwatch roles in bi.tf: created
+# only if missing, never owned by any one stack.
+data "aws_iam_roles" "dms-access-for-tasks" {
+  name_regex = "dms-access-for-tasks"
+}
+resource "null_resource" "create_dms_access_for_tasks_role" {
+  count = local.aurora_migration_dms ? length(data.aws_iam_roles.dms-access-for-tasks.names) > 0 ? 0 : 1 : 0
+
+  provisioner "local-exec" {
+    command = <<-EOT
+      aws iam create-role \
+        --role-name dms-access-for-tasks \
+        --assume-role-policy-document '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"dms.${data.aws_partition.current.dns_suffix}"},"Action":"sts:AssumeRole"}]}'
+      aws iam attach-role-policy \
+        --role-name dms-access-for-tasks \
+        --policy-arn arn:${data.aws_partition.current.partition}:iam::aws:policy/service-role/AmazonDMSRedshiftS3Role || true
+    EOT
+  }
+}
+
+# --- DMS rig -----------------------------------------------------------------
+
+resource "aws_dms_replication_subnet_group" "aurora_migration" {
+  count = local.aurora_migration_dms ? 1 : 0
+
+  replication_subnet_group_id          = "${local.identifier}-aurora-migration"
+  replication_subnet_group_description = "${local.identifier} aurora migration subnet group"
+
+  subnet_ids = local.private_subnet_ids
+
+  tags = local.tags
+}
+
+resource "aws_dms_replication_instance" "aurora_migration" {
+  count = local.aurora_migration_dms ? 1 : 0
+
+  replication_instance_id    = "${local.identifier}-aurora-migration"
+  replication_instance_class = var.aurora_migration_dms_instance_type
+  allocated_storage          = var.aurora_migration_dms_storage
+  engine_version             = var.aurora_migration_dms_engine_version
+  auto_minor_version_upgrade = false # pinned for run-to-run reproducibility across the fleet
+
+  publicly_accessible         = false
+  replication_subnet_group_id = aws_dms_replication_subnet_group.aurora_migration[0].id
+
+  vpc_security_group_ids = [module.aurora_migration_dms_sg[0].security_group_id]
+
+  tags = local.tags
+}
+
+resource "aws_dms_certificate" "aurora_migration" {
+  count = local.aurora_migration_dms ? 1 : 0
+
+  certificate_id  = "${local.identifier}-aurora-migration"
+  certificate_pem = file(local.ca_cert_pem_file)
+
+  tags = local.tags
+}
+
+# Source: ALWAYS the RDS instance, referenced directly - never local.db_host,
+# which flips to Aurora at cutover (the source must keep reading RDS through the
+# fence). 48h binlog retention gives the CDC checkpoint generous slack.
+resource "aws_dms_endpoint" "aurora_migration_source" {
+  count = local.aurora_migration_dms ? 1 : 0
+
+  endpoint_id                 = "${local.identifier}-aurora-migration-source"
+  certificate_arn             = aws_dms_certificate.aurora_migration[0].certificate_arn
+  ssl_mode                    = "verify-full"
+  endpoint_type               = "source"
+  engine_name                 = "mysql"
+  extra_connection_attributes = "afterConnectScript=call mysql.rds_set_configuration('binlog retention hours', 48);"
+  port                        = 3306
+
+  username    = local.db_username
+  password    = module.primary_database[0].db_instance_password
+  server_name = module.primary_database[0].db_instance_address
+
+  tags = local.tags
+}
+
+# Target: the Aurora CLUSTER writer endpoint (never the instance endpoint - the
+# cluster endpoint follows a writer failover; instance endpoints do not). The
+# FK-checks-off Initstmt is load-phase only: the migration runner REMOVES it
+# (endpoint modify, while the task is stopped post-full-load) so ongoing CDC
+# applies with FKs active and target-side cascades execute. ignore_changes keeps
+# Terraform from re-adding it behind the runner's back.
+resource "aws_dms_endpoint" "aurora_migration_target" {
+  count = local.aurora_migration_dms ? 1 : 0
+
+  endpoint_id                 = "${local.identifier}-aurora-migration-target"
+  certificate_arn             = aws_dms_certificate.aurora_migration[0].certificate_arn
+  ssl_mode                    = "verify-full"
+  endpoint_type               = "target"
+  engine_name                 = "aurora"
+  extra_connection_attributes = "Initstmt=SET FOREIGN_KEY_CHECKS=0;"
+  port                        = 3306
+
+  username    = local.db_username
+  password    = random_password.aurora[0].result
+  server_name = module.aurora[0].cluster_endpoint
+
+  tags = local.tags
+
+  lifecycle {
+    ignore_changes = [extra_connection_attributes]
+  }
+}
+
+# Created, never auto-started: the runner starts it only after the native schema
+# pre-load passes its information_schema diff gate.
+resource "aws_dms_replication_task" "aurora_migration" {
+  count = local.aurora_migration_dms ? 1 : 0
+
+  replication_task_id       = "${local.identifier}-aurora-migration"
+  migration_type            = "full-load-and-cdc"
+  replication_instance_arn  = aws_dms_replication_instance.aurora_migration[0].replication_instance_arn
+  table_mappings            = file("static/aurora_migration_mapping.json")
+  replication_task_settings = file("static/aurora_migration_settings.json")
+
+  source_endpoint_arn = aws_dms_endpoint.aurora_migration_source[0].endpoint_arn
+  target_endpoint_arn = aws_dms_endpoint.aurora_migration_target[0].endpoint_arn
+
+  tags = local.tags
+
+  lifecycle {
+    # The runner owns the task lifecycle (start/stop/resume around its gates);
+    # settings drift (e.g. validation counters) must not dirty the plan.
+    ignore_changes = [replication_task_settings]
+  }
+}

--- a/terraform/physical/aurora.tf
+++ b/terraform/physical/aurora.tf
@@ -11,7 +11,7 @@ locals {
 }
 
 resource "random_password" "aurora" {
-  count   = local.db_is_aurora ? 1 : 0
+  count   = local.aurora_present ? 1 : 0
   length  = 40
   special = false
 }
@@ -20,7 +20,11 @@ module "aurora" {
   source  = "terraform-aws-modules/rds-aurora/aws"
   version = "10.2.0"
 
-  count = local.db_is_aurora ? 1 : 0
+  # Present for the steady-state aurora engine AND during an RDS->Aurora DMS
+  # migration (aurora-migration.tf), where it runs ALONGSIDE the live RDS. Both
+  # gates keep the same module instance alive, so the eventual db_engine="aurora"
+  # + aurora_migration_state="off" flip is a no-op for this cluster.
+  count = local.aurora_present ? 1 : 0
 
   name            = local.identifier
   engine          = "aurora-mysql"
@@ -47,7 +51,16 @@ module "aurora" {
     var.rds_multi_az ? { reader = { instance_class = "db.serverless", performance_insights_enabled = true } } : {}
   )
 
-  vpc_security_group_ids = [module.primary_database_sg.security_group_id]
+  # Network guard during a migration: while state="provision" the cluster is
+  # reachable ONLY by the migration DMS instance + the bastion (guard SG,
+  # aurora-migration.tf) - the app cannot touch the empty/loading target even by
+  # misconfiguration (the fresh-install sharp edge). At "cutover" this swaps
+  # in-place to the primary DB SG and the app path opens.
+  vpc_security_group_ids = (
+    var.aurora_migration_state == "provision"
+    ? [module.aurora_migration_guard_sg[0].security_group_id]
+    : [module.primary_database_sg.security_group_id]
+  )
   subnets                = local.private_subnet_ids
   create_db_subnet_group = true
 
@@ -79,7 +92,18 @@ module "aurora" {
         { name = "binlog_format", value = "ROW", apply_method = "pending-reboot" },
         { name = "binlog_row_image", value = "full", apply_method = "pending-reboot" },
         { name = "binlog_checksum", value = "NONE", apply_method = "pending-reboot" },
+        # Explicit even though 0 is the engine default: it must match the RDS
+        # source at migration time and is immutable after cluster creation.
+        { name = "lower_case_table_names", value = "0", apply_method = "pending-reboot" },
       ],
+      # Migration-only relaxations, removed again after cleanup. local_infile is
+      # required by DMS full load; the event scheduler stays OFF until the
+      # cutover repoint so nothing fires on the target before the first app
+      # write (the migration runner asserts both at its gates).
+      local.aurora_migration_active && var.aurora_migration_state == "provision" ? [
+        { name = "local_infile", value = "1", apply_method = "immediate" },
+        { name = "event_scheduler", value = "OFF", apply_method = "immediate" },
+      ] : [],
       contains(var.rds_log_exports, "audit") ? [
         { name = "server_audit_logging", value = "1", apply_method = "immediate" },
         { name = "server_audit_events", value = "CONNECT,QUERY_DCL,QUERY_DDL", apply_method = "immediate" },

--- a/terraform/physical/db.tf
+++ b/terraform/physical/db.tf
@@ -2,17 +2,34 @@
 # var.db_engine. Both module.primary_database (rds) and module.aurora (aurora)
 # are count-gated, so exactly one is present. Consumed by the credentials secret
 # (rds.tf), DMS endpoints (bi.tf), and outputs.tf.
+#
+# aurora_migration_state widens this: during an RDS->Aurora DMS migration
+# (aurora-migration.tf) BOTH engines exist side by side. The Aurora cluster comes
+# up at "provision" (guarded, DMS-only reachable), and these locals - and with
+# them every consumer: the credentials secret, the BI DMS source endpoint, the
+# bastion mysql association, outputs - flip to Aurora at "cutover". db_engine
+# stays "rds" through the whole migration so the live RDS is never in a destroy
+# path; the final retirement (env flips db_engine="aurora" + state="off") is a
+# separate, deliberate, OPA-labeled apply.
 locals {
   db_is_aurora = var.db_engine == "aurora"
 
-  db_host = local.db_is_aurora ? module.aurora[0].cluster_endpoint : module.primary_database[0].db_instance_address
-  db_port = local.db_is_aurora ? module.aurora[0].cluster_port : module.primary_database[0].db_instance_port
+  # Aurora exists: the steady-state aurora engine OR any active migration phase.
+  aurora_migration_active = var.aurora_migration_state != "off"
+  aurora_present          = local.db_is_aurora || local.aurora_migration_active
+
+  # Connection facts point at Aurora: steady-state aurora OR the migration has
+  # reached cutover (cleanup keeps them on Aurora while the DMS rig is removed).
+  db_uses_aurora = local.db_is_aurora || contains(["cutover", "cleanup"], var.aurora_migration_state)
+
+  db_host = local.db_uses_aurora ? module.aurora[0].cluster_endpoint : module.primary_database[0].db_instance_address
+  db_port = local.db_uses_aurora ? module.aurora[0].cluster_port : module.primary_database[0].db_instance_port
 
   db_username = "dozuki"
-  db_password = local.db_is_aurora ? random_password.aurora[0].result : module.primary_database[0].db_instance_password
+  db_password = local.db_uses_aurora ? random_password.aurora[0].result : module.primary_database[0].db_instance_password
 
-  db_identifier  = local.db_is_aurora ? module.aurora[0].cluster_id : module.primary_database[0].db_instance_id
-  db_resource_id = local.db_is_aurora ? module.aurora[0].cluster_resource_id : module.primary_database[0].db_instance_resource_id
+  db_identifier  = local.db_uses_aurora ? module.aurora[0].cluster_id : module.primary_database[0].db_instance_id
+  db_resource_id = local.db_uses_aurora ? module.aurora[0].cluster_resource_id : module.primary_database[0].db_instance_resource_id
 
-  db_reader_endpoint = local.db_is_aurora ? module.aurora[0].cluster_reader_endpoint : ""
+  db_reader_endpoint = local.db_uses_aurora ? module.aurora[0].cluster_reader_endpoint : ""
 }

--- a/terraform/physical/outputs.tf
+++ b/terraform/physical/outputs.tf
@@ -116,3 +116,13 @@ output "dr_rds_backup_replication_arn" {
   description = "ARN of the replicated RDS automated backups in the DR region."
   value       = try(aws_db_instance_automated_backups_replication.primary[0].id, "")
 }
+
+output "aurora_migration_task_arn" {
+  description = "ARN of the Aurora migration DMS task (empty when no migration is active). Consumed by the migration runner."
+  value       = try(aws_dms_replication_task.aurora_migration[0].replication_task_arn, "")
+}
+
+output "aurora_migration_target_endpoint" {
+  description = "Aurora cluster writer endpoint during a migration (empty otherwise). Runner/runbook convenience; the app only ever sees it through the credentials secret after cutover."
+  value       = try(module.aurora[0].cluster_endpoint, "")
+}

--- a/terraform/physical/static/aurora_migration_mapping.json
+++ b/terraform/physical/static/aurora_migration_mapping.json
@@ -1,0 +1,11 @@
+{
+  "rules": [
+    {
+      "rule-type": "selection",
+      "rule-id": "1",
+      "rule-name": "all-app-schemas",
+      "object-locator": { "schema-name": "%", "table-name": "%" },
+      "rule-action": "include"
+    }
+  ]
+}

--- a/terraform/physical/static/aurora_migration_settings.json
+++ b/terraform/physical/static/aurora_migration_settings.json
@@ -1,0 +1,33 @@
+{
+  "TargetMetadata": {
+    "TargetSchema": "",
+    "SupportLobs": true,
+    "FullLobMode": false,
+    "LimitedSizeLobMode": true,
+    "LobMaxSize": 128,
+    "BatchApplyEnabled": false,
+    "TaskRecoveryTableEnabled": false
+  },
+  "FullLoadSettings": {
+    "TargetTablePrepMode": "DO_NOTHING",
+    "StopTaskCachedChangesApplied": true,
+    "StopTaskCachedChangesNotApplied": false,
+    "MaxFullLoadSubTasks": 8,
+    "CommitRate": 10000
+  },
+  "ValidationSettings": {
+    "EnableValidation": true,
+    "ValidationMode": "ROW_LEVEL",
+    "ThreadCount": 5,
+    "FailureMaxCount": 10000,
+    "TableFailureMaxCount": 1000
+  },
+  "ErrorBehavior": {
+    "DataErrorPolicy": "STOP_TASK",
+    "DataTruncationErrorPolicy": "STOP_TASK",
+    "TableErrorPolicy": "STOP_TASK",
+    "DataErrorEscalationPolicy": "STOP_TASK"
+  },
+  "Logging": { "EnableLogging": true },
+  "ControlTablesSettings": { "ControlSchema": "awsdms_control" }
+}

--- a/terraform/physical/util/aurora-migration-runner.sh
+++ b/terraform/physical/util/aurora-migration-runner.sh
@@ -1,0 +1,263 @@
+#!/usr/bin/env bash
+# RDS -> Aurora Serverless v2 migration runner. Drives the DB-side phases the
+# aurora_migration_state Terraform (aurora-migration.tf) cannot: native schema
+# pre-load, DMS task orchestration, validation gates, and the fence/cutover
+# sequence. Every step is the 2026-07-26 gca-rehearsal procedure, productionized
+# (design doc: 3m-aurora-dms-migration-design).
+#
+# Runs on an operator machine with aws cli + jq; all SQL executes ON THE ENV
+# BASTION via SSM (the bastion has mariadb + the primary-DB .my.cnf from its
+# State Manager association). Nothing here talks to a database directly.
+#
+# Usage:
+#   AWS_PROFILE=... aurora-migration-runner.sh <identifier> <region> <phase>
+# Phases (in order):
+#   status    - show everything (safe anytime)
+#   preload   - schema dump/split, dangling-FK scan, base DDL, md5 diff gate
+#   load      - premigration assessment, start task, wait auto-stop, deferred
+#               DDL (indexes then FKs = orphan check), drop the FK Initstmt,
+#               resume CDC
+#   validate  - DMS validation clean + checksums (frozen check; run pre-fence)
+#   fence     - the cutover fence: writer scale-down is YOURS (kubectl); this
+#               does marker + read_only + negative test + the go-live gate and
+#               stops the task at its checkpoint. Prints GO/NO-GO.
+#   cutover-verify - post-`aurora_migration_state=cutover` apply: identity +
+#               committed-write check on Aurora, event scheduler assert.
+#   abort     - pre-first-write abort: revert read_only, resume writers on RDS.
+#   bi-epoch  - restart the BI DMS task against the (now Aurora) source.
+set -euo pipefail
+
+ID="${1:?identifier (e.g. m3-gca)}"; REGION="${2:?region}"; PHASE="${3:?phase}"
+RUN_TAG="aurora-mig-$(date -u +%Y%m%d)"
+SRC_ID="$ID"                       # module.primary_database db identifier
+CLUSTER_ID="$ID"                   # module.aurora cluster identifier
+TASK_ID="${ID}-aurora-migration"   # aws_dms_replication_task.aurora_migration
+
+say() { printf '%s %s\n' "$(date -u +%H:%M:%SZ)" "$*"; }
+die() { say "FATAL: $*" >&2; exit 1; }
+
+# --- discovery ---------------------------------------------------------------
+bastion_id() {
+  aws ec2 describe-instances --region "$REGION" \
+    --filters "Name=tag:Role,Values=Bastion" "Name=instance-state-name,Values=running" \
+               "Name=tag:Environment,Values=${ID#*-}" \
+    --query 'Reservations[0].Instances[0].InstanceId' --output text
+}
+rds_endpoint() { aws rds describe-db-instances --db-instance-identifier "$SRC_ID" --region "$REGION" --query 'DBInstances[0].Endpoint.Address' --output text; }
+aurora_endpoint() { aws rds describe-db-clusters --db-cluster-identifier "$CLUSTER_ID" --region "$REGION" --query 'DBClusters[0].Endpoint' --output text; }
+task_arn() { aws dms describe-replication-tasks --region "$REGION" --filters "Name=replication-task-id,Values=$TASK_ID" --query 'ReplicationTasks[0].ReplicationTaskArn' --output text; }
+task_status() { aws dms describe-replication-tasks --region "$REGION" --filters "Name=replication-task-id,Values=$TASK_ID" --query 'ReplicationTasks[0].Status' --output text; }
+secret_arn() { aws rds describe-db-instances --db-instance-identifier "$SRC_ID" --region "$REGION" >/dev/null && aws secretsmanager list-secrets --region "$REGION" --query "SecretList[?starts_with(Name, '${ID}-database')].ARN | [0]" --output text; }
+src_pg() { aws rds describe-db-instances --db-instance-identifier "$SRC_ID" --region "$REGION" --query 'DBInstances[0].DBParameterGroups[0].DBParameterGroupName' --output text; }
+
+# --- bastion exec (SSM) -------------------------------------------------------
+# ssm_run <<'EOF' ... EOF  -> runs the heredoc as one shell script on the bastion,
+# echoes its stdout, dies on failure. jq builds the params JSON (quote-safe).
+ssm_run() {
+  local script cid status
+  script="$(cat)"
+  cid=$(aws ssm send-command --region "$REGION" --instance-ids "$(bastion_id)" \
+        --document-name AWS-RunShellScript --timeout-seconds 5400 \
+        --parameters "$(jq -n --arg c "$script" '{commands: [$c]}')" \
+        --query 'Command.CommandId' --output text)
+  while :; do
+    status=$(aws ssm get-command-invocation --region "$REGION" --command-id "$cid" --instance-id "$(bastion_id)" --query Status --output text 2>/dev/null || echo Pending)
+    case "$status" in Success|Failed|Cancelled|TimedOut) break;; esac; sleep 10
+  done
+  aws ssm get-command-invocation --region "$REGION" --command-id "$cid" --instance-id "$(bastion_id)" --query StandardOutputContent --output text
+  [ "$status" = "Success" ] || { aws ssm get-command-invocation --region "$REGION" --command-id "$cid" --instance-id "$(bastion_id)" --query StandardErrorContent --output text >&2; die "bastion step failed ($status)"; }
+}
+
+# Write /tmp/mig-{src,tgt}.cnf on the bastion from the credentials secret (same
+# username/password on both sides; only the host differs). Explicit hosts - the
+# association's .my.cnf follows local.db_host, which flips at cutover.
+prep_cnfs() {
+  local sec src tgt; sec=$(secret_arn); src=$(rds_endpoint); tgt=$(aurora_endpoint)
+  ssm_run <<EOF
+set -e; umask 177
+C=\$(aws secretsmanager get-secret-value --region $REGION --secret-id "$sec" --query SecretString --output text)
+U=\$(echo "\$C" | jq -r .username); P=\$(echo "\$C" | jq -r .password)
+for pair in "src $src" "tgt $tgt"; do set -- \$pair
+  printf '[client]\nhost=%s\nuser=%s\npassword=%s\nssl\n' "\$2" "\$U" "\$P" > /tmp/mig-\$1.cnf
+done
+echo CNFS_READY
+EOF
+}
+msrc() { echo "mariadb --defaults-extra-file=/tmp/mig-src.cnf --batch --skip-column-names"; }
+mtgt() { echo "mariadb --defaults-extra-file=/tmp/mig-tgt.cnf --batch --skip-column-names --init-command=\"SET SESSION restrict_fk_on_non_standard_key=0\""; }
+
+# =============================================================================
+case "$PHASE" in
+
+status)
+  say "task: $(task_status 2>/dev/null || echo none)  rds: $(rds_endpoint 2>/dev/null || echo none)  aurora: $(aurora_endpoint 2>/dev/null || echo none)"
+  ;;
+
+preload)
+  prep_cnfs
+  ssm_run <<'EOF'
+set -e; cd /tmp; rm -rf mig && mkdir mig && cd mig
+S="mariadb --defaults-extra-file=/tmp/mig-src.cnf --batch --skip-column-names"
+T="mariadb --defaults-extra-file=/tmp/mig-tgt.cnf --batch --skip-column-names --init-command='SET SESSION restrict_fk_on_non_standard_key=0'"
+# gate: source CDC prereqs
+$S -e "SELECT @@binlog_format, @@binlog_row_image, @@log_bin" | grep -q "ROW	FULL	1" || { echo "SOURCE NOT CDC-READY"; exit 1; }
+# gate: lower_case_table_names must match (immutable on the target)
+[ "$($S -e 'SELECT @@lower_case_table_names')" = "$(eval $T -e "'SELECT @@lower_case_table_names'")" ] || { echo LCTN_MISMATCH; exit 1; }
+# schema list (system + DMS control schemas excluded)
+$S -e "SELECT schema_name FROM information_schema.schemata WHERE schema_name NOT IN ('mysql','information_schema','performance_schema','sys','innodb','tmp','awsdms_control')" > schemas.txt
+# dangling-FK scan: FKs whose referenced table does not exist are unenforceable
+# residue (created with FK checks off) - excluded from the target, reported.
+$S -e "SELECT CONCAT(k.constraint_schema,'.',k.table_name,'.',k.constraint_name) FROM information_schema.key_column_usage k LEFT JOIN information_schema.tables t ON t.table_schema=k.referenced_table_schema AND t.table_name=k.referenced_table_name WHERE k.referenced_table_name IS NOT NULL AND t.table_name IS NULL" > dangling-fks.txt
+echo "dangling FKs: $(wc -l < dangling-fks.txt)"; cat dangling-fks.txt
+# dump DDL, split base (tables w/o secondary indexes+FKs) vs deferred
+mariadb-dump --defaults-extra-file=/tmp/mig-src.cnf --no-data --skip-triggers --databases $(tr '\n' ' ' < schemas.txt) > full.sql
+python3 - <<'PYEOF'
+import re
+base, deferred, buf, cur_t, cur_s, inc = [], [], [], None, None, False
+dangling = set()
+for l in open('dangling-fks.txt'):
+    p = l.strip().split('.')
+    if len(p) == 3: dangling.add((p[0], p[2]))
+def flush():
+    for i in range(len(buf)-1, -1, -1):
+        s = buf[i].strip()
+        if s.startswith(')'):
+            j = i-1
+            while j >= 0 and not buf[j].strip(): j -= 1
+            if j >= 0 and buf[j].rstrip().endswith(','): buf[j] = buf[j].rstrip()[:-1]+'\n'
+            break
+    base.extend(buf); buf.clear()
+for line in open('full.sql', errors='replace'):
+    if line.startswith('CREATE TABLE'):
+        inc = True; m = re.match(r'CREATE TABLE `([^`]+)`', line); cur_t = m.group(1) if m else None
+        buf.append(line); continue
+    if line.startswith('USE `') or 'CREATE DATABASE' in line:
+        m = re.search(r'`([^`]+)`', line); cur_s = m.group(1) if m else cur_s
+        base.append(line); continue
+    if inc:
+        s = line.strip(); fq = f"`{cur_s}`.`{cur_t}`"
+        cm = re.match(r'CONSTRAINT `([^`]+)` FOREIGN KEY', s)
+        if cm and 'FOREIGN KEY' in s:
+            if (cur_s, cm.group(1)) not in dangling:
+                deferred.append(f"ALTER TABLE {fq} ADD {s.rstrip(',')};\n")
+            continue
+        if re.match(r'^(KEY|INDEX|FULLTEXT KEY|SPATIAL KEY) ', s):
+            deferred.append(f"ALTER TABLE {fq} ADD {s.rstrip(',')};\n"); continue
+        buf.append(line)
+        if s.startswith(')') and s.endswith(';'): inc = False; flush()
+    else:
+        base.append(line)
+open('base.sql','w').writelines(base)
+open('deferred-idx.sql','w').writelines([l for l in deferred if 'FOREIGN KEY' not in l])
+open('deferred-fk.sql','w').writelines([l for l in deferred if 'FOREIGN KEY' in l])
+print(f"base={len(base)} idx={sum('FOREIGN KEY' not in l for l in deferred)} fk={sum('FOREIGN KEY' in l for l in deferred)}")
+PYEOF
+eval $T < base.sql; echo BASE_APPLIED
+# md5 diff gate: identical column definitions on both sides (base tables only)
+Q="SELECT c.table_schema,c.table_name,c.column_name,c.column_type,c.is_nullable,IFNULL(c.column_default,'~N~'),c.extra FROM information_schema.columns c JOIN information_schema.tables t ON c.table_schema=t.table_schema AND c.table_name=t.table_name WHERE t.table_type='BASE TABLE' AND c.table_schema NOT IN ('mysql','information_schema','performance_schema','sys','innodb','tmp','awsdms_control') ORDER BY c.table_schema,c.table_name,c.ordinal_position"
+$S -e "$Q" > cols-src.tsv; eval $T -e "\"$Q\"" > cols-tgt.tsv
+[ "$(md5sum < cols-src.tsv)" = "$(md5sum < cols-tgt.tsv)" ] && echo MD5_GATE_PASS || { echo MD5_GATE_FAIL; diff cols-src.tsv cols-tgt.tsv | head -20; exit 1; }
+EOF
+  say "preload complete - md5 gate passed; review any dangling FKs above"
+  ;;
+
+load)
+  [ "$(task_status)" = "ready" ] || die "task not ready (status=$(task_status))"
+  say "premigration assessment"
+  aws dms start-replication-task-assessment --replication-task-arn "$(task_arn)" --region "$REGION" >/dev/null || say "WARN: assessment API unavailable - inventory gates from preload stand in"
+  say "starting full load + CDC"
+  aws dms start-replication-task --replication-task-arn "$(task_arn)" --start-replication-task-type start-replication --region "$REGION" >/dev/null
+  say "waiting for the automatic post-full-load stop (StopTaskCachedChangesApplied)"
+  while :; do s=$(task_status); say "  task=$s"; [ "$s" = "stopped" ] && break; [ "$s" = "failed" ] && die "task failed - check the DMS task log"; sleep 60; done
+  say "applying deferred DDL (indexes, then FKs = orphan check) while quiescent"
+  prep_cnfs
+  ssm_run <<'EOF'
+set -e; cd /tmp/mig
+T="mariadb --defaults-extra-file=/tmp/mig-tgt.cnf --init-command='SET SESSION restrict_fk_on_non_standard_key=0'"
+eval $T < deferred-idx.sql; echo IDX_APPLIED
+eval $T < deferred-fk.sql;  echo FK_APPLIED_ZERO_ORPHANS
+EOF
+  say "removing the FK-off Initstmt from the target endpoint (task stopped)"
+  TEP=$(aws dms describe-endpoints --region "$REGION" --filters "Name=endpoint-id,Values=${ID}-aurora-migration-target" --query 'Endpoints[0].EndpointArn' --output text)
+  aws dms modify-endpoint --endpoint-arn "$TEP" --extra-connection-attributes "" --region "$REGION" >/dev/null
+  RIARN=$(aws dms describe-replication-instances --region "$REGION" --filters "Name=replication-instance-id,Values=${ID}-aurora-migration" --query 'ReplicationInstances[0].ReplicationInstanceArn' --output text)
+  aws dms test-connection --replication-instance-arn "$RIARN" --endpoint-arn "$TEP" --region "$REGION" >/dev/null
+  say "waiting for the endpoint re-test (modify invalidates it)"
+  while [ "$(aws dms describe-connections --region "$REGION" --filters "Name=endpoint-arn,Values=$TEP" --query 'Connections[0].Status' --output text)" != "successful" ]; do sleep 10; done
+  say "resuming CDC (fresh sessions, FK checks ON)"
+  aws dms start-replication-task --replication-task-arn "$(task_arn)" --start-replication-task-type resume-processing --region "$REGION" >/dev/null
+  while [ "$(task_status)" != "running" ]; do sleep 10; done
+  say "load complete - CDC running. Soak >= 1 day, then 'validate'."
+  ;;
+
+validate)
+  say "DMS validation states:"
+  aws dms describe-table-statistics --replication-task-arn "$(task_arn)" --region "$REGION" --query 'TableStatistics[].ValidationState' --output text | tr '\t' '\n' | sort | uniq -c
+  BAD=$(aws dms describe-table-statistics --replication-task-arn "$(task_arn)" --region "$REGION" --query 'length(TableStatistics[?ValidationState!=`Validated` && ValidationState!=`No primary Key`])' --output text)
+  [ "$BAD" = "0" ] && say "VALIDATION GATE PASS (no-PK tables are the only exceptions - review the list above)" || die "validation gate FAIL: $BAD tables not Validated"
+  ;;
+
+fence)
+  say "PRECONDITION (yours): app writers scaled down (queueworkerd/crond/app write tier) + DDL freeze in effect"
+  prep_cnfs
+  SEC=$(secret_arn); MARK="cutover-$(date -u +%s)"
+  say "step 1: kill remaining app sessions + commit marker '$MARK'"
+  ssm_run <<EOF
+set -e
+S="mariadb --defaults-extra-file=/tmp/mig-src.cnf --batch --skip-column-names"
+\$S -e "CREATE DATABASE IF NOT EXISTS aurora_mig_ctl; CREATE TABLE IF NOT EXISTS aurora_mig_ctl.marker (id INT AUTO_INCREMENT PRIMARY KEY, tag VARCHAR(64), at DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6));"
+for id in \$(\$S -e "SELECT id FROM information_schema.processlist WHERE user NOT IN ('rdsadmin','\$(\$S -e 'SELECT CURRENT_USER()' | cut -d@ -f1)') AND command != 'Binlog Dump'"); do \$S -e "CALL mysql.rds_kill(\$id);" || true; done
+\$S -e "INSERT INTO aurora_mig_ctl.marker (tag) VALUES ('$MARK');"
+echo MARKER_COMMITTED
+EOF
+  say "step 2: read_only=1 via parameter group + poll"
+  aws rds modify-db-parameter-group --db-parameter-group-name "$(src_pg)" --region "$REGION" --parameters "ParameterName=read_only,ParameterValue=1,ApplyMethod=immediate" >/dev/null
+  while :; do RO=$(ssm_run <<'EOF'
+mariadb --defaults-extra-file=/tmp/mig-src.cnf --batch --skip-column-names -e "SELECT @@read_only"
+EOF
+); RO=$(echo "$RO" | tr -d '[:space:]'); say "  read_only=$RO"; [ "$RO" = "1" ] && break; sleep 15; done
+  say "step 3: negative write test (must be refused)"
+  ssm_run <<'EOF'
+if mariadb --defaults-extra-file=/tmp/mig-src.cnf -e "INSERT INTO aurora_mig_ctl.marker (tag) VALUES ('must-fail');" 2>/tmp/neg.err; then echo FENCE_BREACH; exit 1; else echo FENCE_OK; fi
+EOF
+  say "step 4: go-live gate - marker on Aurora + validation drained + task stop"
+  while :; do N=$(ssm_run <<EOF
+mariadb --defaults-extra-file=/tmp/mig-tgt.cnf --batch --skip-column-names -e "SELECT COUNT(*) FROM aurora_mig_ctl.marker WHERE tag='$MARK'" 2>/dev/null || echo 0
+EOF
+); N=$(echo "$N" | tr -d '[:space:]'); say "  marker_on_aurora=$N"; [ "$N" = "1" ] && break; sleep 10; done
+  while :; do P=$(aws dms describe-table-statistics --replication-task-arn "$(task_arn)" --region "$REGION" --query 'length(TableStatistics[?ValidationState==`Pending records`||ValidationState==`Suspended records`||ValidationState==`Mismatched records`])' --output text); say "  unclean_validation_tables=$P"; [ "$P" = "0" ] && break; sleep 20; done
+  aws dms stop-replication-task --replication-task-arn "$(task_arn)" --region "$REGION" >/dev/null
+  while [ "$(task_status)" != "stopped" ]; do sleep 10; done
+  say "GO: gate passed, task stopped at checkpoint: $(aws dms describe-replication-tasks --region "$REGION" --filters "Name=replication-task-id,Values=$TASK_ID" --query 'ReplicationTasks[0].RecoveryCheckpoint' --output text)"
+  say "NEXT: apply aurora_migration_state=cutover (Spacelift), then run 'cutover-verify'"
+  ;;
+
+cutover-verify)
+  prep_cnfs
+  ssm_run <<'EOF'
+set -e
+T="mariadb --defaults-extra-file=/tmp/mig-tgt.cnf --batch --skip-column-names"
+$T -e "SELECT @@aurora_version" | grep -q "8.4" || { echo WRONG_TARGET; exit 1; }
+$T -e "INSERT INTO aurora_mig_ctl.marker (tag) VALUES ('PROMOTION-FIRST-WRITE');" && echo AURORA_WRITE_COMMITTED
+echo "event_scheduler=$($T -e 'SELECT @@event_scheduler')"
+EOF
+  say "point of no return crossed - fail forward from here. Scale writers back up; leave RDS read_only."
+  ;;
+
+abort)
+  say "pre-first-write abort: unfencing the source"
+  aws rds modify-db-parameter-group --db-parameter-group-name "$(src_pg)" --region "$REGION" --parameters "ParameterName=read_only,ParameterValue=0,ApplyMethod=immediate" >/dev/null
+  say "read_only reverting - verify with 'status', scale writers back up on RDS. Aurora untouched."
+  ;;
+
+bi-epoch)
+  say "restarting the BI DMS task with a full reload against the (now Aurora) source"
+  BI=$(aws dms describe-replication-tasks --region "$REGION" --filters "Name=replication-task-id,Values=$ID" --query 'ReplicationTasks[0].{arn:ReplicationTaskArn,st:Status}' --output json)
+  ARN=$(echo "$BI" | jq -r .arn); ST=$(echo "$BI" | jq -r .st)
+  [ "$ST" = "running" ] && { aws dms stop-replication-task --replication-task-arn "$ARN" --region "$REGION" >/dev/null; while [ "$(aws dms describe-replication-tasks --region "$REGION" --filters "Name=replication-task-id,Values=$ID" --query 'ReplicationTasks[0].Status' --output text)" != "stopped" ]; do sleep 10; done; }
+  aws dms start-replication-task --replication-task-arn "$ARN" --start-replication-task-type reload-target --region "$REGION" >/dev/null
+  say "BI task reloading from Aurora (its source endpoint already follows the flipped db host)"
+  ;;
+
+*) die "unknown phase: $PHASE" ;;
+esac

--- a/terraform/physical/variables.tf
+++ b/terraform/physical/variables.tf
@@ -463,6 +463,47 @@ variable "aurora_snapshot_identifier" {
   default     = ""
 }
 
+variable "aurora_migration_state" {
+  description = <<-EOT
+    RDS -> Aurora DMS migration state machine (aurora-migration.tf). off = no
+    migration (default). provision = Aurora comes up empty alongside the live RDS,
+    guarded to DMS+bastion, with the DMS rig created but not started. cutover =
+    connection facts (secret/outputs/BI DMS/bastion) flip to Aurora and the app SG
+    path opens - apply only at the migration runner's go-live gate. cleanup = the
+    DMS rig is removed; Aurora stays primary, the RDS survives as the fail-forward
+    net until the env's final db_engine="aurora" flip. Only meaningful while
+    db_engine="rds".
+  EOT
+  type        = string
+  default     = "off"
+  validation {
+    condition     = contains(["off", "provision", "cutover", "cleanup"], var.aurora_migration_state)
+    error_message = "aurora_migration_state must be one of: off, provision, cutover, cleanup."
+  }
+  validation {
+    condition     = var.aurora_migration_state == "off" || var.db_engine == "rds"
+    error_message = "aurora_migration_state is only meaningful while db_engine=\"rds\" (it migrates RDS to Aurora)."
+  }
+}
+
+variable "aurora_migration_dms_instance_type" {
+  description = "Replication instance class for the Aurora migration DMS rig."
+  type        = string
+  default     = "dms.c5.large"
+}
+
+variable "aurora_migration_dms_storage" {
+  description = "Allocated storage (GB) for the Aurora migration DMS replication instance."
+  type        = number
+  default     = 100
+}
+
+variable "aurora_migration_dms_engine_version" {
+  description = "Pinned DMS engine version for the migration rig (run-to-run reproducibility; 3.6.1 = the rehearsal-proven version)."
+  type        = string
+  default     = "3.6.1"
+}
+
 
 variable "delete_after" {
   description = "Optional RFC3339 timestamp. When set, every resource is tagged deleteAfter=<value> so the ResourceReaper janitor can purge it after that time if teardown fails. Empty = no tag (normal deploys)."


### PR DESCRIPTION
Adds an `aurora_migration_state` state machine (off/provision/cutover/cleanup) to the physical layer for DMS-based RDS -> Aurora Serverless v2 migrations, one gated apply per transition.

## How it works
- **provision**: `module.aurora`'s count widens so the cluster comes up empty ALONGSIDE the live RDS (db_engine stays "rds" - the RDS is never in a destroy path). The cluster sits on a new guard SG reachable only by the migration DMS instance and the bastion, so nothing can boot against the empty target. The DMS rig (pinned engine, verify-full TLS endpoints, task with rehearsal-proven settings) is created but never auto-started; a runner drives it from the env bastion.
- **cutover**: `db.tf`'s engine-neutral locals flip, repointing the credentials secret, outputs, BI DMS source, and bastion mysql config to Aurora in one apply; the cluster swaps onto the primary DB SG.
- **cleanup**: the DMS rig is removed. Aurora stays primary; the RDS survives (read_only, fail-forward net) until the env's final `db_engine="aurora"` flip retires it - which deliberately trips the db-replace-guard OPA policy.

## Notable details
- Source endpoint pins the RDS instance address directly (never `local.db_host`, which flips at cutover); target uses the Aurora cluster writer endpoint (survives failover).
- Target's load-phase `Initstmt=SET FOREIGN_KEY_CHECKS=0` is removed out-of-band by the runner after deferred FKs are active (ignore_changes guards it) - MySQL doesn't binlog cascaded child rows, so CDC must apply with FKs on.
- `lower_case_table_names` pinned explicitly (immutable at creation, must match the source); `local_infile` + `event_scheduler=OFF` are provision-phase-only cluster params.
- `dms-access-for-tasks` account role created via the same keep-out-of-state pattern as the dms-vpc role.

The runner scripts (schema pre-load, task orchestration, validation gates, fence/cutover) come in a follow-up PR.