### PR TITLE
fix(physical): aurora runner secret lookup breaks under list-secrets pagination

### DIFF
--- a/terraform/physical/util/aurora-migration-runner.sh
+++ b/terraform/physical/util/aurora-migration-runner.sh
@@ -50,8 +50,16 @@ task_arn() { aws dms describe-replication-tasks --region "$REGION" --filters "Na
 task_status() { aws dms describe-replication-tasks --region "$REGION" --filters "Name=replication-task-id,Values=$TASK_ID" --query 'ReplicationTasks[0].Status' --output text 2>/dev/null || echo none; }
 bi_task_arn() { aws dms describe-replication-tasks --region "$REGION" --filters "Name=replication-task-id,Values=$ID" --query 'ReplicationTasks[0].ReplicationTaskArn' --output text 2>/dev/null; }
 bi_task_status() { aws dms describe-replication-tasks --region "$REGION" --filters "Name=replication-task-id,Values=$ID" --query 'ReplicationTasks[0].Status' --output text 2>/dev/null || echo none; }
-primary_secret() { aws secretsmanager list-secrets --region "$REGION" --query "SecretList[?starts_with(Name, '${ID}-database')].ARN | [0]" --output text; }
-migration_secret() { aws secretsmanager list-secrets --region "$REGION" --query "SecretList[?starts_with(Name, '${ID}-aurora-migration')].ARN | [0]" --output text; }
+# NOTE: the projection query has NO `| [0]`. A `| [0]` inside --query is a
+# pipe-expression the AWS CLI evaluates PER PAGE of paginated list-secrets
+# results, so a page without a match emits "None" and the match on a later page
+# emits the ARN - the caller then sees "None" first and the whole chain fails.
+# The bare projection aggregates across every page; we pick the first real ARN.
+first_secret_arn() { # $1 = name prefix
+  aws secretsmanager list-secrets --region "$REGION" --query "SecretList[?starts_with(Name, '$1')].ARN" --output text | tr '\t' '\n' | grep -v '^None$' | grep . | head -1
+}
+primary_secret() { first_secret_arn "${ID}-database"; }
+migration_secret() { first_secret_arn "${ID}-aurora-migration"; }
 src_pg() { aws rds describe-db-instances --db-instance-identifier "$SRC_ID" --region "$REGION" --query 'DBInstances[0].DBParameterGroups[0].DBParameterGroupName' --output text; }
 primary_secret_host() { aws secretsmanager get-secret-value --region "$REGION" --secret-id "$(primary_secret)" --query SecretString --output text | jq -r .host; }
 


### PR DESCRIPTION
The migration runner's `primary_secret`/`migration_secret` used `--query 'SecretList[?...].ARN | [0]'`. The `| [0]` is evaluated per page of paginated `list-secrets` output, so a page with no match returns `None` and the real ARN lands on a later page. The caller reads `None` first and every downstream step (cnf prep, fence guards) fails closed against a live secret.

Fix: drop the per-page pipe, let the projection aggregate across all pages, pick the first real ARN in shell.

Caught live running the gca Aurora canary `preload`. Static review (4 Codex rounds) couldn't see it - it never executes the script. Proven against the live gca account: `primary secret host` now resolves the RDS endpoint correctly.