### PR TITLE
fix(logical): key grafana-db-create job name on db_resource_id

### DIFF
--- a/terraform/logical/bi.tf
+++ b/terraform/logical/bi.tf
@@ -147,7 +147,14 @@ resource "kubernetes_job_v1" "grafana_db_create" {
   count = (var.enable_bi || var.enable_dashboards) ? 1 : 0
 
   metadata {
-    name      = "grafana-db-create"
+    # Fold the primary DB's resourceId into the Job name (short sha256 suffix) so a database
+    # replacement (new db_resource_id, e.g. a snapshot re-restore to a new cluster) yields a new
+    # name and Terraform creates a fresh Job. The old static name meant the already-Completed Job
+    # was never recreated on later applies, so grafana_primary never got created on the replaced
+    # DB and the dashboards Grafana couldn't start. Same #4a fix the migration Job uses. When
+    # db_resource_id is empty (default) the name stays "grafana-db-create" - no diff for stacks not
+    # wiring it yet.
+    name      = var.db_resource_id == "" ? "grafana-db-create" : "grafana-db-create-${substr(sha256(var.db_resource_id), 0, 8)}"
     namespace = kubernetes_namespace_v1.app.metadata[0].name
   }
   spec {


### PR DESCRIPTION
Task #13, drafted this session. Draft pending your review.

The `grafana-db-create` Job in `terraform/logical/bi.tf` had a static name, so once it Completed it was never recreated on later applies. When the app DB is **replaced** (new `db_resource_id` — e.g. a snapshot re-restore to a new cluster), `grafana_primary` never got created on the new DB and the dashboards Grafana couldn't start. This bit us live during the 3M cutover (manual `CREATE DATABASE`).

Fix: fold `db_resource_id` into the Job name via a short sha256 suffix — the same #4a pattern the migration Job uses — so a DB replacement changes the name and Terraform creates a fresh Job.

- `db_resource_id` already in scope (variables.tf, default `""`, wired from physical).
- Empty default → name stays `grafana-db-create` (no diff for stacks not wiring it yet).
- Set → e.g. `grafana-db-create-ee897478` (valid DNS-1123 label, <63 chars).
- One-time re-run on first apply where it's set is harmless (SQL is create-if-not-exists).