### PR TITLE
chore(physical): hardcode 3 AZs, delete the azs_count variable

### DIFF
--- a/live/logical.hcl
+++ b/live/logical.hcl
@@ -5,7 +5,6 @@ dependency "physical" {
 
   mock_outputs = {
     vpc_id                        = "temporary-dummy-id"
-    azs_count                     = 3
     eks_cluster_id                = "dummy-cluster-id"
     eks_cluster_access_role_arn   = "dummy-arn"
     dns_domain_name               = "dummy-lb-dns"
@@ -31,7 +30,6 @@ dependency "physical" {
 
 inputs = {
   vpc_id    = dependency.physical.outputs.vpc_id
-  azs_count = dependency.physical.outputs.azs_count
 
 
   eks_cluster_id              = dependency.physical.outputs.eks_cluster_id

--- a/terraform/CONTRACT.md
+++ b/terraform/CONTRACT.md
@@ -18,7 +18,6 @@ config layer, not produced by the cloud layer.
 | `s3_kms_key_id` | Object-store KMS key | `s3_kms_key_id` | N/A — `""` (SeaweedFS volumes ride Azure Storage encryption at rest) |
 | `s3_replicate_buckets` | Migration-from-existing-buckets flag | `s3_replicate_buckets` | N/A — `false` |
 | `vpc_id` | Network ID † | `vpc_id` | `vnet_id` |
-| `azs_count` | AZ count † | `azs_count` | N/A — `3` (zonal layout is Azure-internal) |
 | `vault_address` | HashiCorp Vault address (secret backend) | `"http://" + vault_endpoint_dns + ":8200"` | N/A — Azure uses Key Vault via ESO (`key_vault_uri`) |
 | `dms_task_arn` / `dms_enabled` | BI replication | `dms_task_arn` / `dms_enabled` | N/A — `""` / `false` (BI deferred past Azure v1) |
 | `bi_database_credential_secret` | BI DB secret | `bi_database_credential_secret` | N/A — `""` |

--- a/terraform/physical/README.md
+++ b/terraform/physical/README.md
@@ -15,9 +15,9 @@
 | Name | Version |
 |------|---------|
 | <a name="provider_archive"></a> [archive](#provider\_archive) | 2.8.0 |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.56.0 |
-| <a name="provider_aws.dns"></a> [aws.dns](#provider\_aws.dns) | 6.56.0 |
-| <a name="provider_aws.dr"></a> [aws.dr](#provider\_aws.dr) | 6.56.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.54.0 |
+| <a name="provider_aws.dns"></a> [aws.dns](#provider\_aws.dns) | 6.54.0 |
+| <a name="provider_aws.dr"></a> [aws.dr](#provider\_aws.dr) | 6.54.0 |
 | <a name="provider_null"></a> [null](#provider\_null) | 3.3.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | 3.9.0 |
 | <a name="provider_terraform"></a> [terraform](#provider\_terraform) | n/a |
@@ -122,8 +122,6 @@
 | [aws_lambda_function.sns_to_slack](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function) | resource |
 | [aws_lambda_permission.dms_restart_permission](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_permission) | resource |
 | [aws_lambda_permission.sns_to_slack_permission](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_permission) | resource |
-| [aws_msk_cluster.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/msk_cluster) | resource |
-| [aws_msk_configuration.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/msk_configuration) | resource |
 | [aws_rds_cluster.dr_aurora_secondary](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/rds_cluster) | resource |
 | [aws_rds_global_cluster.aurora](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/rds_global_cluster) | resource |
 | [aws_route53_record.subdomain](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
@@ -160,12 +158,8 @@
 | [aws_secretsmanager_secret_version.primary_database_credentials](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_version) | resource |
 | [aws_secretsmanager_secret_version.replica_database_credentials](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_version) | resource |
 | [aws_security_group.dr_aurora](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
-| [aws_security_group.kafka](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_security_group.vault_endpoint](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_security_group_rule.aurora_migration_dms_to_rds](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.kafka_egress](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.kafka_ingress_cidr_blocks](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.kafka_ingress_security_groups](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.nlb_to_envoy_http](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.nlb_to_envoy_http_shifted](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.nlb_to_envoy_https](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
@@ -241,7 +235,6 @@
 | <a name="input_aurora_min_acu"></a> [aurora\_min\_acu](#input\_aurora\_min\_acu) | Aurora Serverless v2 minimum capacity (ACUs). | `number` | `0.5` | no |
 | <a name="input_aurora_snapshot_identifier"></a> [aurora\_snapshot\_identifier](#input\_aurora\_snapshot\_identifier) | Optional RDS DB snapshot ARN to restore the Aurora cluster from (migration path). Empty = fresh cluster. | `string` | `""` | no |
 | <a name="input_aws_profile"></a> [aws\_profile](#input\_aws\_profile) | If running terraform from a workstation, which AWS CLI profile should we use for asset provisioning. | `string` | `""` | no |
-| <a name="input_azs_count"></a> [azs\_count](#input\_azs\_count) | The number of availability zones we should use for deployment. | `number` | `3` | no |
 | <a name="input_bi_access_cidrs"></a> [bi\_access\_cidrs](#input\_bi\_access\_cidrs) | If BI and public access is enabled, these CIDRs will be permitted through the firewall to access it. If VPN is enabled, these are the CIDRs that are allowed to connect to the VPN server. If left empty it will default to your VPC CIDR | `list(string)` | `[]` | no |
 | <a name="input_bi_dms_enabled"></a> [bi\_dms\_enabled](#input\_bi\_dms\_enabled) | If BI is enabled, whether or not to use DMS for conditional replication if true or a basic RDS read replica if false. | `bool` | `false` | no |
 | <a name="input_bi_public_access"></a> [bi\_public\_access](#input\_bi\_public\_access) | NOTE: This is mutually exclusive with VPN access, both cannot be enabled at the same time. If BI is enabled and you need access to the BI database server from outside the amazon network, set this to true. | `bool` | `false` | no |
@@ -261,7 +254,6 @@
 | <a name="input_eks_kms_key_id"></a> [eks\_kms\_key\_id](#input\_eks\_kms\_key\_id) | AWS KMS key identifier for EKS encryption. The identifier can be one of the following format: Key id, key ARN, alias name or alias ARN | `string` | `""` | no |
 | <a name="input_enable_bi"></a> [enable\_bi](#input\_enable\_bi) | This option will spin up a BI slave of your master database and enable conditional replication (everything but the mysql table will be replicated so you can have custom users). | `bool` | `false` | no |
 | <a name="input_enable_dr"></a> [enable\_dr](#input\_enable\_dr) | Enable the always-on cross-region DR data-protection layer (RDS automated-backup replication + S3 CRR). On by default; ephemeral/dev stacks may set false. | `bool` | `true` | no |
-| <a name="input_enable_webhooks"></a> [enable\_webhooks](#input\_enable\_webhooks) | This option will spin up a managed Kafka & Redis cluster to support private webhooks. | `bool` | `false` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | Environment of the application | `string` | `"dev"` | no |
 | <a name="input_external_fqdn"></a> [external\_fqdn](#input\_external\_fqdn) | If an external fqdn is desired for this environment it will be used for certificates instead of auto-generating one. | `string` | `""` | no |
 | <a name="input_highly_available_nat_gateway"></a> [highly\_available\_nat\_gateway](#input\_highly\_available\_nat\_gateway) | Should be true if you want to provision a highly available NAT Gateway across all of your private networks | `bool` | `true` | no |
@@ -300,7 +292,6 @@
 | <a name="output_aurora_migration_credentials_secret"></a> [aurora\_migration\_credentials\_secret](#output\_aurora\_migration\_credentials\_secret) | Secret ARN holding the Aurora migration target credentials (empty when no migration is active). Runner use only. |
 | <a name="output_aurora_migration_target_endpoint"></a> [aurora\_migration\_target\_endpoint](#output\_aurora\_migration\_target\_endpoint) | Aurora cluster writer endpoint during a migration (empty otherwise). Runner/runbook convenience; the app only ever sees it through the credentials secret after cutover. |
 | <a name="output_aurora_migration_task_arn"></a> [aurora\_migration\_task\_arn](#output\_aurora\_migration\_task\_arn) | ARN of the Aurora migration DMS task (empty when no migration is active). Consumed by the migration runner. |
-| <a name="output_azs_count"></a> [azs\_count](#output\_azs\_count) | n/a |
 | <a name="output_bastion_asg_name"></a> [bastion\_asg\_name](#output\_bastion\_asg\_name) | n/a |
 | <a name="output_bi_database_credential_secret"></a> [bi\_database\_credential\_secret](#output\_bi\_database\_credential\_secret) | If BI is enabled, this is the ARN to the AWS SecretsManager secret that contains the connection information for the BI database. |
 | <a name="output_bi_vpn_configuration_bucket"></a> [bi\_vpn\_configuration\_bucket](#output\_bi\_vpn\_configuration\_bucket) | If BI is enabled, this is the S3 bucket that stores the OpenVPN configuration files for clients to connect to the BI database from the internet. |
@@ -320,7 +311,6 @@
 | <a name="output_guide_images_bucket"></a> [guide\_images\_bucket](#output\_guide\_images\_bucket) | n/a |
 | <a name="output_guide_objects_bucket"></a> [guide\_objects\_bucket](#output\_guide\_objects\_bucket) | n/a |
 | <a name="output_guide_pdfs_bucket"></a> [guide\_pdfs\_bucket](#output\_guide\_pdfs\_bucket) | n/a |
-| <a name="output_msk_bootstrap_brokers"></a> [msk\_bootstrap\_brokers](#output\_msk\_bootstrap\_brokers) | Kafka bootstrap broker list |
 | <a name="output_nlb_dns_name"></a> [nlb\_dns\_name](#output\_nlb\_dns\_name) | The FQDN of the NLB. |
 | <a name="output_nlb_http_target_group_arn"></a> [nlb\_http\_target\_group\_arn](#output\_nlb\_http\_target\_group\_arn) | NLB HTTP target group ARN for TargetGroupBinding |
 | <a name="output_nlb_https_target_group_arn"></a> [nlb\_https\_target\_group\_arn](#output\_nlb\_https\_target\_group\_arn) | NLB HTTPS target group ARN for TargetGroupBinding |

--- a/terraform/physical/main.tf
+++ b/terraform/physical/main.tf
@@ -164,7 +164,15 @@ locals {
   s3_public_access_block_buckets = var.s3_block_public_access ? aws_s3_bucket.guide_buckets : {}
 
   # --VPC--
-  azs_count          = var.azs_count
+  # Hardcoded 3. The old azs_count variable was never set to anything else in five
+  # years, and it never actually worked as a knob: private subnet indices started AT
+  # azs_count, so changing it renumbered (replaced) every private subnet, and values
+  # above 3 silently round-robined onto the first three AZs anyway because the module
+  # azs list was sliced to 3. Three is the right number for this product (EKS quorum,
+  # Aurora spread, one NAT per AZ under HA). If per-region flexibility is ever really
+  # needed, it requires an append-only subnet layout (private at fixed low indices,
+  # public carved from the top), gated to new stacks - not a tunable variable.
+  azs_count          = 3
   create_vpc         = var.vpc_id == "" ? true : false
   vpc_id             = local.create_vpc ? module.vpc[0].vpc_id : var.vpc_id
   vpc_cidr           = local.create_vpc ? module.vpc[0].vpc_cidr_block : data.aws_vpc.this[0].cidr_block

--- a/terraform/physical/outputs.tf
+++ b/terraform/physical/outputs.tf
@@ -41,9 +41,6 @@ output "vpc_id" {
   description = "VPC ID"
   value       = local.vpc_id
 }
-output "azs_count" {
-  value = local.azs_count
-}
 output "dms_task_arn" {
   description = "DMS Replication Task ARN for BI"
   value       = try(aws_dms_replication_task.this[0].replication_task_arn, "")

--- a/terraform/physical/variables.tf
+++ b/terraform/physical/variables.tf
@@ -166,17 +166,6 @@ variable "vpc_cidr" {
   default     = "172.16.0.0/16"
 }
 
-variable "azs_count" {
-  description = "The number of availability zones we should use for deployment."
-  type        = number
-  default     = 3
-
-  validation {
-    condition     = var.azs_count >= 3 && var.azs_count <= 10
-    error_message = "AZ count must be between 3 and 10."
-  }
-}
-
 variable "highly_available_nat_gateway" {
   description = "Should be true if you want to provision a highly available NAT Gateway across all of your private networks"
   type        = bool

--- a/terraform/physical/vpc.tf
+++ b/terraform/physical/vpc.tf
@@ -35,7 +35,7 @@ module "vpc" {
 
   name = local.identifier
   cidr = var.vpc_cidr
-  azs  = slice(data.aws_availability_zones.available.names, 0, 3)
+  azs  = slice(data.aws_availability_zones.available.names, 0, local.azs_count)
 
   enable_nat_gateway   = true
   single_nat_gateway   = !var.highly_available_nat_gateway


### PR DESCRIPTION
Kills finding D from the AZ/PVC adversarial review by deleting the trap rather than fixing its math.

The knob was never turned - every stack in five years ran the default 3 - and it never worked:

- values above 3 silently round-robined subnets onto the first three AZs (`azs` was hardcoded `slice(...,0,3)` while subnet math used `azs_count`)
- above 8, the cidrsubnet index overflowed the sixteen /20s in a /16 and failed outright
- changing it on a live stack renumbered every private subnet (indices start AT `azs_count`) - a full subnet replacement

The `azs` list now derives from the same local as the subnet math so the two can never disagree. The dead `azs_count` output and passthrough go too; the logical layer declares no such variable in any current ref. infra-live's side landed in b27a90c, which also fixed the stale `msk_bootstrap_brokers` passthrough that would have failed the first stack to bump `infra_version` to 8.x.

Zero-diff on every existing stack: the default was already 3, and the rendered subnet CIDRs are identical.

If per-region AZ flexibility is ever genuinely needed, it takes an append-only subnet layout (private at fixed low indices, public carved from the top) gated to new stacks - a design decision, not a variable.