### PR TITLE
feat(logical): flux drift-warn, slack alerts, crds CreateReplace, maxHistory

### DIFF
--- a/terraform/logical/README.md
+++ b/terraform/logical/README.md
@@ -55,6 +55,8 @@ No modules.
 | [kubectl_manifest.dozuki_helmrelease](https://registry.terraform.io/providers/alekc/kubectl/2.1.5/docs/resources/manifest) | resource |
 | [kubectl_manifest.dozuki_ocirepository](https://registry.terraform.io/providers/alekc/kubectl/2.1.5/docs/resources/manifest) | resource |
 | [kubectl_manifest.envoy_gateway_crds](https://registry.terraform.io/providers/alekc/kubectl/2.1.5/docs/resources/manifest) | resource |
+| [kubectl_manifest.flux_slack_alert](https://registry.terraform.io/providers/alekc/kubectl/2.1.5/docs/resources/manifest) | resource |
+| [kubectl_manifest.flux_slack_provider](https://registry.terraform.io/providers/alekc/kubectl/2.1.5/docs/resources/manifest) | resource |
 | [kubectl_manifest.peer_auth_carveouts](https://registry.terraform.io/providers/alekc/kubectl/2.1.5/docs/resources/manifest) | resource |
 | [kubectl_manifest.peer_auth_strict](https://registry.terraform.io/providers/alekc/kubectl/2.1.5/docs/resources/manifest) | resource |
 | [kubernetes_cluster_role_binding_v1.dozuki_list_role_binding](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/cluster_role_binding_v1) | resource |
@@ -79,6 +81,7 @@ No modules.
 | [kubernetes_role_binding_v1.dozuki_subsite_role_binding](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/role_binding_v1) | resource |
 | [kubernetes_role_v1.dozuki_subsite_role](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/role_v1) | resource |
 | [kubernetes_secret_v1.flux_ghcr_pull](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret_v1) | resource |
+| [kubernetes_secret_v1.flux_slack_webhook](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret_v1) | resource |
 | [kubernetes_secret_v1.flux_values](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret_v1) | resource |
 | [kubernetes_secret_v1.gateway_tls](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret_v1) | resource |
 | [kubernetes_secret_v1.ghcr_pull](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret_v1) | resource |
@@ -164,6 +167,7 @@ No modules.
 | <a name="input_environment"></a> [environment](#input\_environment) | Environment of the application | `string` | `"dev"` | no |
 | <a name="input_external_dns_sa_name"></a> [external\_dns\_sa\_name](#input\_external\_dns\_sa\_name) | external-dns service account name (must match the AWS role trust subject). | `string` | `"external-dns"` | no |
 | <a name="input_flux_chart_version"></a> [flux\_chart\_version](#input\_flux\_chart\_version) | fluxcd-community/flux2 chart version for the app-delivery controllers. 2.19.0 = Flux 2.9.1 (helm-controller v1.6.2, Helm 4/SSA line), validated adopting the release cleanly on min under Helm 3 and 4. | `string` | `"2.19.0"` | no |
+| <a name="input_flux_slack_webhook_url"></a> [flux\_slack\_webhook\_url](#input\_flux\_slack\_webhook\_url) | Slack incoming-webhook URL for Flux notifications. When set, notification-controller comes up and a Provider(type=slack)+Alert post HelmRelease/OCIRepository events (successes and failures) to Slack. Empty (default) wires nothing and leaves the controller off - fully opt-in per env. | `string` | `""` | no |
 | <a name="input_frontegg_api_token"></a> [frontegg\_api\_token](#input\_frontegg\_api\_token) | Frontegg API token (Azure only; AWS reads Vault). | `string` | `""` | no |
 | <a name="input_frontegg_client_id"></a> [frontegg\_client\_id](#input\_frontegg\_client\_id) | Frontegg client ID (Azure only; AWS reads Vault). | `string` | `""` | no |
 | <a name="input_gateway_dns_label"></a> [gateway\_dns\_label](#input\_gateway\_dns\_label) | Azure DNS label for the gateway LoadBalancer (azure). Yields <label>.<region>.cloudapp.azure.com. Empty = LB public IP with no DNS label. | `string` | `""` | no |

--- a/terraform/logical/flux.tf
+++ b/terraform/logical/flux.tf
@@ -354,12 +354,14 @@ resource "helm_release" "flux" {
     aws_iam_role_policy.flux_source_ecr_read,
   ]
 
-  # Only the two controllers the app-delivery path needs; the rest add footprint + images to mirror.
+  # Only the controllers the app-delivery path needs; the rest add footprint + images to mirror.
+  # notification-controller comes up only when a Slack webhook is wired (var.flux_slack_webhook_url);
+  # it is what turns the Provider/Alert below into actual Slack posts, so no webhook means no controller.
   values = [yamlencode({
     imageAutomationController = { create = false }
     imageReflectionController = { create = false }
     kustomizeController       = { create = false }
-    notificationController    = { create = false }
+    notificationController    = { create = var.flux_slack_webhook_url != "" }
     helmController            = { create = true }
     sourceController          = { create = true }
   })]
@@ -460,11 +462,18 @@ resource "kubectl_manifest" "dozuki_helmrelease" {
       releaseName      = "dozuki"
       targetNamespace  = kubernetes_namespace_v1.app.metadata[0].name
       storageNamespace = kubernetes_namespace_v1.app.metadata[0].name
-      maxHistory       = 0 # keep unlimited history; helm-controller defaults to 5 and would prune
+      maxHistory       = 20 # cap stored release revisions; unbounded history piles up storage-namespace Secrets over time
       chartRef         = { kind = "OCIRepository", name = "dozuki", namespace = kubernetes_namespace_v1.flux_system.metadata[0].name }
       install          = { disableWait = false, timeout = "4h30m", remediation = { retries = 0 } }
-      upgrade          = { disableWait = false, timeout = "4h30m", remediation = { retries = 0, remediateLastFailure = false } }
-      # driftDetection intentionally omitted: a completed migration Job must not be recreated/rerun.
+      # crds=CreateReplace so chart CRD changes actually apply on upgrade - helm-controller skips CRD updates by default.
+      upgrade = { disableWait = false, timeout = "4h30m", crds = "CreateReplace", remediation = { retries = 0, remediateLastFailure = false } }
+      # driftDetection in warn mode surfaces cluster drift (events + metrics) WITHOUT auto-correcting it, so nothing gets
+      # reverted under us. Jobs are ignored (empty-string JSON pointer = the whole object) so a completed migration/db-create
+      # Job never registers as drift and never gets recreated/rerun - the reason drift detection was omitted before.
+      driftDetection = {
+        mode   = "warn"
+        ignore = [{ paths = [""], target = { kind = "Job" } }]
+      }
       valuesFrom = [{ kind = "Secret", name = kubernetes_secret_v1.flux_values.metadata[0].name, valuesKey = "values.yaml" }]
     }
   })
@@ -480,6 +489,56 @@ resource "kubectl_manifest" "dozuki_helmrelease" {
       error_message = "istio_mesh_state requires commercial AWS EKS (non-GovCloud). Gov needs the phase-2 image mirror; Azure is not supported yet."
     }
   }
+}
+
+# ---------------------------------------------------------------------------
+# notification-controller -> Slack. Flux posts HelmRelease/OCIRepository events (both failures and
+# successes, eventSeverity=info) to a Slack incoming webhook. Entirely gated on var.flux_slack_webhook_url:
+# empty (the default) creates NO Secret/Provider/Alert and leaves notification-controller off (above), so
+# an env without a webhook wired stays exactly as it was. This layer has no Kustomizations, so the Alert
+# scopes to the resources that actually exist here: the app HelmRelease and its OCIRepository source.
+# ---------------------------------------------------------------------------
+
+# The webhook URL as a Secret the Provider references by `address` key (never inlined in the Provider spec).
+resource "kubernetes_secret_v1" "flux_slack_webhook" {
+  count = var.flux_slack_webhook_url != "" ? 1 : 0
+  metadata {
+    name      = "flux-slack-webhook"
+    namespace = kubernetes_namespace_v1.flux_system.metadata[0].name
+  }
+  data = { address = var.flux_slack_webhook_url }
+}
+
+resource "kubectl_manifest" "flux_slack_provider" {
+  count      = var.flux_slack_webhook_url != "" ? 1 : 0
+  depends_on = [helm_release.flux, kubernetes_secret_v1.flux_slack_webhook]
+  yaml_body = yamlencode({
+    apiVersion = "notification.toolkit.fluxcd.io/v1beta3"
+    kind       = "Provider"
+    metadata   = { name = "slack", namespace = kubernetes_namespace_v1.flux_system.metadata[0].name }
+    spec = {
+      type      = "slack"
+      secretRef = { name = kubernetes_secret_v1.flux_slack_webhook[0].metadata[0].name }
+    }
+  })
+}
+
+resource "kubectl_manifest" "flux_slack_alert" {
+  count      = var.flux_slack_webhook_url != "" ? 1 : 0
+  depends_on = [kubectl_manifest.flux_slack_provider]
+  yaml_body = yamlencode({
+    apiVersion = "notification.toolkit.fluxcd.io/v1beta3"
+    kind       = "Alert"
+    metadata   = { name = "dozuki", namespace = kubernetes_namespace_v1.flux_system.metadata[0].name }
+    spec = {
+      providerRef   = { name = "slack" }
+      eventSeverity = "info" # info => both success and failure events; "error" would drop successes
+      eventSources = [
+        { kind = "HelmRelease", name = "*" },
+        { kind = "OCIRepository", name = "*" },
+      ]
+    }
+  })
 }
 
 # Hand the running release off to Flux without uninstalling it: forget helm_release.app from state

--- a/terraform/logical/variables.tf
+++ b/terraform/logical/variables.tf
@@ -565,3 +565,10 @@ variable "flux_chart_version" {
   type        = string
   default     = "2.19.0"
 }
+
+variable "flux_slack_webhook_url" {
+  description = "Slack incoming-webhook URL for Flux notifications. When set, notification-controller comes up and a Provider(type=slack)+Alert post HelmRelease/OCIRepository events (successes and failures) to Slack. Empty (default) wires nothing and leaves the controller off - fully opt-in per env."
+  type        = string
+  default     = ""
+  sensitive   = true
+}


### PR DESCRIPTION
Four approved Flux improvements (task #12), drafted + workflow-reviewed (APPROVE, 0 blockers). Draft pending your review.

1. **driftDetection = warn + ignore Jobs** — surfaces drift in events/metrics without auto-correcting; Jobs ignored so a completed migration/db-create Job never registers as drift (the reason drift detection was omitted before).
2. **notification-controller → Slack** — new `var.flux_slack_webhook_url` (default `""`, sensitive). Empty: no Secret/Provider/Alert, controller stays off → existing envs unchanged. Set: Secret + Provider(type slack) + Alert (info severity = successes + failures, scoped to HelmRelease + OCIRepository).
3. **upgrade.crds = CreateReplace** — chart CRD changes apply on upgrade.
4. **maxHistory = 20** — caps stored release-revision Secrets (was 0 = unbounded).

Runbook (suspend/resume, reconcile --with-source, forceAt un-stall) still to add; cosign chart signing deferred to CI.