### PR TITLE
fix(physical): scope dms event alerts to own tasks + apply resizes immediately

### DIFF
--- a/terraform/physical/aurora-migration.tf
+++ b/terraform/physical/aurora-migration.tf
@@ -135,6 +135,11 @@ resource "aws_dms_replication_subnet_group" "aurora_migration" {
 }
 
 resource "aws_dms_replication_instance" "aurora_migration" {
+  # Modifications (e.g. an instance-class bump when a load OOMs) must take
+  # effect NOW, not at the maintenance window - the apac full load crash-looped
+  # for an hour while a scheduled resize sat waiting.
+  apply_immediately = true
+
   count = local.aurora_migration_dms ? 1 : 0
 
   replication_instance_id    = "${local.identifier}-aurora-migration"

--- a/terraform/physical/monitoring.tf
+++ b/terraform/physical/monitoring.tf
@@ -389,13 +389,21 @@ resource "aws_cloudwatch_event_rule" "dms_task_state_changed_rule" {
   name        = "${local.identifier}-dms-task-changed-rule"
   description = "Capture change state of DMS replication tasks"
 
+  # Scoped to THIS env's task ARNs: DMS state-change events are account+region
+  # wide, so an unscoped pattern forwards every other env's task events too -
+  # each env's slack lambda then stamps its own identifier on a foreign task
+  # (an m3-apac migration OOM alerted as m3-gca).
   event_pattern = jsonencode({
     "source" : [
       "aws.dms"
     ],
     "detail-type" : [
       "DMS Replication Task State Change"
-    ]
+    ],
+    "resources" : compact(concat(
+      [for t in aws_dms_replication_task.this : t.replication_task_arn],
+      local.aurora_migration_dms ? [aws_dms_replication_task.aurora_migration[0].replication_task_arn] : []
+    ))
   })
 }
 


### PR DESCRIPTION
Two DMS ops defects surfaced by the apac migration load:

1. **Cross-env mislabeled alerts.** The `dms_task_state_changed_rule` EventBridge pattern had no `resources` filter; DMS state-change events are account+region wide, so every env's rule forwarded every other env's task events and each slack lambda stamped its own identifier on the foreign task - David got apac's OOM labeled `m3-gca`. Pattern now lists this env's own task ARNs (BI + migration task when present).

2. **Resize stuck at maintenance window.** The migration DMS instance lacked `apply_immediately`, so the OOM-fix resize to `dms.c5.xlarge` sat in `scheduled-modifications` while the load crash-looped (forced out-of-band to unblock apac). The migration rig is ours to bounce.