### PR TITLE
fix(physical): aurora migration review round 2 - fence ownership, creds, gates

### DIFF
--- a/terraform/physical/README.md
+++ b/terraform/physical/README.md
@@ -20,6 +20,7 @@
 | <a name="provider_aws.dr"></a> [aws.dr](#provider\_aws.dr) | 6.56.0 |
 | <a name="provider_null"></a> [null](#provider\_null) | 3.3.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | 3.9.0 |
+| <a name="provider_terraform"></a> [terraform](#provider\_terraform) | n/a |
 
 ## Modules
 
@@ -153,8 +154,10 @@
 | [aws_s3_bucket_versioning.dr_guide_buckets](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_versioning) | resource |
 | [aws_s3_bucket_versioning.guide_buckets_versioning](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_versioning) | resource |
 | [aws_s3_bucket_versioning.logging_bucket_versioning_block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_versioning) | resource |
+| [aws_secretsmanager_secret.aurora_migration_credentials](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret) | resource |
 | [aws_secretsmanager_secret.primary_database_credentials](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret) | resource |
 | [aws_secretsmanager_secret.replica_database_credentials](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret) | resource |
+| [aws_secretsmanager_secret_version.aurora_migration_credentials](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_version) | resource |
 | [aws_secretsmanager_secret_version.primary_database_credentials](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_version) | resource |
 | [aws_secretsmanager_secret_version.replica_database_credentials](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_version) | resource |
 | [aws_security_group.dr_aurora](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
@@ -185,6 +188,7 @@
 | [null_resource.replication_control](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [null_resource.s3_replication_job_init](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [random_password.aurora](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
+| [terraform_data.aurora_migration_phase](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/resources/data) | resource |
 | [archive_file.dms_restart_lambda](https://registry.terraform.io/providers/hashicorp/archive/2.8.0/docs/data-sources/file) | data source |
 | [archive_file.slack_sns_lambda](https://registry.terraform.io/providers/hashicorp/archive/2.8.0/docs/data-sources/file) | data source |
 | [aws_availability_zones.available](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/availability_zones) | data source |
@@ -233,6 +237,7 @@
 | <a name="input_aurora_migration_dms_engine_version"></a> [aurora\_migration\_dms\_engine\_version](#input\_aurora\_migration\_dms\_engine\_version) | Pinned DMS engine version for the migration rig (run-to-run reproducibility; 3.6.1 = the rehearsal-proven version). | `string` | `"3.6.1"` | no |
 | <a name="input_aurora_migration_dms_instance_type"></a> [aurora\_migration\_dms\_instance\_type](#input\_aurora\_migration\_dms\_instance\_type) | Replication instance class for the Aurora migration DMS rig. | `string` | `"dms.c5.large"` | no |
 | <a name="input_aurora_migration_dms_storage"></a> [aurora\_migration\_dms\_storage](#input\_aurora\_migration\_dms\_storage) | Allocated storage (GB) for the Aurora migration DMS replication instance. | `number` | `100` | no |
+| <a name="input_aurora_migration_source_fenced"></a> [aurora\_migration\_source\_fenced](#input\_aurora\_migration\_source\_fenced) | Cutover write-fence for the RDS source during an Aurora migration. When true,<br>read\_only=1 is injected into the RDS parameter group AS CONFIG, so the fence<br>is Terraform-owned: no concurrent or subsequent apply can silently revert it<br>(an out-of-band fence would be reset by any refreshed apply mid-cutover).<br>Set true (gated apply) at the runner's fence step; back to false only on a<br>pre-cutover abort. On RDS MySQL 8.0.36+ read\_only=1 is a complete fence for<br>every customer account - no grantable privilege bypasses it. | `bool` | `false` | no |
 | <a name="input_aurora_migration_state"></a> [aurora\_migration\_state](#input\_aurora\_migration\_state) | RDS -> Aurora DMS migration state machine (aurora-migration.tf). off = no<br>migration (default). provision = Aurora comes up empty alongside the live RDS,<br>guarded to DMS+bastion, with the DMS rig created but not started. cutover =<br>connection facts (secret/outputs/BI DMS/bastion) flip to Aurora and the app SG<br>path opens - apply only at the migration runner's go-live gate. cleanup = the<br>DMS rig is removed; Aurora stays primary, the RDS survives as the fail-forward<br>net until the env's final db\_engine="aurora" flip. Only meaningful while<br>db\_engine="rds". | `string` | `"off"` | no |
 | <a name="input_aurora_min_acu"></a> [aurora\_min\_acu](#input\_aurora\_min\_acu) | Aurora Serverless v2 minimum capacity (ACUs). | `number` | `0.5` | no |
 | <a name="input_aurora_snapshot_identifier"></a> [aurora\_snapshot\_identifier](#input\_aurora\_snapshot\_identifier) | Optional RDS DB snapshot ARN to restore the Aurora cluster from (migration path). Empty = fresh cluster. | `string` | `""` | no |
@@ -293,6 +298,7 @@
 |------|-------------|
 | <a name="output_aurora_dr_global_cluster_id"></a> [aurora\_dr\_global\_cluster\_id](#output\_aurora\_dr\_global\_cluster\_id) | Aurora global cluster id (empty unless the Aurora DR secondary is enabled). |
 | <a name="output_aurora_dr_secondary_endpoint"></a> [aurora\_dr\_secondary\_endpoint](#output\_aurora\_dr\_secondary\_endpoint) | Reader endpoint of the headless DR secondary (populated once instances exist post-failover). |
+| <a name="output_aurora_migration_credentials_secret"></a> [aurora\_migration\_credentials\_secret](#output\_aurora\_migration\_credentials\_secret) | Secret ARN holding the Aurora migration target credentials (empty when no migration is active). Runner use only. |
 | <a name="output_aurora_migration_target_endpoint"></a> [aurora\_migration\_target\_endpoint](#output\_aurora\_migration\_target\_endpoint) | Aurora cluster writer endpoint during a migration (empty otherwise). Runner/runbook convenience; the app only ever sees it through the credentials secret after cutover. |
 | <a name="output_aurora_migration_task_arn"></a> [aurora\_migration\_task\_arn](#output\_aurora\_migration\_task\_arn) | ARN of the Aurora migration DMS task (empty when no migration is active). Consumed by the migration runner. |
 | <a name="output_azs_count"></a> [azs\_count](#output\_azs\_count) | n/a |

--- a/terraform/physical/aurora-migration.tf
+++ b/terraform/physical/aurora-migration.tf
@@ -222,3 +222,61 @@ resource "aws_dms_replication_task" "aurora_migration" {
     ignore_changes = [replication_task_settings]
   }
 }
+
+# --- migration credentials -----------------------------------------------------
+
+# Aurora's master password (random_password.aurora) exists only in Terraform
+# state until cutover updates the primary credentials secret. The migration
+# runner needs target credentials from provision onward, so they get their own
+# secret for the migration's lifetime.
+resource "aws_secretsmanager_secret" "aurora_migration_credentials" {
+  count = local.aurora_migration_dms ? 1 : 0
+
+  name_prefix             = "${local.identifier}-aurora-migration"
+  description             = "Aurora migration target credentials (runner use only; removed at cleanup)"
+  recovery_window_in_days = 0
+
+  tags = local.tags
+}
+
+resource "aws_secretsmanager_secret_version" "aurora_migration_credentials" {
+  count = local.aurora_migration_dms ? 1 : 0
+
+  secret_id = aws_secretsmanager_secret.aurora_migration_credentials[0].id
+  secret_string = jsonencode({
+    host     = module.aurora[0].cluster_endpoint
+    port     = 3306
+    username = local.db_username
+    password = random_password.aurora[0].result
+  })
+}
+
+# --- transition safety ---------------------------------------------------------
+
+# Phase memory: replaced on every state change, so the PLAN DIFF always shows
+# "aurora_migration_phase must be replaced: <old> -> <new>" - the reviewer of the
+# gated apply sees the transition explicitly. Terraform cannot hard-enforce a
+# transition graph at plan time (the previous value is unknowable exactly when it
+# changes), so enforcement is layered instead:
+#   - the db-replace-guard OPA policy already fails any plan that destroys the
+#     Aurora cluster or the RDS instance without the allow-db-replace label
+#     (covers the catastrophic cutover/cleanup -> off reversal);
+#   - every transition is a gated, human-confirmed Spacelift apply showing this
+#     resource's replacement diff;
+#   - the migration runner's phases each assert the AWS-side facts they need
+#     (task exists/stopped, marker present, secret host) before acting.
+resource "terraform_data" "aurora_migration_phase" {
+  input            = var.aurora_migration_state
+  triggers_replace = var.aurora_migration_state
+
+  lifecycle {
+    # The BI replica secret mixes hosts/credentials across engines if a
+    # non-DMS BI path is active during a migration (its host selector keys on
+    # db_engine, its credentials on local.db_*). The 3M fleet is BI-via-DMS;
+    # anything else must not migrate until that seam is reworked.
+    precondition {
+      condition     = var.aurora_migration_state == "off" || !var.enable_bi || local.dms_enabled
+      error_message = "aurora_migration_state requires BI disabled or BI-via-DMS (bi_dms_enabled/bi_public_access): the RDS-read-replica BI path would mix engines at cutover."
+    }
+  }
+}

--- a/terraform/physical/aurora-migration.tf
+++ b/terraform/physical/aurora-migration.tf
@@ -117,6 +117,15 @@ resource "null_resource" "create_dms_access_for_tasks_role" {
 resource "aws_dms_replication_subnet_group" "aurora_migration" {
   count = local.aurora_migration_dms ? 1 : 0
 
+  # AWS requires the account-wide DMS roles to exist before the first DMS
+  # resource is created; the create-if-absent null_resources must win the race
+  # on a fresh account.
+  depends_on = [
+    null_resource.create_dms_vpc_role,
+    null_resource.create_dms_cloudwatch_role,
+    null_resource.create_dms_access_for_tasks_role,
+  ]
+
   replication_subnet_group_id          = "${local.identifier}-aurora-migration"
   replication_subnet_group_description = "${local.identifier} aurora migration subnet group"
 

--- a/terraform/physical/bi.tf
+++ b/terraform/physical/bi.tf
@@ -1,6 +1,6 @@
 
 data "aws_iam_role" "dms-vpc-role" {
-  count = local.dms_enabled ? try(length(data.aws_iam_roles.dms-vpc-roles.arns), 0) > 0 ? 1 : 0 : 0
+  count = (local.dms_enabled || local.aurora_migration_dms) ? try(length(data.aws_iam_roles.dms-vpc-roles.arns), 0) > 0 ? 1 : 0 : 0
 
   name = "dms-vpc-role"
 }
@@ -8,7 +8,7 @@ data "aws_iam_roles" "dms-vpc-roles" {
   name_regex = "dms-vpc-role"
 }
 data "aws_iam_role" "dms-cloudwatch-role" {
-  count = local.dms_enabled ? try(length(data.aws_iam_roles.dms-cloudwatch-roles.arns), 0) > 0 ? 1 : 0 : 0
+  count = (local.dms_enabled || local.aurora_migration_dms) ? try(length(data.aws_iam_roles.dms-cloudwatch-roles.arns), 0) > 0 ? 1 : 0 : 0
 
   name = "dms-cloudwatch-logs-role"
 }
@@ -229,11 +229,26 @@ module "rds_replica_database" {
 # primary's group, and the DMS BI replica is a writable DMS target that must
 # not be frozen with the source, so it moves to this group for the migration.
 resource "aws_db_parameter_group" "bi_replica" {
+  # Keep parameter parity with aws_db_parameter_group.default: a replica moved
+  # here (aurora stacks always; rds stacks during a migration) must not silently
+  # lose its slow/general log exports on the next reboot.
   count = local.dms_enabled && (var.db_engine == "aurora" || local.aurora_migration_active) ? 1 : 0
 
   name_prefix = "${local.identifier}-bi-"
   family      = "mysql${var.rds_engine_family}"
 
+  parameter {
+    name  = "slow_query_log"
+    value = "1"
+  }
+  parameter {
+    name  = "general_log"
+    value = "1"
+  }
+  parameter {
+    name  = "log_output"
+    value = "FILE"
+  }
   parameter {
     name  = "binlog_format"
     value = "ROW"

--- a/terraform/physical/bi.tf
+++ b/terraform/physical/bi.tf
@@ -18,7 +18,8 @@ data "aws_iam_roles" "dms-cloudwatch-roles" {
 # We create the dms-vpc-role and dms-cloudwatch-logs-role using a null_resource to prevent the removal of the
 # account-wide role should this stack be deleted. In other words, to keep the role out of the state.
 resource "null_resource" "create_dms_vpc_role" {
-  count = local.dms_enabled ? length(data.aws_iam_role.dms-vpc-role) > 0 ? 0 : 1 : 0
+  # Needed by BI DMS and the Aurora migration rig alike.
+  count = (local.dms_enabled || local.aurora_migration_dms) ? length(data.aws_iam_role.dms-vpc-role) > 0 ? 0 : 1 : 0
 
   provisioner "local-exec" {
     command = <<-EOT
@@ -32,7 +33,8 @@ resource "null_resource" "create_dms_vpc_role" {
   }
 }
 resource "null_resource" "create_dms_cloudwatch_role" {
-  count = local.dms_enabled ? length(data.aws_iam_role.dms-cloudwatch-role) > 0 ? 0 : 1 : 0
+  # Needed by BI DMS and the Aurora migration rig alike.
+  count = (local.dms_enabled || local.aurora_migration_dms) ? length(data.aws_iam_role.dms-cloudwatch-role) > 0 ? 0 : 1 : 0
 
   provisioner "local-exec" {
     command = <<-EOT

--- a/terraform/physical/bi.tf
+++ b/terraform/physical/bi.tf
@@ -224,9 +224,12 @@ module "rds_replica_database" {
 
 # Aurora stacks have no instance-level parameter group to reuse (the cluster
 # uses a cluster parameter group), so the DMS replica gets its own copy of
-# aws_db_parameter_group.default. rds stacks keep sharing the primary's group.
+# aws_db_parameter_group.default. rds stacks keep sharing the primary's group -
+# EXCEPT during an Aurora migration: the fence injects read_only=1 into the
+# primary's group, and the DMS BI replica is a writable DMS target that must
+# not be frozen with the source, so it moves to this group for the migration.
 resource "aws_db_parameter_group" "bi_replica" {
-  count = local.dms_enabled && var.db_engine == "aurora" ? 1 : 0
+  count = local.dms_enabled && (var.db_engine == "aurora" || local.aurora_migration_active) ? 1 : 0
 
   name_prefix = "${local.identifier}-bi-"
   family      = "mysql${var.rds_engine_family}"
@@ -300,7 +303,7 @@ module "dms_replica_database" {
 
   # DB parameter group
   create_db_parameter_group = false
-  parameter_group_name      = var.db_engine == "rds" ? aws_db_parameter_group.default[0].name : aws_db_parameter_group.bi_replica[0].name
+  parameter_group_name      = var.db_engine == "rds" && !local.aurora_migration_active ? aws_db_parameter_group.default[0].name : aws_db_parameter_group.bi_replica[0].name
 
   create_db_option_group = false
 

--- a/terraform/physical/outputs.tf
+++ b/terraform/physical/outputs.tf
@@ -126,3 +126,8 @@ output "aurora_migration_target_endpoint" {
   description = "Aurora cluster writer endpoint during a migration (empty otherwise). Runner/runbook convenience; the app only ever sees it through the credentials secret after cutover."
   value       = try(module.aurora[0].cluster_endpoint, "")
 }
+
+output "aurora_migration_credentials_secret" {
+  description = "Secret ARN holding the Aurora migration target credentials (empty when no migration is active). Runner use only."
+  value       = try(aws_secretsmanager_secret.aurora_migration_credentials[0].arn, "")
+}

--- a/terraform/physical/rds.tf
+++ b/terraform/physical/rds.tf
@@ -133,6 +133,18 @@ resource "aws_db_parameter_group" "default" {
     value = "33554432"
   }
 
+  # Terraform-owned cutover fence (see var.aurora_migration_source_fenced): the
+  # parameter exists in config only while fenced, so a mid-cutover apply can
+  # never silently reopen the source. Absent = engine default (writable).
+  dynamic "parameter" {
+    for_each = var.aurora_migration_source_fenced ? [1] : []
+    content {
+      name         = "read_only"
+      value        = "1"
+      apply_method = "immediate"
+    }
+  }
+
   lifecycle {
     create_before_destroy = true
   }

--- a/terraform/physical/static/aurora_migration_mapping.json
+++ b/terraform/physical/static/aurora_migration_mapping.json
@@ -6,6 +6,13 @@
       "rule-name": "all-app-schemas",
       "object-locator": { "schema-name": "%", "table-name": "%" },
       "rule-action": "include"
-    }
+    },
+    { "rule-type": "selection", "rule-id": "2", "rule-name": "x-mysql", "object-locator": { "schema-name": "mysql", "table-name": "%" }, "rule-action": "exclude" },
+    { "rule-type": "selection", "rule-id": "3", "rule-name": "x-sys", "object-locator": { "schema-name": "sys", "table-name": "%" }, "rule-action": "exclude" },
+    { "rule-type": "selection", "rule-id": "4", "rule-name": "x-ischema", "object-locator": { "schema-name": "information_schema", "table-name": "%" }, "rule-action": "exclude" },
+    { "rule-type": "selection", "rule-id": "5", "rule-name": "x-pschema", "object-locator": { "schema-name": "performance_schema", "table-name": "%" }, "rule-action": "exclude" },
+    { "rule-type": "selection", "rule-id": "6", "rule-name": "x-innodb", "object-locator": { "schema-name": "innodb", "table-name": "%" }, "rule-action": "exclude" },
+    { "rule-type": "selection", "rule-id": "7", "rule-name": "x-tmp", "object-locator": { "schema-name": "tmp", "table-name": "%" }, "rule-action": "exclude" },
+    { "rule-type": "selection", "rule-id": "8", "rule-name": "x-dmsctl", "object-locator": { "schema-name": "awsdms%", "table-name": "%" }, "rule-action": "exclude" }
   ]
 }

--- a/terraform/physical/util/aurora-migration-runner.sh
+++ b/terraform/physical/util/aurora-migration-runner.sh
@@ -3,35 +3,36 @@
 # aurora_migration_state Terraform (aurora-migration.tf) cannot: native schema
 # pre-load, DMS task orchestration, validation gates, and the fence/cutover
 # sequence. Every step is the 2026-07-26 gca-rehearsal procedure, productionized
-# (design doc: 3m-aurora-dms-migration-design).
+# (design doc: 3m-aurora-dms-migration-design; review round 2 fixes folded in).
 #
 # Runs on an operator machine with aws cli + jq; all SQL executes ON THE ENV
-# BASTION via SSM (the bastion has mariadb + the primary-DB .my.cnf from its
-# State Manager association). Nothing here talks to a database directly.
+# BASTION via SSM (the bastion has mariadb installed by its State Manager
+# association). Nothing here talks to a database directly.
 #
 # Usage:
 #   AWS_PROFILE=... aurora-migration-runner.sh <identifier> <region> <phase>
-# Phases (in order):
-#   status    - show everything (safe anytime)
-#   preload   - schema dump/split, dangling-FK scan, base DDL, md5 diff gate
-#   load      - premigration assessment, start task, wait auto-stop, deferred
-#               DDL (indexes then FKs = orphan check), drop the FK Initstmt,
-#               resume CDC
-#   validate  - DMS validation clean + checksums (frozen check; run pre-fence)
-#   fence     - the cutover fence: writer scale-down is YOURS (kubectl); this
-#               does marker + read_only + negative test + the go-live gate and
-#               stops the task at its checkpoint. Prints GO/NO-GO.
-#   cutover-verify - post-`aurora_migration_state=cutover` apply: identity +
-#               committed-write check on Aurora, event scheduler assert.
-#   abort     - pre-first-write abort: revert read_only, resume writers on RDS.
-#   bi-epoch  - restart the BI DMS task against the (now Aurora) source.
+# Phases, in order:
+#   status         - show everything (safe anytime)
+#   preload        - schema dump/split, dangling-FK scan, object artifact dump,
+#                    base DDL, information_schema md5 gate
+#   load           - assessment, full load to the automatic cached-changes stop,
+#                    deferred indexes then FKs (= orphan check), Initstmt
+#                    removal while stopped + endpoint re-test, CDC resume
+#   validate       - DMS validation whitelist gate + table checksums
+#                    (CHECKSUM_TABLES="db.t1 db.t2" env var adds tables)
+#   fence          - marker + Terraform-owned read_only fence + negative test +
+#                    go-live gate + object install + final task stop.
+#                    Interactive: pauses for the fenced=true Spacelift apply.
+#   cutover-verify - POST-promotion verification (the gated physical cutover
+#                    apply + its auto-following logical apply ARE the promotion;
+#                    the point of no return is the logical apply repointing the
+#                    app - gate BEFORE confirming physical, not here).
+#   abort          - pre-cutover abort with hard guards; refuses after cutover.
+#   bi-epoch       - reload the BI DMS task from the (now Aurora) source.
 set -euo pipefail
 
 ID="${1:?identifier (e.g. m3-gca)}"; REGION="${2:?region}"; PHASE="${3:?phase}"
-RUN_TAG="aurora-mig-$(date -u +%Y%m%d)"
-SRC_ID="$ID"                       # module.primary_database db identifier
-CLUSTER_ID="$ID"                   # module.aurora cluster identifier
-TASK_ID="${ID}-aurora-migration"   # aws_dms_replication_task.aurora_migration
+SRC_ID="$ID"; CLUSTER_ID="$ID"; TASK_ID="${ID}-aurora-migration"
 
 say() { printf '%s %s\n' "$(date -u +%H:%M:%SZ)" "$*"; }
 die() { say "FATAL: $*" >&2; exit 1; }
@@ -46,13 +47,23 @@ bastion_id() {
 rds_endpoint() { aws rds describe-db-instances --db-instance-identifier "$SRC_ID" --region "$REGION" --query 'DBInstances[0].Endpoint.Address' --output text; }
 aurora_endpoint() { aws rds describe-db-clusters --db-cluster-identifier "$CLUSTER_ID" --region "$REGION" --query 'DBClusters[0].Endpoint' --output text; }
 task_arn() { aws dms describe-replication-tasks --region "$REGION" --filters "Name=replication-task-id,Values=$TASK_ID" --query 'ReplicationTasks[0].ReplicationTaskArn' --output text; }
-task_status() { aws dms describe-replication-tasks --region "$REGION" --filters "Name=replication-task-id,Values=$TASK_ID" --query 'ReplicationTasks[0].Status' --output text; }
-secret_arn() { aws rds describe-db-instances --db-instance-identifier "$SRC_ID" --region "$REGION" >/dev/null && aws secretsmanager list-secrets --region "$REGION" --query "SecretList[?starts_with(Name, '${ID}-database')].ARN | [0]" --output text; }
+task_status() { aws dms describe-replication-tasks --region "$REGION" --filters "Name=replication-task-id,Values=$TASK_ID" --query 'ReplicationTasks[0].Status' --output text 2>/dev/null || echo none; }
+bi_task_arn() { aws dms describe-replication-tasks --region "$REGION" --filters "Name=replication-task-id,Values=$ID" --query 'ReplicationTasks[0].ReplicationTaskArn' --output text 2>/dev/null; }
+bi_task_status() { aws dms describe-replication-tasks --region "$REGION" --filters "Name=replication-task-id,Values=$ID" --query 'ReplicationTasks[0].Status' --output text 2>/dev/null || echo none; }
+primary_secret() { aws secretsmanager list-secrets --region "$REGION" --query "SecretList[?starts_with(Name, '${ID}-database')].ARN | [0]" --output text; }
+migration_secret() { aws secretsmanager list-secrets --region "$REGION" --query "SecretList[?starts_with(Name, '${ID}-aurora-migration')].ARN | [0]" --output text; }
 src_pg() { aws rds describe-db-instances --db-instance-identifier "$SRC_ID" --region "$REGION" --query 'DBInstances[0].DBParameterGroups[0].DBParameterGroupName' --output text; }
+primary_secret_host() { aws secretsmanager get-secret-value --region "$REGION" --secret-id "$(primary_secret)" --query SecretString --output text | jq -r .host; }
 
-# --- bastion exec (SSM) -------------------------------------------------------
-# ssm_run <<'EOF' ... EOF  -> runs the heredoc as one shell script on the bastion,
-# echoes its stdout, dies on failure. jq builds the params JSON (quote-safe).
+# DMS validation clean-state whitelist: anything else is unclean. Matched
+# case-insensitively ("No primary key" casing differs across DMS versions).
+unclean_validation_count() {
+  aws dms describe-table-statistics --replication-task-arn "$(task_arn)" --region "$REGION" \
+    --query 'TableStatistics[].ValidationState' --output text | tr '\t' '\n' | \
+    awk 'BEGIN{IGNORECASE=1} !/^validated$/ && !/^no primary key$/ && NF {c++} END{print c+0}'
+}
+
+# --- bastion exec (SSM) ------------------------------------------------------
 ssm_run() {
   local script cid status
   script="$(cat)"
@@ -68,29 +79,32 @@ ssm_run() {
   [ "$status" = "Success" ] || { aws ssm get-command-invocation --region "$REGION" --command-id "$cid" --instance-id "$(bastion_id)" --query StandardErrorContent --output text >&2; die "bastion step failed ($status)"; }
 }
 
-# Write /tmp/mig-{src,tgt}.cnf on the bastion from the credentials secret (same
-# username/password on both sides; only the host differs). Explicit hosts - the
-# association's .my.cnf follows local.db_host, which flips at cutover.
+# Source cnf: primary secret credentials + the RDS address PINNED explicitly
+# (the secret's host flips to Aurora at cutover - the source cnf must not).
+# Target cnf: the migration credentials secret (Aurora's own password, which
+# never lives in the primary secret before cutover).
 prep_cnfs() {
-  local sec src tgt; sec=$(secret_arn); src=$(rds_endpoint); tgt=$(aurora_endpoint)
+  local psec msec src tgt
+  psec=$(primary_secret); msec=$(migration_secret); src=$(rds_endpoint); tgt=$(aurora_endpoint)
+  [ -n "$msec" ] && [ "$msec" != "None" ] || die "migration credentials secret not found - is aurora_migration_state=provision applied?"
   ssm_run <<EOF
 set -e; umask 177
-C=\$(aws secretsmanager get-secret-value --region $REGION --secret-id "$sec" --query SecretString --output text)
-U=\$(echo "\$C" | jq -r .username); P=\$(echo "\$C" | jq -r .password)
-for pair in "src $src" "tgt $tgt"; do set -- \$pair
-  printf '[client]\nhost=%s\nuser=%s\npassword=%s\nssl\n' "\$2" "\$U" "\$P" > /tmp/mig-\$1.cnf
-done
+P=\$(aws secretsmanager get-secret-value --region $REGION --secret-id "$psec" --query SecretString --output text)
+printf '[client]\nhost=%s\nuser=%s\npassword=%s\nssl\n' "$src" "\$(echo "\$P" | jq -r .username)" "\$(echo "\$P" | jq -r .password)" > /tmp/mig-src.cnf
+M=\$(aws secretsmanager get-secret-value --region $REGION --secret-id "$msec" --query SecretString --output text)
+printf '[client]\nhost=%s\nuser=%s\npassword=%s\nssl\n' "$tgt" "\$(echo "\$M" | jq -r .username)" "\$(echo "\$M" | jq -r .password)" > /tmp/mig-tgt.cnf
 echo CNFS_READY
 EOF
 }
-msrc() { echo "mariadb --defaults-extra-file=/tmp/mig-src.cnf --batch --skip-column-names"; }
-mtgt() { echo "mariadb --defaults-extra-file=/tmp/mig-tgt.cnf --batch --skip-column-names --init-command=\"SET SESSION restrict_fk_on_non_standard_key=0\""; }
 
 # =============================================================================
 case "$PHASE" in
 
 status)
-  say "task: $(task_status 2>/dev/null || echo none)  rds: $(rds_endpoint 2>/dev/null || echo none)  aurora: $(aurora_endpoint 2>/dev/null || echo none)"
+  say "migration task: $(task_status)   bi task: $(bi_task_status)"
+  say "rds: $(rds_endpoint 2>/dev/null || echo none)"
+  say "aurora: $(aurora_endpoint 2>/dev/null || echo none)"
+  say "primary secret host: $(primary_secret_host 2>/dev/null || echo unknown)  (aurora after cutover)"
   ;;
 
 preload)
@@ -99,17 +113,17 @@ preload)
 set -e; cd /tmp; rm -rf mig && mkdir mig && cd mig
 S="mariadb --defaults-extra-file=/tmp/mig-src.cnf --batch --skip-column-names"
 T="mariadb --defaults-extra-file=/tmp/mig-tgt.cnf --batch --skip-column-names --init-command='SET SESSION restrict_fk_on_non_standard_key=0'"
-# gate: source CDC prereqs
 $S -e "SELECT @@binlog_format, @@binlog_row_image, @@log_bin" | grep -q "ROW	FULL	1" || { echo "SOURCE NOT CDC-READY"; exit 1; }
-# gate: lower_case_table_names must match (immutable on the target)
 [ "$($S -e 'SELECT @@lower_case_table_names')" = "$(eval $T -e "'SELECT @@lower_case_table_names'")" ] || { echo LCTN_MISMATCH; exit 1; }
-# schema list (system + DMS control schemas excluded)
-$S -e "SELECT schema_name FROM information_schema.schemata WHERE schema_name NOT IN ('mysql','information_schema','performance_schema','sys','innodb','tmp','awsdms_control')" > schemas.txt
-# dangling-FK scan: FKs whose referenced table does not exist are unenforceable
-# residue (created with FK checks off) - excluded from the target, reported.
+$S -e "SELECT schema_name FROM information_schema.schemata WHERE schema_name NOT IN ('mysql','information_schema','performance_schema','sys','innodb','tmp') AND schema_name NOT LIKE 'awsdms%'" > schemas.txt
+# dangling FKs: unenforceable residue, excluded from the target and reported
 $S -e "SELECT CONCAT(k.constraint_schema,'.',k.table_name,'.',k.constraint_name) FROM information_schema.key_column_usage k LEFT JOIN information_schema.tables t ON t.table_schema=k.referenced_table_schema AND t.table_name=k.referenced_table_name WHERE k.referenced_table_name IS NOT NULL AND t.table_name IS NULL" > dangling-fks.txt
 echo "dangling FKs: $(wc -l < dangling-fks.txt)"; cat dangling-fks.txt
-# dump DDL, split base (tables w/o secondary indexes+FKs) vs deferred
+# object artifacts: routines/events/triggers are NOT migrated by DMS and NOT in
+# base DDL. Dumped here; installed on the target by fence (after the final task
+# stop, so triggers can never fire on DMS-applied DML). Empty on the 3M fleet.
+mariadb-dump --defaults-extra-file=/tmp/mig-src.cnf --no-data --no-create-info --no-create-db --routines --events --triggers --skip-opt --databases $(tr '\n' ' ' < schemas.txt) > objects.sql || true
+echo "object artifact counts: routines=$($S -e "SELECT COUNT(*) FROM information_schema.routines WHERE routine_schema NOT IN ('mysql','sys')") triggers=$($S -e "SELECT COUNT(*) FROM information_schema.triggers WHERE trigger_schema NOT IN ('mysql','sys')") events=$($S -e "SELECT COUNT(*) FROM information_schema.events WHERE event_schema NOT IN ('mysql','sys')")"
 mariadb-dump --defaults-extra-file=/tmp/mig-src.cnf --no-data --skip-triggers --databases $(tr '\n' ' ' < schemas.txt) > full.sql
 python3 - <<'PYEOF'
 import re
@@ -153,21 +167,19 @@ open('deferred-fk.sql','w').writelines([l for l in deferred if 'FOREIGN KEY' in 
 print(f"base={len(base)} idx={sum('FOREIGN KEY' not in l for l in deferred)} fk={sum('FOREIGN KEY' in l for l in deferred)}")
 PYEOF
 eval $T < base.sql; echo BASE_APPLIED
-# md5 diff gate: identical column definitions on both sides (base tables only)
-Q="SELECT c.table_schema,c.table_name,c.column_name,c.column_type,c.is_nullable,IFNULL(c.column_default,'~N~'),c.extra FROM information_schema.columns c JOIN information_schema.tables t ON c.table_schema=t.table_schema AND c.table_name=t.table_name WHERE t.table_type='BASE TABLE' AND c.table_schema NOT IN ('mysql','information_schema','performance_schema','sys','innodb','tmp','awsdms_control') ORDER BY c.table_schema,c.table_name,c.ordinal_position"
+Q="SELECT c.table_schema,c.table_name,c.column_name,c.column_type,c.is_nullable,IFNULL(c.column_default,'~N~'),c.extra FROM information_schema.columns c JOIN information_schema.tables t ON c.table_schema=t.table_schema AND c.table_name=t.table_name WHERE t.table_type='BASE TABLE' AND c.table_schema NOT IN ('mysql','information_schema','performance_schema','sys','innodb','tmp') AND c.table_schema NOT LIKE 'awsdms%' ORDER BY c.table_schema,c.table_name,c.ordinal_position"
 $S -e "$Q" > cols-src.tsv; eval $T -e "\"$Q\"" > cols-tgt.tsv
 [ "$(md5sum < cols-src.tsv)" = "$(md5sum < cols-tgt.tsv)" ] && echo MD5_GATE_PASS || { echo MD5_GATE_FAIL; diff cols-src.tsv cols-tgt.tsv | head -20; exit 1; }
 EOF
-  say "preload complete - md5 gate passed; review any dangling FKs above"
+  say "preload complete - md5 gate passed; review dangling FKs + object counts above"
   ;;
 
 load)
   [ "$(task_status)" = "ready" ] || die "task not ready (status=$(task_status))"
-  say "premigration assessment"
-  aws dms start-replication-task-assessment --replication-task-arn "$(task_arn)" --region "$REGION" >/dev/null || say "WARN: assessment API unavailable - inventory gates from preload stand in"
+  aws dms start-replication-task-assessment --replication-task-arn "$(task_arn)" --region "$REGION" >/dev/null 2>&1 && say "premigration assessment started" || say "WARN: assessment API unavailable - preload inventory gates stand in"
   say "starting full load + CDC"
   aws dms start-replication-task --replication-task-arn "$(task_arn)" --start-replication-task-type start-replication --region "$REGION" >/dev/null
-  say "waiting for the automatic post-full-load stop (StopTaskCachedChangesApplied)"
+  say "waiting for the automatic post-full-load stop"
   while :; do s=$(task_status); say "  task=$s"; [ "$s" = "stopped" ] && break; [ "$s" = "failed" ] && die "task failed - check the DMS task log"; sleep 60; done
   say "applying deferred DDL (indexes, then FKs = orphan check) while quiescent"
   prep_cnfs
@@ -182,7 +194,6 @@ EOF
   aws dms modify-endpoint --endpoint-arn "$TEP" --extra-connection-attributes "" --region "$REGION" >/dev/null
   RIARN=$(aws dms describe-replication-instances --region "$REGION" --filters "Name=replication-instance-id,Values=${ID}-aurora-migration" --query 'ReplicationInstances[0].ReplicationInstanceArn' --output text)
   aws dms test-connection --replication-instance-arn "$RIARN" --endpoint-arn "$TEP" --region "$REGION" >/dev/null
-  say "waiting for the endpoint re-test (modify invalidates it)"
   while [ "$(aws dms describe-connections --region "$REGION" --filters "Name=endpoint-arn,Values=$TEP" --query 'Connections[0].Status' --output text)" != "successful" ]; do sleep 10; done
   say "resuming CDC (fresh sessions, FK checks ON)"
   aws dms start-replication-task --replication-task-arn "$(task_arn)" --start-replication-task-type resume-processing --region "$REGION" >/dev/null
@@ -193,70 +204,147 @@ EOF
 validate)
   say "DMS validation states:"
   aws dms describe-table-statistics --replication-task-arn "$(task_arn)" --region "$REGION" --query 'TableStatistics[].ValidationState' --output text | tr '\t' '\n' | sort | uniq -c
-  BAD=$(aws dms describe-table-statistics --replication-task-arn "$(task_arn)" --region "$REGION" --query 'length(TableStatistics[?ValidationState!=`Validated` && ValidationState!=`No primary Key`])' --output text)
-  [ "$BAD" = "0" ] && say "VALIDATION GATE PASS (no-PK tables are the only exceptions - review the list above)" || die "validation gate FAIL: $BAD tables not Validated"
+  U=$(unclean_validation_count)
+  [ "$U" = "0" ] || die "validation gate FAIL: $U tables outside the clean set (Validated / No primary key)"
+  say "no-PK tables (classified exceptions):"
+  aws dms describe-table-statistics --replication-task-arn "$(task_arn)" --region "$REGION" --query 'TableStatistics[?contains(ValidationState, `rimary`)].TableName' --output text | head -5
+  if [ -n "${CHECKSUM_TABLES:-}" ]; then
+    prep_cnfs
+    say "checksums (source vs target) - writers should be quiet for a stable compare"
+    for t in $CHECKSUM_TABLES; do
+      R=$(ssm_run <<EOF
+A=\$(mariadb --defaults-extra-file=/tmp/mig-src.cnf --batch --skip-column-names -e "CHECKSUM TABLE $t" | awk '{print \$2}')
+B=\$(mariadb --defaults-extra-file=/tmp/mig-tgt.cnf --batch --skip-column-names -e "CHECKSUM TABLE $t" | awk '{print \$2}')
+[ "\$A" = "\$B" ] && echo "MATCH \$A" || echo "MISMATCH src=\$A tgt=\$B"
+EOF
+)
+      say "  $t: $(echo "$R" | tail -1)"; echo "$R" | grep -q MISMATCH && die "checksum mismatch on $t"
+    done
+  fi
+  say "VALIDATION GATE PASS"
   ;;
 
 fence)
-  say "PRECONDITION (yours): app writers scaled down (queueworkerd/crond/app write tier) + DDL freeze in effect"
+  say "PRECONDITIONS (yours): app writers scaled to zero + DDL freeze in effect"
   prep_cnfs
-  SEC=$(secret_arn); MARK="cutover-$(date -u +%s)"
-  say "step 1: kill remaining app sessions + commit marker '$MARK'"
+  # BI task must stop BEFORE the cutover apply mutates its source endpoint
+  # (DMS rejects endpoint modification on a running task).
+  if [ "$(bi_task_status)" = "running" ]; then
+    say "stopping the BI DMS task ahead of the endpoint repoint"
+    aws dms stop-replication-task --replication-task-arn "$(bi_task_arn)" --region "$REGION" >/dev/null
+    while [ "$(bi_task_status)" != "stopped" ]; do sleep 10; done
+  fi
+  MARK="cutover-$(date -u +%s)"
+  say "killing every DB session except our own (by connection id - the app and
+       this runner share the master user, so a username filter would spare the
+       app), then committing marker '$MARK' in the same session"
   ssm_run <<EOF
 set -e
-S="mariadb --defaults-extra-file=/tmp/mig-src.cnf --batch --skip-column-names"
-\$S -e "CREATE DATABASE IF NOT EXISTS aurora_mig_ctl; CREATE TABLE IF NOT EXISTS aurora_mig_ctl.marker (id INT AUTO_INCREMENT PRIMARY KEY, tag VARCHAR(64), at DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6));"
-for id in \$(\$S -e "SELECT id FROM information_schema.processlist WHERE user NOT IN ('rdsadmin','\$(\$S -e 'SELECT CURRENT_USER()' | cut -d@ -f1)') AND command != 'Binlog Dump'"); do \$S -e "CALL mysql.rds_kill(\$id);" || true; done
-\$S -e "INSERT INTO aurora_mig_ctl.marker (tag) VALUES ('$MARK');"
+mariadb --defaults-extra-file=/tmp/mig-src.cnf --batch --skip-column-names <<'SQL'
+CREATE DATABASE IF NOT EXISTS aurora_mig_ctl;
+CREATE TABLE IF NOT EXISTS aurora_mig_ctl.marker (id INT AUTO_INCREMENT PRIMARY KEY, tag VARCHAR(64), at DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6));
+SQL
+mariadb --defaults-extra-file=/tmp/mig-src.cnf --batch --skip-column-names -e "
+  SELECT GROUP_CONCAT(CONCAT('CALL mysql.rds_kill(', id, ');') SEPARATOR ' ')
+  FROM information_schema.processlist
+  WHERE id != CONNECTION_ID() AND user NOT IN ('rdsadmin') AND command != 'Binlog Dump';" | \
+  tr ' ' '\n' | grep -v '^\$' | while read -r stmt; do mariadb --defaults-extra-file=/tmp/mig-src.cnf -e "\$stmt" 2>/dev/null || true; done
+mariadb --defaults-extra-file=/tmp/mig-src.cnf -e "INSERT INTO aurora_mig_ctl.marker (tag) VALUES ('$MARK');"
 echo MARKER_COMMITTED
 EOF
-  say "step 2: read_only=1 via parameter group + poll"
-  aws rds modify-db-parameter-group --db-parameter-group-name "$(src_pg)" --region "$REGION" --parameters "ParameterName=read_only,ParameterValue=1,ApplyMethod=immediate" >/dev/null
+  say ""
+  say ">>> NOW APPLY THE TERRAFORM FENCE: set aurora_migration_source_fenced = true"
+  say ">>> in this env's env.hcl and confirm the gated physical apply, then return."
+  say "Polling for read_only=1 (the apply + parameter propagation)..."
   while :; do RO=$(ssm_run <<'EOF'
 mariadb --defaults-extra-file=/tmp/mig-src.cnf --batch --skip-column-names -e "SELECT @@read_only"
 EOF
-); RO=$(echo "$RO" | tr -d '[:space:]'); say "  read_only=$RO"; [ "$RO" = "1" ] && break; sleep 15; done
-  say "step 3: negative write test (must be refused)"
+); RO=$(echo "$RO" | tr -d '[:space:]'); say "  read_only=$RO"; [ "$RO" = "1" ] && break; sleep 30; done
+  say "negative write test (must be refused)"
   ssm_run <<'EOF'
 if mariadb --defaults-extra-file=/tmp/mig-src.cnf -e "INSERT INTO aurora_mig_ctl.marker (tag) VALUES ('must-fail');" 2>/tmp/neg.err; then echo FENCE_BREACH; exit 1; else echo FENCE_OK; fi
 EOF
-  say "step 4: go-live gate - marker on Aurora + validation drained + task stop"
+  say "final source binlog coordinate:"
+  ssm_run <<'EOF'
+mariadb --defaults-extra-file=/tmp/mig-src.cnf --batch -e "SHOW MASTER STATUS;" | head -2
+EOF
+  say "gate: marker on Aurora"
   while :; do N=$(ssm_run <<EOF
 mariadb --defaults-extra-file=/tmp/mig-tgt.cnf --batch --skip-column-names -e "SELECT COUNT(*) FROM aurora_mig_ctl.marker WHERE tag='$MARK'" 2>/dev/null || echo 0
 EOF
 ); N=$(echo "$N" | tr -d '[:space:]'); say "  marker_on_aurora=$N"; [ "$N" = "1" ] && break; sleep 10; done
-  while :; do P=$(aws dms describe-table-statistics --replication-task-arn "$(task_arn)" --region "$REGION" --query 'length(TableStatistics[?ValidationState==`Pending records`||ValidationState==`Suspended records`||ValidationState==`Mismatched records`])' --output text); say "  unclean_validation_tables=$P"; [ "$P" = "0" ] && break; sleep 20; done
+  say "gate: validation fully clean (whitelist)"
+  while :; do U=$(unclean_validation_count); say "  unclean=$U"; [ "$U" = "0" ] && break; sleep 20; done
+  say "installing object artifacts on the target (routines/events/triggers; DMS"
+  say "is about to stop for good, so triggers can never fire on replicated DML)"
+  ssm_run <<'EOF'
+set -e
+if [ -s /tmp/mig/objects.sql ]; then
+  mariadb --defaults-extra-file=/tmp/mig-tgt.cnf < /tmp/mig/objects.sql && echo OBJECTS_INSTALLED
+else
+  echo NO_OBJECTS_TO_INSTALL
+fi
+EOF
+  say "final task stop + checkpoint"
   aws dms stop-replication-task --replication-task-arn "$(task_arn)" --region "$REGION" >/dev/null
   while [ "$(task_status)" != "stopped" ]; do sleep 10; done
-  say "GO: gate passed, task stopped at checkpoint: $(aws dms describe-replication-tasks --region "$REGION" --filters "Name=replication-task-id,Values=$TASK_ID" --query 'ReplicationTasks[0].RecoveryCheckpoint' --output text)"
-  say "NEXT: apply aurora_migration_state=cutover (Spacelift), then run 'cutover-verify'"
+  say "checkpoint: $(aws dms describe-replication-tasks --region "$REGION" --filters "Name=replication-task-id,Values=$TASK_ID" --query 'ReplicationTasks[0].RecoveryCheckpoint' --output text)"
+  say ""
+  say "GO: the gate has passed. Confirming the aurora_migration_state=cutover"
+  say "physical apply IS the promotion - its auto-following logical apply"
+  say "repoints the app at Aurora (the point of no return). After the logical"
+  say "apply completes, run 'cutover-verify'. To stand down instead, run 'abort'."
   ;;
 
 cutover-verify)
+  # Post-promotion verification. The logical stack has already repointed the app.
   prep_cnfs
   ssm_run <<'EOF'
 set -e
 T="mariadb --defaults-extra-file=/tmp/mig-tgt.cnf --batch --skip-column-names"
 $T -e "SELECT @@aurora_version" | grep -q "8.4" || { echo WRONG_TARGET; exit 1; }
-$T -e "INSERT INTO aurora_mig_ctl.marker (tag) VALUES ('PROMOTION-FIRST-WRITE');" && echo AURORA_WRITE_COMMITTED
-echo "event_scheduler=$($T -e 'SELECT @@event_scheduler')"
+echo "aurora identity OK: $($T -e 'SELECT @@aurora_server_id')"
+$T -e "INSERT INTO aurora_mig_ctl.marker (tag) VALUES ('post-promotion-verify');" && echo AURORA_WRITE_OK
+echo "event_scheduler=$($T -e 'SELECT @@event_scheduler') (expect ON post-cutover; OFF means the provision-phase param is still active - re-check the cutover apply)"
+echo "objects on target: routines=$($T -e "SELECT COUNT(*) FROM information_schema.routines WHERE routine_schema NOT IN ('mysql','sys')") triggers=$($T -e "SELECT COUNT(*) FROM information_schema.triggers WHERE trigger_schema NOT IN ('mysql','sys')") events=$($T -e "SELECT COUNT(*) FROM information_schema.events WHERE event_schema NOT IN ('mysql','sys')")"
 EOF
-  say "point of no return crossed - fail forward from here. Scale writers back up; leave RDS read_only."
+  say "compare object counts to preload's; verify app health, then schedule 'bi-epoch' and later cleanup."
   ;;
 
 abort)
-  say "pre-first-write abort: unfencing the source"
-  aws rds modify-db-parameter-group --db-parameter-group-name "$(src_pg)" --region "$REGION" --parameters "ParameterName=read_only,ParameterValue=0,ApplyMethod=immediate" >/dev/null
-  say "read_only reverting - verify with 'status', scale writers back up on RDS. Aurora untouched."
+  # Hard guards: abort is PRE-CUTOVER ONLY. After the cutover apply the app is
+  # writing to Aurora and reopening RDS would split-brain.
+  H=$(primary_secret_host); A=$(aurora_endpoint 2>/dev/null || echo none)
+  [ "$H" = "$A" ] && die "REFUSED: primary secret host already points at Aurora - cutover has been applied. Fail forward."
+  prep_cnfs
+  PW=$(ssm_run <<'EOF'
+mariadb --defaults-extra-file=/tmp/mig-tgt.cnf --batch --skip-column-names -e "SELECT COUNT(*) FROM aurora_mig_ctl.marker WHERE tag LIKE 'post-promotion%'" 2>/dev/null || echo 0
+EOF
+); PW=$(echo "$PW" | tr -d '[:space:]')
+  [ "$PW" = "0" ] || die "REFUSED: post-promotion writes exist on Aurora. Fail forward."
+  say ">>> UNFENCE: set aurora_migration_source_fenced = false in env.hcl and"
+  say ">>> confirm the gated apply. Polling for read_only=0..."
+  while :; do RO=$(ssm_run <<'EOF'
+mariadb --defaults-extra-file=/tmp/mig-src.cnf --batch --skip-column-names -e "SELECT @@read_only"
+EOF
+); RO=$(echo "$RO" | tr -d '[:space:]'); say "  read_only=$RO"; [ "$RO" = "0" ] && break; sleep 30; done
+  if [ "$(task_status)" = "stopped" ]; then
+    say "re-establishing CDC from the checkpoint (so the migration can retry later)"
+    aws dms start-replication-task --replication-task-arn "$(task_arn)" --start-replication-task-type resume-processing --region "$REGION" >/dev/null
+  fi
+  if [ "$(bi_task_status)" = "stopped" ]; then
+    say "resuming the BI task against the (still RDS) source"
+    aws dms start-replication-task --replication-task-arn "$(bi_task_arn)" --start-replication-task-type resume-processing --region "$REGION" >/dev/null
+  fi
+  say "ABORTED cleanly: source writable again, Aurora untouched by the app, CDC re-established. Scale writers back up."
   ;;
 
 bi-epoch)
-  say "restarting the BI DMS task with a full reload against the (now Aurora) source"
-  BI=$(aws dms describe-replication-tasks --region "$REGION" --filters "Name=replication-task-id,Values=$ID" --query 'ReplicationTasks[0].{arn:ReplicationTaskArn,st:Status}' --output json)
-  ARN=$(echo "$BI" | jq -r .arn); ST=$(echo "$BI" | jq -r .st)
-  [ "$ST" = "running" ] && { aws dms stop-replication-task --replication-task-arn "$ARN" --region "$REGION" >/dev/null; while [ "$(aws dms describe-replication-tasks --region "$REGION" --filters "Name=replication-task-id,Values=$ID" --query 'ReplicationTasks[0].Status' --output text)" != "stopped" ]; do sleep 10; done; }
-  aws dms start-replication-task --replication-task-arn "$ARN" --start-replication-task-type reload-target --region "$REGION" >/dev/null
-  say "BI task reloading from Aurora (its source endpoint already follows the flipped db host)"
+  ST=$(bi_task_status)
+  [ "$ST" = "stopped" ] || { [ "$ST" = "running" ] && { aws dms stop-replication-task --replication-task-arn "$(bi_task_arn)" --region "$REGION" >/dev/null; while [ "$(bi_task_status)" != "stopped" ]; do sleep 10; done; }; }
+  say "reloading the BI target from the (now Aurora) source"
+  aws dms start-replication-task --replication-task-arn "$(bi_task_arn)" --start-replication-task-type reload-target --region "$REGION" >/dev/null
+  say "BI task reloading (its source endpoint followed the flipped db host at the cutover apply)"
   ;;
 
 *) die "unknown phase: $PHASE" ;;

--- a/terraform/physical/util/aurora-migration-runner.sh
+++ b/terraform/physical/util/aurora-migration-runner.sh
@@ -68,11 +68,18 @@ unclean_validation_count() {
 # fenced source's final coordinate. DMS stopping is NOT a drain gate by itself;
 # this comparison is what proves every fenced-source event was consumed.
 checkpoint_reached() { # $1=final_file_seq $2=final_pos
-  local ck seq pos
+  local ck m seq pos
   ck=$(aws dms describe-replication-tasks --region "$REGION" --filters "Name=replication-task-id,Values=$TASK_ID" --query 'ReplicationTasks[0].RecoveryCheckpoint' --output text)
-  seq=$(echo "$ck" | grep -oE '\$\.[0-9]+:[0-9]+' | head -1 | cut -d. -f2 | cut -d: -f1)
-  pos=$(echo "$ck" | grep -oE '\$\.[0-9]+:[0-9]+' | head -1 | cut -d: -f2)
-  [ -n "$seq" ] && [ -n "$pos" ] || return 1
+  # Two checkpoint spellings observed in the wild: "mysql-bin-changelog.009875:153"
+  # (documented) and the abbreviated "$.583860:1357" (seen live in the rehearsal).
+  m=$(echo "$ck" | grep -oE 'mysql-bin-changelog\.[0-9]+:[0-9]+' | head -1)
+  [ -n "$m" ] && { seq=$(echo "$m" | cut -d. -f2 | cut -d: -f1); pos=$(echo "$m" | cut -d: -f2); }
+  if [ -z "${seq:-}" ]; then
+    m=$(echo "$ck" | grep -oE '\$\.[0-9]+:[0-9]+' | head -1)
+    [ -n "$m" ] && { seq=$(echo "$m" | cut -d. -f2 | cut -d: -f1); pos=$(echo "$m" | cut -d: -f2); }
+  fi
+  [ -n "${seq:-}" ] && [ -n "${pos:-}" ] || return 1
+  seq=$((10#$seq)); pos=$((10#$pos))
   [ "$seq" -gt "$1" ] || { [ "$seq" -eq "$1" ] && [ "$pos" -ge "$2" ]; }
 }
 
@@ -308,7 +315,13 @@ mariadb --defaults-extra-file=/tmp/mig-tgt.cnf --batch --skip-column-names -e "S
 EOF
 ); N=$(echo "$N" | tr -d '[:space:]'); say "  marker_on_aurora=$N"; [ "$N" = "1" ] && break; sleep 10; done
   say "gate: DMS checkpoint at or past the final coordinate (the actual drain proof)"
-  while :; do if checkpoint_reached "$FINAL_FILE" "$FINAL_POS"; then say "  checkpoint reached"; break; fi; say "  waiting for checkpoint..."; sleep 15; done
+  FINAL_FILE=$((10#$FINAL_FILE))
+  CKTRIES=0
+  while :; do
+    if checkpoint_reached "$FINAL_FILE" "$FINAL_POS"; then say "  checkpoint reached"; break; fi
+    CKTRIES=$((CKTRIES+1)); [ "$CKTRIES" -gt 60 ] && die "checkpoint did not reach the final coordinate in 15m - inspect the task (unparseable checkpoint formats also land here; RecoveryCheckpoint: $(aws dms describe-replication-tasks --region "$REGION" --filters "Name=replication-task-id,Values=$TASK_ID" --query 'ReplicationTasks[0].RecoveryCheckpoint' --output text))"
+    say "  waiting for checkpoint..."; sleep 15
+  done
   say "gate: validation fully clean (whitelist)"
   while :; do U=$(unclean_validation_count); say "  unclean=$U"; [ "$U" = "0" ] && break; sleep 20; done
   say "FINAL task stop + checkpoint record"
@@ -324,11 +337,15 @@ S="mariadb --defaults-extra-file=/tmp/mig-src.cnf --batch --skip-column-names"
 $S -e "SELECT schema_name FROM information_schema.schemata WHERE schema_name NOT IN ('mysql','information_schema','performance_schema','sys','innodb','tmp','aurora_mig_ctl') AND schema_name NOT LIKE 'awsdms%'" > /tmp/fence-schemas.txt
 mariadb-dump --defaults-extra-file=/tmp/mig-src.cnf --no-data --no-create-info --no-create-db --routines --events --triggers --skip-opt --databases $(tr '\n' ' ' < /tmp/fence-schemas.txt) > /tmp/fence-objects.sql
 SRC_COUNTS="$($S -e "SELECT CONCAT((SELECT COUNT(*) FROM information_schema.routines WHERE routine_schema NOT IN ('mysql','sys')),'/',(SELECT COUNT(*) FROM information_schema.triggers WHERE trigger_schema NOT IN ('mysql','sys')),'/',(SELECT COUNT(*) FROM information_schema.events WHERE event_schema NOT IN ('mysql','sys')))")"
-if [ "$SRC_COUNTS" = "0/0/0" ]; then echo "NO_OBJECTS_ON_SOURCE (verified live, not from a stale artifact)"; exit 0; fi
-mariadb --defaults-extra-file=/tmp/mig-tgt.cnf < /tmp/fence-objects.sql
 T="mariadb --defaults-extra-file=/tmp/mig-tgt.cnf --batch --skip-column-names"
+if [ "$SRC_COUNTS" != "0/0/0" ]; then
+  mariadb --defaults-extra-file=/tmp/mig-tgt.cnf < /tmp/fence-objects.sql
+fi
+# the src-vs-tgt comparison ALWAYS runs: with a 0/0/0 source it proves no stale
+# objects linger on the target from an earlier aborted attempt.
 TGT_COUNTS="$($T -e "SELECT CONCAT((SELECT COUNT(*) FROM information_schema.routines WHERE routine_schema NOT IN ('mysql','sys')),'/',(SELECT COUNT(*) FROM information_schema.triggers WHERE trigger_schema NOT IN ('mysql','sys')),'/',(SELECT COUNT(*) FROM information_schema.events WHERE event_schema NOT IN ('mysql','sys')))")"
-[ "$SRC_COUNTS" = "$TGT_COUNTS" ] && echo "OBJECTS_INSTALLED_AND_VERIFIED $SRC_COUNTS" || { echo "OBJECT_COUNT_MISMATCH src=$SRC_COUNTS tgt=$TGT_COUNTS"; exit 1; }
+[ -n "$TGT_COUNTS" ] || { echo "OBJECT_COUNT_UNREADABLE"; exit 1; }
+[ "$SRC_COUNTS" = "$TGT_COUNTS" ] && echo "OBJECTS_VERIFIED $SRC_COUNTS" || { echo "OBJECT_COUNT_MISMATCH src=$SRC_COUNTS tgt=$TGT_COUNTS"; exit 1; }
 EOF
   say ""
   say "GO: the gate has passed. Confirming the aurora_migration_state=cutover"
@@ -385,9 +402,13 @@ EOF
 mariadb --defaults-extra-file=/tmp/mig-src.cnf --batch --skip-column-names -e "SELECT @@read_only"
 EOF
 ); RO=$(echo "$RO" | tr -d '[:space:]'); say "  read_only=$RO"; [ "$RO" = "0" ] && break; sleep 30; done
-  # re-verify the guard AFTER the human-gated apply window (TOCTOU close-out)
-  H2=$(primary_secret_host) || die "post-unfence verification failed (fail closed)"
-  [ "$H2" = "$(aurora_endpoint)" ] && die "INCONSISTENT: secret now points at Aurora after unfence - investigate before touching writers"
+  # re-verify the guard AFTER the human-gated apply window (TOCTOU close-out).
+  # Every fact is captured with an explicit error check: an unreadable fact is a
+  # refusal, never a pass.
+  H2=$(primary_secret_host) || die "post-unfence verification failed reading the secret (fail closed)"
+  A2=$(aurora_endpoint) || die "post-unfence verification failed resolving Aurora (fail closed)"
+  [ -n "$H2" ] && [ "$H2" != "null" ] && [ -n "$A2" ] && [ "$A2" != "null" ] || die "post-unfence verification got empty facts (fail closed)"
+  [ "$H2" = "$A2" ] && die "INCONSISTENT: secret now points at Aurora after unfence - investigate before touching writers"
   if [ "$(task_status)" = "stopped" ]; then
     say "re-establishing CDC from the checkpoint (so the migration can retry later)"
     aws dms start-replication-task --replication-task-arn "$(task_arn)" --start-replication-task-type resume-processing --region "$REGION" >/dev/null

--- a/terraform/physical/util/aurora-migration-runner.sh
+++ b/terraform/physical/util/aurora-migration-runner.sh
@@ -60,7 +60,20 @@ primary_secret_host() { aws secretsmanager get-secret-value --region "$REGION" -
 unclean_validation_count() {
   aws dms describe-table-statistics --replication-task-arn "$(task_arn)" --region "$REGION" \
     --query 'TableStatistics[].ValidationState' --output text | tr '\t' '\n' | \
-    awk 'BEGIN{IGNORECASE=1} !/^validated$/ && !/^no primary key$/ && NF {c++} END{print c+0}'
+    awk '{ l=tolower($0) } l != "validated" && l != "no primary key" && NF { c++ } END { print c+0 }'
+}
+
+# Parse "mysql-bin-changelog.NNNN / POS" style coordinates out of the task's
+# RecoveryCheckpoint ("checkpoint:V1#...#$.NNNN:POS:...") and compare with the
+# fenced source's final coordinate. DMS stopping is NOT a drain gate by itself;
+# this comparison is what proves every fenced-source event was consumed.
+checkpoint_reached() { # $1=final_file_seq $2=final_pos
+  local ck seq pos
+  ck=$(aws dms describe-replication-tasks --region "$REGION" --filters "Name=replication-task-id,Values=$TASK_ID" --query 'ReplicationTasks[0].RecoveryCheckpoint' --output text)
+  seq=$(echo "$ck" | grep -oE '\$\.[0-9]+:[0-9]+' | head -1 | cut -d. -f2 | cut -d: -f1)
+  pos=$(echo "$ck" | grep -oE '\$\.[0-9]+:[0-9]+' | head -1 | cut -d: -f2)
+  [ -n "$seq" ] && [ -n "$pos" ] || return 1
+  [ "$seq" -gt "$1" ] || { [ "$seq" -eq "$1" ] && [ "$pos" -ge "$2" ]; }
 }
 
 # --- bastion exec (SSM) ------------------------------------------------------
@@ -122,7 +135,7 @@ echo "dangling FKs: $(wc -l < dangling-fks.txt)"; cat dangling-fks.txt
 # object artifacts: routines/events/triggers are NOT migrated by DMS and NOT in
 # base DDL. Dumped here; installed on the target by fence (after the final task
 # stop, so triggers can never fire on DMS-applied DML). Empty on the 3M fleet.
-mariadb-dump --defaults-extra-file=/tmp/mig-src.cnf --no-data --no-create-info --no-create-db --routines --events --triggers --skip-opt --databases $(tr '\n' ' ' < schemas.txt) > objects.sql || true
+mariadb-dump --defaults-extra-file=/tmp/mig-src.cnf --no-data --no-create-info --no-create-db --routines --events --triggers --skip-opt --databases $(tr '\n' ' ' < schemas.txt) > objects.sql
 echo "object artifact counts: routines=$($S -e "SELECT COUNT(*) FROM information_schema.routines WHERE routine_schema NOT IN ('mysql','sys')") triggers=$($S -e "SELECT COUNT(*) FROM information_schema.triggers WHERE trigger_schema NOT IN ('mysql','sys')") events=$($S -e "SELECT COUNT(*) FROM information_schema.events WHERE event_schema NOT IN ('mysql','sys')")"
 mariadb-dump --defaults-extra-file=/tmp/mig-src.cnf --no-data --skip-triggers --databases $(tr '\n' ' ' < schemas.txt) > full.sql
 python3 - <<'PYEOF'
@@ -213,12 +226,16 @@ validate)
     say "checksums (source vs target) - writers should be quiet for a stable compare"
     for t in $CHECKSUM_TABLES; do
       R=$(ssm_run <<EOF
+set -e
 A=\$(mariadb --defaults-extra-file=/tmp/mig-src.cnf --batch --skip-column-names -e "CHECKSUM TABLE $t" | awk '{print \$2}')
 B=\$(mariadb --defaults-extra-file=/tmp/mig-tgt.cnf --batch --skip-column-names -e "CHECKSUM TABLE $t" | awk '{print \$2}')
-[ "\$A" = "\$B" ] && echo "MATCH \$A" || echo "MISMATCH src=\$A tgt=\$B"
+# fail CLOSED: empty (connection/SQL failure) or NULL (nonexistent table) are
+# errors, never matches.
+case "\$A\$B" in (*NULL*|"") echo "INVALID src=\$A tgt=\$B"; exit 0;; esac
+[ -n "\$A" ] && [ -n "\$B" ] && [ "\$A" = "\$B" ] && echo "MATCH \$A" || echo "MISMATCH src=\$A tgt=\$B"
 EOF
 )
-      say "  $t: $(echo "$R" | tail -1)"; echo "$R" | grep -q MISMATCH && die "checksum mismatch on $t"
+      say "  $t: $(echo "$R" | tail -1)"; echo "$R" | grep -qE "MISMATCH|INVALID" && die "checksum gate failed on $t"
     done
   fi
   say "VALIDATION GATE PASS"
@@ -235,60 +252,84 @@ fence)
     while [ "$(bi_task_status)" != "stopped" ]; do sleep 10; done
   fi
   MARK="cutover-$(date -u +%s)"
-  say "killing every DB session except our own (by connection id - the app and
-       this runner share the master user, so a username filter would spare the
-       app), then committing marker '$MARK' in the same session"
+  say "kill sweep (by connection id - app and runner share the master user) + marker '$MARK'"
   ssm_run <<EOF
 set -e
-mariadb --defaults-extra-file=/tmp/mig-src.cnf --batch --skip-column-names <<'SQL'
+M="mariadb --defaults-extra-file=/tmp/mig-src.cnf --batch --skip-column-names"
+\$M <<'SQL'
 CREATE DATABASE IF NOT EXISTS aurora_mig_ctl;
 CREATE TABLE IF NOT EXISTS aurora_mig_ctl.marker (id INT AUTO_INCREMENT PRIMARY KEY, tag VARCHAR(64), at DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6));
 SQL
-mariadb --defaults-extra-file=/tmp/mig-src.cnf --batch --skip-column-names -e "
-  SELECT GROUP_CONCAT(CONCAT('CALL mysql.rds_kill(', id, ');') SEPARATOR ' ')
-  FROM information_schema.processlist
-  WHERE id != CONNECTION_ID() AND user NOT IN ('rdsadmin') AND command != 'Binlog Dump';" | \
-  tr ' ' '\n' | grep -v '^\$' | while read -r stmt; do mariadb --defaults-extra-file=/tmp/mig-src.cnf -e "\$stmt" 2>/dev/null || true; done
+# one CALL per session id; sweep repeatedly until no foreign sessions remain
+# (each sweep's SELECT excludes its own momentary connection + rdsadmin + the
+# DMS binlog reader, which must keep streaming until the final stop)
+for sweep in 1 2 3; do
+  IDS=\$(\$M -e "SELECT id FROM information_schema.processlist WHERE id != CONNECTION_ID() AND user NOT IN ('rdsadmin') AND command != 'Binlog Dump'")
+  [ -z "\$IDS" ] && break
+  for i in \$IDS; do \$M -e "CALL mysql.rds_kill(\$i);" 2>/dev/null || true; done
+  sleep 2
+done
+LEFT=\$(\$M -e "SELECT COUNT(*) FROM information_schema.processlist WHERE id != CONNECTION_ID() AND user NOT IN ('rdsadmin') AND command != 'Binlog Dump'")
+echo "foreign_sessions_remaining=\$LEFT"
+[ "\$LEFT" = "0" ] || exit 1
 mariadb --defaults-extra-file=/tmp/mig-src.cnf -e "INSERT INTO aurora_mig_ctl.marker (tag) VALUES ('$MARK');"
 echo MARKER_COMMITTED
 EOF
   say ""
   say ">>> NOW APPLY THE TERRAFORM FENCE: set aurora_migration_source_fenced = true"
   say ">>> in this env's env.hcl and confirm the gated physical apply, then return."
-  say "Polling for read_only=1 (the apply + parameter propagation)..."
+  say "Polling for read_only=1..."
   while :; do RO=$(ssm_run <<'EOF'
 mariadb --defaults-extra-file=/tmp/mig-src.cnf --batch --skip-column-names -e "SELECT @@read_only"
 EOF
 ); RO=$(echo "$RO" | tr -d '[:space:]'); say "  read_only=$RO"; [ "$RO" = "1" ] && break; sleep 30; done
+  say "post-fence kill sweep (anything that connected during the apply window;"
+  say "read_only already blocks their writes, this just tidies sessions)"
+  ssm_run <<'EOF'
+M="mariadb --defaults-extra-file=/tmp/mig-src.cnf --batch --skip-column-names"
+for i in $($M -e "SELECT id FROM information_schema.processlist WHERE id != CONNECTION_ID() AND user NOT IN ('rdsadmin') AND command != 'Binlog Dump'"); do $M -e "CALL mysql.rds_kill($i);" 2>/dev/null || true; done
+echo SWEPT
+EOF
   say "negative write test (must be refused)"
   ssm_run <<'EOF'
 if mariadb --defaults-extra-file=/tmp/mig-src.cnf -e "INSERT INTO aurora_mig_ctl.marker (tag) VALUES ('must-fail');" 2>/tmp/neg.err; then echo FENCE_BREACH; exit 1; else echo FENCE_OK; fi
 EOF
-  say "final source binlog coordinate:"
-  ssm_run <<'EOF'
-mariadb --defaults-extra-file=/tmp/mig-src.cnf --batch -e "SHOW MASTER STATUS;" | head -2
+  say "capturing the FINAL source binlog coordinate (nothing can write past it now)"
+  COORD=$(ssm_run <<'EOF'
+mariadb --defaults-extra-file=/tmp/mig-src.cnf --batch --skip-column-names -e "SHOW MASTER STATUS" | awk '{print $1, $2}'
 EOF
+)
+  FINAL_FILE=$(echo "$COORD" | awk '{print $1}' | grep -oE '[0-9]+$'); FINAL_POS=$(echo "$COORD" | awk '{print $2}' | tr -d '[:space:]')
+  [ -n "$FINAL_FILE" ] && [ -n "$FINAL_POS" ] || die "could not capture the final binlog coordinate"
+  say "final coordinate: file-seq=$FINAL_FILE pos=$FINAL_POS"
   say "gate: marker on Aurora"
   while :; do N=$(ssm_run <<EOF
 mariadb --defaults-extra-file=/tmp/mig-tgt.cnf --batch --skip-column-names -e "SELECT COUNT(*) FROM aurora_mig_ctl.marker WHERE tag='$MARK'" 2>/dev/null || echo 0
 EOF
 ); N=$(echo "$N" | tr -d '[:space:]'); say "  marker_on_aurora=$N"; [ "$N" = "1" ] && break; sleep 10; done
+  say "gate: DMS checkpoint at or past the final coordinate (the actual drain proof)"
+  while :; do if checkpoint_reached "$FINAL_FILE" "$FINAL_POS"; then say "  checkpoint reached"; break; fi; say "  waiting for checkpoint..."; sleep 15; done
   say "gate: validation fully clean (whitelist)"
   while :; do U=$(unclean_validation_count); say "  unclean=$U"; [ "$U" = "0" ] && break; sleep 20; done
-  say "installing object artifacts on the target (routines/events/triggers; DMS"
-  say "is about to stop for good, so triggers can never fire on replicated DML)"
-  ssm_run <<'EOF'
-set -e
-if [ -s /tmp/mig/objects.sql ]; then
-  mariadb --defaults-extra-file=/tmp/mig-tgt.cnf < /tmp/mig/objects.sql && echo OBJECTS_INSTALLED
-else
-  echo NO_OBJECTS_TO_INSTALL
-fi
-EOF
-  say "final task stop + checkpoint"
+  say "FINAL task stop + checkpoint record"
   aws dms stop-replication-task --replication-task-arn "$(task_arn)" --region "$REGION" >/dev/null
   while [ "$(task_status)" != "stopped" ]; do sleep 10; done
   say "checkpoint: $(aws dms describe-replication-tasks --region "$REGION" --filters "Name=replication-task-id,Values=$TASK_ID" --query 'ReplicationTasks[0].RecoveryCheckpoint' --output text)"
+  say "installing object artifacts AFTER the final stop (DMS can never apply DML"
+  say "through freshly installed triggers). Dumped FRESH from the fenced source -"
+  say "consistent by construction, immune to bastion replacement losing /tmp."
+  ssm_run <<'EOF'
+set -e; umask 177
+S="mariadb --defaults-extra-file=/tmp/mig-src.cnf --batch --skip-column-names"
+$S -e "SELECT schema_name FROM information_schema.schemata WHERE schema_name NOT IN ('mysql','information_schema','performance_schema','sys','innodb','tmp','aurora_mig_ctl') AND schema_name NOT LIKE 'awsdms%'" > /tmp/fence-schemas.txt
+mariadb-dump --defaults-extra-file=/tmp/mig-src.cnf --no-data --no-create-info --no-create-db --routines --events --triggers --skip-opt --databases $(tr '\n' ' ' < /tmp/fence-schemas.txt) > /tmp/fence-objects.sql
+SRC_COUNTS="$($S -e "SELECT CONCAT((SELECT COUNT(*) FROM information_schema.routines WHERE routine_schema NOT IN ('mysql','sys')),'/',(SELECT COUNT(*) FROM information_schema.triggers WHERE trigger_schema NOT IN ('mysql','sys')),'/',(SELECT COUNT(*) FROM information_schema.events WHERE event_schema NOT IN ('mysql','sys')))")"
+if [ "$SRC_COUNTS" = "0/0/0" ]; then echo "NO_OBJECTS_ON_SOURCE (verified live, not from a stale artifact)"; exit 0; fi
+mariadb --defaults-extra-file=/tmp/mig-tgt.cnf < /tmp/fence-objects.sql
+T="mariadb --defaults-extra-file=/tmp/mig-tgt.cnf --batch --skip-column-names"
+TGT_COUNTS="$($T -e "SELECT CONCAT((SELECT COUNT(*) FROM information_schema.routines WHERE routine_schema NOT IN ('mysql','sys')),'/',(SELECT COUNT(*) FROM information_schema.triggers WHERE trigger_schema NOT IN ('mysql','sys')),'/',(SELECT COUNT(*) FROM information_schema.events WHERE event_schema NOT IN ('mysql','sys')))")"
+[ "$SRC_COUNTS" = "$TGT_COUNTS" ] && echo "OBJECTS_INSTALLED_AND_VERIFIED $SRC_COUNTS" || { echo "OBJECT_COUNT_MISMATCH src=$SRC_COUNTS tgt=$TGT_COUNTS"; exit 1; }
+EOF
   say ""
   say "GO: the gate has passed. Confirming the aurora_migration_state=cutover"
   say "physical apply IS the promotion - its auto-following logical apply"
@@ -312,22 +353,41 @@ EOF
   ;;
 
 abort)
-  # Hard guards: abort is PRE-CUTOVER ONLY. After the cutover apply the app is
-  # writing to Aurora and reopening RDS would split-brain.
-  H=$(primary_secret_host); A=$(aurora_endpoint 2>/dev/null || echo none)
+  # Hard, fail-closed guards: abort is PRE-CUTOVER ONLY. Cutover cannot be
+  # in-flight concurrently: the fence-required-at-cutover Terraform validation
+  # means an unfence apply and a cutover apply are mutually exclusive changes
+  # to the same gated stack.
+  H=$(primary_secret_host) || die "REFUSED: cannot read the primary secret (fail closed)"
+  A=$(aurora_endpoint) || die "REFUSED: cannot resolve the Aurora endpoint (fail closed)"
+  [ -n "$H" ] && [ -n "$A" ] || die "REFUSED: empty endpoint facts (fail closed)"
   [ "$H" = "$A" ] && die "REFUSED: primary secret host already points at Aurora - cutover has been applied. Fail forward."
   prep_cnfs
   PW=$(ssm_run <<'EOF'
-mariadb --defaults-extra-file=/tmp/mig-tgt.cnf --batch --skip-column-names -e "SELECT COUNT(*) FROM aurora_mig_ctl.marker WHERE tag LIKE 'post-promotion%'" 2>/dev/null || echo 0
+set -e
+mariadb --defaults-extra-file=/tmp/mig-tgt.cnf --batch --skip-column-names -e "SELECT COUNT(*) FROM aurora_mig_ctl.marker WHERE tag LIKE 'post-promotion%'"
 EOF
-); PW=$(echo "$PW" | tr -d '[:space:]')
+) || die "REFUSED: cannot query Aurora for promotion evidence (fail closed)"
+  PW=$(echo "$PW" | tr -d '[:space:]')
   [ "$PW" = "0" ] || die "REFUSED: post-promotion writes exist on Aurora. Fail forward."
+  say "removing any objects the fence installed on the target (triggers must not"
+  say "fire on replicated DML when CDC resumes for a retry)"
+  ssm_run <<'EOF'
+set -e
+T="mariadb --defaults-extra-file=/tmp/mig-tgt.cnf --batch --skip-column-names"
+$T -e "SELECT CONCAT('DROP TRIGGER IF EXISTS \`',trigger_schema,'\`.\`',trigger_name,'\`;') FROM information_schema.triggers WHERE trigger_schema NOT IN ('mysql','sys')" > /tmp/drop-objs.sql
+$T -e "SELECT CONCAT('DROP EVENT IF EXISTS \`',event_schema,'\`.\`',event_name,'\`;') FROM information_schema.events WHERE event_schema NOT IN ('mysql','sys')" >> /tmp/drop-objs.sql
+if [ -s /tmp/drop-objs.sql ]; then mariadb --defaults-extra-file=/tmp/mig-tgt.cnf < /tmp/drop-objs.sql && echo TARGET_OBJECTS_DROPPED; else echo NO_TARGET_OBJECTS; fi
+EOF
   say ">>> UNFENCE: set aurora_migration_source_fenced = false in env.hcl and"
-  say ">>> confirm the gated apply. Polling for read_only=0..."
+  say ">>> confirm the gated apply (Terraform refuses this while state=cutover)."
+  say "Polling for read_only=0..."
   while :; do RO=$(ssm_run <<'EOF'
 mariadb --defaults-extra-file=/tmp/mig-src.cnf --batch --skip-column-names -e "SELECT @@read_only"
 EOF
 ); RO=$(echo "$RO" | tr -d '[:space:]'); say "  read_only=$RO"; [ "$RO" = "0" ] && break; sleep 30; done
+  # re-verify the guard AFTER the human-gated apply window (TOCTOU close-out)
+  H2=$(primary_secret_host) || die "post-unfence verification failed (fail closed)"
+  [ "$H2" = "$(aurora_endpoint)" ] && die "INCONSISTENT: secret now points at Aurora after unfence - investigate before touching writers"
   if [ "$(task_status)" = "stopped" ]; then
     say "re-establishing CDC from the checkpoint (so the migration can retry later)"
     aws dms start-replication-task --replication-task-arn "$(task_arn)" --start-replication-task-type resume-processing --region "$REGION" >/dev/null
@@ -336,7 +396,7 @@ EOF
     say "resuming the BI task against the (still RDS) source"
     aws dms start-replication-task --replication-task-arn "$(bi_task_arn)" --start-replication-task-type resume-processing --region "$REGION" >/dev/null
   fi
-  say "ABORTED cleanly: source writable again, Aurora untouched by the app, CDC re-established. Scale writers back up."
+  say "ABORTED cleanly: source writable, Aurora untouched by the app, CDC re-established. Scale writers back up."
   ;;
 
 bi-epoch)

--- a/terraform/physical/variables.tf
+++ b/terraform/physical/variables.tf
@@ -520,6 +520,13 @@ variable "aurora_migration_source_fenced" {
     condition     = !var.aurora_migration_source_fenced || var.aurora_migration_state != "off"
     error_message = "aurora_migration_source_fenced requires an active aurora_migration_state."
   }
+  validation {
+    # Once cutover is applied the app writes to Aurora; unfencing the RDS then
+    # would split-brain. The fence stays on through cutover and cleanup - the
+    # RDS unfreezes only at its final retirement (db_engine flip).
+    condition     = var.aurora_migration_source_fenced || !contains(["cutover", "cleanup"], var.aurora_migration_state)
+    error_message = "aurora_migration_source_fenced must remain true while aurora_migration_state is cutover or cleanup (unfencing a replaced source would split-brain)."
+  }
 }
 
 

--- a/terraform/physical/variables.tf
+++ b/terraform/physical/variables.tf
@@ -504,6 +504,24 @@ variable "aurora_migration_dms_engine_version" {
   default     = "3.6.1"
 }
 
+variable "aurora_migration_source_fenced" {
+  description = <<-EOT
+    Cutover write-fence for the RDS source during an Aurora migration. When true,
+    read_only=1 is injected into the RDS parameter group AS CONFIG, so the fence
+    is Terraform-owned: no concurrent or subsequent apply can silently revert it
+    (an out-of-band fence would be reset by any refreshed apply mid-cutover).
+    Set true (gated apply) at the runner's fence step; back to false only on a
+    pre-cutover abort. On RDS MySQL 8.0.36+ read_only=1 is a complete fence for
+    every customer account - no grantable privilege bypasses it.
+  EOT
+  type        = bool
+  default     = false
+  validation {
+    condition     = !var.aurora_migration_source_fenced || var.aurora_migration_state != "off"
+    error_message = "aurora_migration_source_fenced requires an active aurora_migration_state."
+  }
+}
+
 
 variable "delete_after" {
   description = "Optional RFC3339 timestamp. When set, every resource is tagged deleteAfter=<value> so the ResourceReaper janitor can purge it after that time if teardown fails. Empty = no tag (normal deploys)."


### PR DESCRIPTION
Draft while under Codex review. Folds in all 11 blockers + 1 correctness finding from the round-1 review of #320:

- Terraform-owned cutover fence (`aurora_migration_source_fenced` -> read_only=1 in the RDS PG as config; no apply can silently unfence mid-cutover)
- dedicated migration credentials secret for the Aurora target (its password lives only in TF state pre-cutover)
- DMS mapping excludes system schemas explicitly
- session kill by connection id (app + runner share the master user)
- BI task stopped in fence, before the cutover apply touches its endpoint; bi-epoch reloads after
- validation gates: case-insensitive clean-state whitelist + implemented checksums
- abort: hard post-cutover refusal guards + CDC/BI re-establishment for retries
- object artifacts (routines/events/triggers) dumped at preload, installed after the final task stop
- cutover-verify reframed as post-promotion verification (fence's GO gates the promotion; the auto-following logical apply is the PONR)
- dms-vpc/cloudwatch roles for BI-less accounts
- transition tripwire via terraform_data phase memory + db-replace-guard OPA as the destructive-reversal backstop + BI-non-DMS precondition