### PR TITLE
fix(logical): keep EBS-backed workloads off spot and stop stranding them

### DIFF
--- a/terraform/logical/flux.tf
+++ b/terraform/logical/flux.tf
@@ -195,11 +195,62 @@ locals {
   # cleanly. helm_release.app got the same effect from helm's deep merge of its two values files + set
   # list. Both deep-merges are unconditional (no cond?{}:{} ternary): on non-azure app_azure_values has
   # neither key, so try(...,{}) yields {} and the merged result equals base.
+  # AWS-only: pin every EBS-backed subchart workload to the on-demand NodePool.
+  #
+  # These pods (opensearch, prometheus, alertmanager, dashboards-grafana) each own a
+  # zonal EBS volume. On the spot pool, an AZ-wide spot shortage left them Pending with
+  # no legal fallback - the volume pins the zone, the on-demand pool's taint blocked
+  # entry, and that is the old spot-fleet stranding incident reproduced (adversarial
+  # AZ/PVC review, 2026-07-28; observed live: all three volumes on one spot c4.xlarge).
+  # On-demand placement plus the on-demand pool's WhenEmpty consolidation makes their
+  # disruptions rare and their replacement capacity reliably provisionable in the
+  # volume's AZ.
+  #
+  # Lives HERE and not in chart defaults on purpose: the selector/toleration reference
+  # Karpenter/EKS labels that do not exist on onprem or AKS clusters - baked into the
+  # chart they would make these pods unschedulable there. Same reason the chart's
+  # dozuki.onDemand* helpers gate on aws.enabled. The `for..if` idiom (not cond?{}:{})
+  # matches app_azure_values - see the type-unification note above it.
+  stateful_node_selector = { "karpenter.sh/capacity-type" = "on-demand" }
+  stateful_tolerations = [{
+    key      = "eks.amazonaws.com/capacity-type"
+    operator = "Equal"
+    value    = "on-demand"
+    effect   = "NoSchedule"
+  }]
+  app_stateful_scheduling = {
+    for k, v in {
+      opensearch = {
+        nodeSelector = local.stateful_node_selector
+        tolerations  = local.stateful_tolerations
+      }
+      "kube-prometheus-stack" = {
+        prometheus = { prometheusSpec = {
+          nodeSelector = local.stateful_node_selector
+          tolerations  = local.stateful_tolerations
+        } }
+        alertmanager = { alertmanagerSpec = {
+          nodeSelector = local.stateful_node_selector
+          tolerations  = local.stateful_tolerations
+        } }
+      }
+      # The customer dashboards Grafana (top-level `grafana` key; the kps ops grafana
+      # is emptyDir-only and stays on spot). Deep-merged below - base sets env and
+      # secret mounts under the same key.
+      grafana = {
+        nodeSelector = local.stateful_node_selector
+        tolerations  = local.stateful_tolerations
+      }
+    } : k => v if var.cloud == "aws"
+  }
+
   app_values = merge(
     local.app_base_values,
     { for k, v in local.app_azure_values : k => v if k != "gateway" && k != "objectStorage" },
     { gateway = merge(local.app_base_values.gateway, try(local.app_azure_values.gateway, {})) },
     { objectStorage = merge(local.app_base_values.objectStorage, try(local.app_azure_values.objectStorage, {})) },
+    { for k, v in local.app_stateful_scheduling : k => v if k != "grafana" },
+    { grafana = merge(local.app_base_values.grafana, try(local.app_stateful_scheduling.grafana, {})) },
   )
 }
 

--- a/terraform/logical/kubernetes.tf
+++ b/terraform/logical/kubernetes.tf
@@ -274,12 +274,38 @@ resource "kubernetes_manifest" "nodepool_spot" {
               {
                 key      = "karpenter.sh/capacity-type"
                 operator = "In"
-                values   = ["spot"]
+                # Spot preferred, on-demand as fallback. Karpenter's
+                # price-capacity-optimized allocation picks spot whenever any
+                # spot offering exists, so steady-state cost is unchanged - but
+                # when an AZ's spot pool empties (a real ICE event), pods on
+                # this pool get on-demand capacity there instead of pending
+                # until AWS restores spot to that zone. Matters most for a pod
+                # whose EBS volume pins it to the dry AZ: with spot-only this
+                # was an unbounded outage (the adversarial AZ/PVC review's top
+                # finding, and the same terminal state as the old spot-fleet
+                # stranding incidents).
+                values = ["spot", "on-demand"]
               },
               {
                 key      = "kubernetes.io/arch"
                 operator = "In"
                 values   = ["amd64"]
+              },
+              # Floor the hardware: without these, arch-only requirements let
+              # Karpenter buy previous-generation burstable spot - a live smoke
+              # cluster ran prometheus, alertmanager and opensearch on a
+              # c4.xlarge, with t2.medium alongside (t-class CPU credits
+              # throttle sustained load into mystery latency). Mirrors the
+              # built-in system pool's own category/generation floor.
+              {
+                key      = "eks.amazonaws.com/instance-category"
+                operator = "In"
+                values   = ["c", "m", "r"]
+              },
+              {
+                key      = "eks.amazonaws.com/instance-generation"
+                operator = "Gt"
+                values   = ["4"]
               }
             ]
           },
