### PR TITLE
fix(physical): dms slack alerts - regional task link, page only on failures

### DIFF
--- a/terraform/physical/util/sns_to_slack.py
+++ b/terraform/physical/util/sns_to_slack.py
@@ -79,9 +79,13 @@ def lambda_handler(event, context):
         detail_message = message_json['detail'].get('detailMessage', 'N/A')
         resource_arn = message_json['resources'][0] if message_json['resources'] else 'N/A'
         replication_task_name = get_task_name(resource_arn)
-        replication_task_link = f"https://console.aws.amazon.com/dms/v2/home?region=us-east-1#taskDetails/{replication_task_name}"
+        # Link to THIS region's console (was hardcoded us-east-1).
+        replication_task_link = f"https://console.aws.amazon.com/dms/v2/home?region={region}#taskDetails/{replication_task_name}"
 
-        if "stopped" in detail_message or "ERROR" in detail_message:
+        # Page the channel only on failures. A plain "Replication task stopped"
+        # is routine (operator stops, the migration's automatic
+        # post-full-load stop, fence-time stops) and must not @channel.
+        if "ERROR" in detail_message or "FATAL" in detail_message or "fail" in detail_message.lower():
             header = "*DMS Alarm! <!channel>*"
         else:
             header = "*DMS Notification*"


### PR DESCRIPTION
Two `sns_to_slack.py` defects from tonight's alert stream:

1. The task console link hardcoded `region=us-east-1` - ap-southeast-1 tasks linked to the wrong region.
2. `@channel` fired on any message containing \"stopped\", paging everyone for routine stops (operator stops, the migration's automatic post-full-load stop, fence-time stops during cutovers - tonight would have paged repeatedly). Now pages only on ERROR/FATAL/failure; plain state changes post without the ping.