### PR TITLE
fix(logical): dedupe flux alert fields to env + versions

### DIFF
--- a/terraform/logical/flux.tf
+++ b/terraform/logical/flux.tf
@@ -543,10 +543,10 @@ resource "kubectl_manifest" "flux_slack_alert" {
       # Every env posts to the same channel with the identical object title
       # (helmrelease/dozuki.flux-system), so stamp the env identity onto each
       # notification - otherwise fleet messages are indistinguishable.
-      summary = "${var.customer}-${var.environment}"
+      # Just env + versions: summary and cluster duplicated env on every fleet
+      # stack (eks_cluster_id == customer-environment), tripling the same value.
       eventMetadata = {
         env             = "${var.customer}-${var.environment}"
-        cluster         = var.eks_cluster_id
         chart           = var.chart_version
         app-image       = var.image_tag
         webnextjs-image = var.nextjs_tag


### PR DESCRIPTION
`summary` and `cluster` tripled the same value on every fleet stack (`eks_cluster_id` == `customer-environment`). Alerts now carry one `env` field plus `chart`/`app-image`/`webnextjs-image`. The stale `app-version` field is removed at its source in helm#166 (chart appVersion dropped).