@@ -334,6 +360,17 @@ resource "kubernetes_manifest" "nodepool_on_demand" {
                 key      = "kubernetes.io/arch"
                 operator = "In"
                 values   = ["amd64"]
+              },
+              # Same hardware floor as the spot pool (see the comment there).
+              {
+                key      = "eks.amazonaws.com/instance-category"
+                operator = "In"
+                values   = ["c", "m", "r"]
+              },
+              {
+                key      = "eks.amazonaws.com/instance-generation"
+                operator = "Gt"
+                values   = ["4"]
               }
             ]
             taints = [
@@ -354,7 +391,14 @@ resource "kubernetes_manifest" "nodepool_on_demand" {
         )
       }
       disruption = {
-        consolidationPolicy = "WhenEmptyOrUnderutilized"
+        # WhenEmpty, not WhenEmptyOrUnderutilized: this pool exists for workloads
+        # that are expensive to move - the on-demand-pinned app tier and (via the
+        # values CPI sets on the monitoring/search subcharts) every EBS-backed
+        # singleton. Underutilization-driven bin-packing was detaching and
+        # re-attaching 50Gi volumes on routine 60-second consolidation passes,
+        # and every forced reschedule re-rolls the AZ-capacity dice. These nodes
+        # now go away only when empty, on AMI drift, or at the 336h expiry.
+        consolidationPolicy = "WhenEmpty"
         consolidateAfter    = "1m"
       }
       weight = 10


### PR DESCRIPTION
Implements the infrastructure half of the adversarial AZ/PVC review (four independent reviewers - three Claude agents + codex - plus live verification against a smoke cluster).

## The finding

The old spot-fleet stranding incident was reproducible: every EBS-backed workload (opensearch, prometheus, alertmanager, dashboards-grafana) could ONLY run on spot - the on-demand pool is tainted, and the built-in general-purpose pool is not enabled. A bound volume pins its pod to an AZ; an AZ-wide spot shortage then leaves no legal node anywhere, Pending unbounded. Live confirmation: on a fresh smoke cluster all three volumes bound into one AZ, attached to a single spot **c4.xlarge** (arch-only requirements let Karpenter buy previous-gen burstable).

## The changes

1. **Spot pool: capacity-type `["spot", "on-demand"]`.** Price-capacity-optimized allocation still picks spot whenever it exists (steady-state cost unchanged); an AZ spot drought now degrades to on-demand instead of stranding.
2. **Hardware floor on both custom pools** (category c/m/r, generation > 4 - mirrors the built-in `system` pool). No more t2/c4-class nodes; t-class CPU credits throttle sustained load.
3. **On-demand pool consolidates `WhenEmpty`.** It hosts what is expensive to move; underutilization bin-packing was detaching/re-attaching 50Gi volumes on 60-second passes, each reschedule re-rolling the AZ dice.
4. **flux.tf pins the EBS-backed subchart workloads on-demand** via their own nodeSelector/tolerations values, gated `cloud == "aws"`. Deliberately not in chart defaults - the Karpenter/EKS labels don't exist on onprem/AKS and would make those pods unschedulable there.

## Companion

Chart-side pieces (beanstalkd/memcached PDB corrections, dashboards-grafana PVC removal, opensearch values cleanup) are in helm `fix/stateful-scheduling`.

## Notes for review

- Existing nodes: the requirement changes affect new NodeClaims; running nodes churn naturally (Auto Mode drift/expiry) rather than being replaced by this apply.
- NodePool edits are `kubernetes_manifest` updates in place - no destroy/recreate of the pools.
- Deferred deliberately (from the review, not forgotten): per-AZ capacity floors and real HA for opensearch/alertmanager - sizing/cost decisions, not bug fixes.