### PR TITLE
fix(physical): drop explicit lower_case_table_names from the aurora cluster PG

### DIFF
--- a/terraform/physical/aurora.tf
+++ b/terraform/physical/aurora.tf
@@ -92,9 +92,13 @@ module "aurora" {
         { name = "binlog_format", value = "ROW", apply_method = "pending-reboot" },
         { name = "binlog_row_image", value = "full", apply_method = "pending-reboot" },
         { name = "binlog_checksum", value = "NONE", apply_method = "pending-reboot" },
-        # Explicit even though 0 is the engine default: it must match the RDS
-        # source at migration time and is immutable after cluster creation.
-        { name = "lower_case_table_names", value = "0", apply_method = "pending-reboot" },
+        # lower_case_table_names is intentionally NOT set here even though the
+        # migration requires 0 (it must match the RDS source). 0 IS the engine
+        # default, and AWS refuses ModifyDBClusterParameterGroup on that
+        # parameter once the PG is associated with a live cluster - so an
+        # explicit entry bricks every EXISTING aurora env's first apply of this
+        # code (caught on dev-min). The migration runner asserts the effective
+        # value at its gates instead.
       ],
       # Migration-only relaxations, removed again after cleanup. local_infile is
       # required by DMS full load; the event scheduler stays OFF until the


### PR DESCRIPTION
AWS refuses `ModifyDBClusterParameterGroup` on `lower_case_table_names` once the PG is associated with a live Aurora cluster - even setting it to its current/default value. The explicit entry (added in #322 for migration-source parity) therefore fails the first v7.22.x physical apply on every **existing** aurora env:

```
InvalidParameterCombination: The value for the lower_case_table_names parameter can't be changed ...
This parameter group is associated with one or more Aurora MySQL DB clusters.
```

Caught live on dev-min (the PR #328 canary pin). New clusters (like the gca migration provision) are unaffected - the PG is created before association. `0` is the engine default anyway, and the migration runner asserts the effective value at its gates, which is where the parity check belongs.