### PR TITLE
fix(logical): add chart + app image versions to flux slack notifications

### DIFF
--- a/terraform/logical/flux.tf
+++ b/terraform/logical/flux.tf
@@ -538,8 +538,11 @@ resource "kubectl_manifest" "flux_slack_alert" {
       # notification - otherwise fleet messages are indistinguishable.
       summary = "${var.customer}-${var.environment}"
       eventMetadata = {
-        env     = "${var.customer}-${var.environment}"
-        cluster = var.eks_cluster_id
+        env             = "${var.customer}-${var.environment}"
+        cluster         = var.eks_cluster_id
+        chart           = var.chart_version
+        app-image       = var.image_tag
+        webnextjs-image = var.nextjs_tag
       }
       eventSources = [
         { kind = "HelmRelease", name = "*" },


### PR DESCRIPTION
Adds `chart` (chart_version), `app-image` (image_tag), and `webnextjs-image` (nextjs_tag) to the Alert `eventMetadata`, alongside the env identity from #331. All three flow through TF applies (the only path they change), so each Slack message states exactly what shipped.