### PR TITLE
fix(physical): dr bucket lifecycle + ssl-only policies on content buckets

### DIFF
--- a/terraform/physical/README.md
+++ b/terraform/physical/README.md
@@ -141,6 +141,8 @@
 | [aws_s3_bucket_ownership_controls.dr_guide_pdf_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_ownership_controls) | resource |
 | [aws_s3_bucket_ownership_controls.guide_pdf_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_ownership_controls) | resource |
 | [aws_s3_bucket_ownership_controls.logging_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_ownership_controls) | resource |
+| [aws_s3_bucket_policy.dr_guide_buckets](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |
+| [aws_s3_bucket_policy.guide_buckets](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |
 | [aws_s3_bucket_policy.logging_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |
 | [aws_s3_bucket_public_access_block.dr_guide_buckets](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block) | resource |
 | [aws_s3_bucket_public_access_block.guide_buckets_acl_block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block) | resource |
@@ -190,10 +192,12 @@
 | [aws_availability_zones.dr](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/availability_zones) | data source |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_iam_policy_document.cluster_access](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.dr_guide_buckets_ssl_only](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.dr_s3_replication](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.dr_s3_replication_assume](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.eks_worker](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.eks_worker_kms](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.guide_buckets_ssl_only](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.lambda_execution](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.lambda_permissions](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.logging_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |

--- a/terraform/physical/dr.tf
+++ b/terraform/physical/dr.tf
@@ -174,9 +174,14 @@ resource "aws_s3_bucket_versioning" "dr_guide_buckets" {
   }
 }
 
-# Same multipart hygiene as the primary buckets (s3.tf): failed uploads leave
-# invisible parts that bill forever. No noncurrent-version archival here though,
-# a DR restore should not wait on Deep Archive retrieval.
+# Same multipart hygiene as the primary buckets (s3.tf), plus two replica-only
+# rules. Noncurrent versions EXPIRE here (30d) instead of archiving: the
+# indefinite undo history already lives in the primary's Deep Archive tier, and
+# without a rule the replica accumulates every superseded version forever.
+# Current objects go to Intelligent-Tiering on day 0: a replica is write-only
+# until a disaster, IT keeps millisecond access with no retrieval fee (so RTO
+# is unaffected, unlike IA or the archive tiers), and objects under 128K are
+# exempt from the monitoring fee so small images cannot turn it into a loss.
 resource "aws_s3_bucket_lifecycle_configuration" "dr_guide_buckets" {
   for_each = aws_s3_bucket.dr_guide_buckets
   provider = aws.dr
@@ -191,6 +196,51 @@ resource "aws_s3_bucket_lifecycle_configuration" "dr_guide_buckets" {
 
     abort_incomplete_multipart_upload {
       days_after_initiation = 7
+    }
+
+    transition {
+      days          = 0
+      storage_class = "INTELLIGENT_TIERING"
+    }
+
+    noncurrent_version_expiration {
+      noncurrent_days = 30
+    }
+  }
+}
+
+# S3.5: reject plaintext requests. Replication and restore tooling are TLS-only,
+# so the deny has no legitimate traffic to break.
+resource "aws_s3_bucket_policy" "dr_guide_buckets" {
+  for_each = aws_s3_bucket.dr_guide_buckets
+  provider = aws.dr
+
+  bucket = each.value.id
+  policy = data.aws_iam_policy_document.dr_guide_buckets_ssl_only[each.key].json
+}
+
+data "aws_iam_policy_document" "dr_guide_buckets_ssl_only" {
+  for_each = aws_s3_bucket.dr_guide_buckets
+
+  statement {
+    sid     = "DenyInsecureTransport"
+    effect  = "Deny"
+    actions = ["s3:*"]
+
+    resources = [
+      each.value.arn,
+      "${each.value.arn}/*",
+    ]
+
+    condition {
+      test     = "Bool"
+      variable = "aws:SecureTransport"
+      values   = ["false"]
+    }
+
+    principals {
+      type        = "*"
+      identifiers = ["*"]
     }
   }
 }

--- a/terraform/physical/s3.tf
+++ b/terraform/physical/s3.tf
@@ -344,6 +344,30 @@ data "aws_iam_policy_document" "logging_policy" {
       "${aws_s3_bucket.logging_bucket.arn}/*",
     ]
   }
+
+  # S3.5: reject plaintext requests. The S3 log-delivery service and any
+  # consumers use TLS, so nothing legitimate is denied.
+  statement {
+    sid     = "DenyInsecureTransport"
+    effect  = "Deny"
+    actions = ["s3:*"]
+
+    resources = [
+      aws_s3_bucket.logging_bucket.arn,
+      "${aws_s3_bucket.logging_bucket.arn}/*",
+    ]
+
+    condition {
+      test     = "Bool"
+      variable = "aws:SecureTransport"
+      values   = ["false"]
+    }
+
+    principals {
+      type        = "*"
+      identifiers = ["*"]
+    }
+  }
 }
 
 resource "aws_s3_bucket_public_access_block" "logging_bucket_acl_block" {
@@ -547,6 +571,42 @@ resource "aws_s3_bucket_lifecycle_configuration" "guide_buckets" {
     noncurrent_version_transition {
       noncurrent_days = 30
       storage_class   = "DEEP_ARCHIVE"
+    }
+  }
+}
+
+# S3.5: reject plaintext requests on the content buckets. App, replication,
+# and presigned-URL access are all TLS, so the deny breaks nothing. The DR
+# replicas carry the same policy in dr.tf.
+resource "aws_s3_bucket_policy" "guide_buckets" {
+  for_each = aws_s3_bucket.guide_buckets
+
+  bucket = each.value.id
+  policy = data.aws_iam_policy_document.guide_buckets_ssl_only[each.key].json
+}
+
+data "aws_iam_policy_document" "guide_buckets_ssl_only" {
+  for_each = aws_s3_bucket.guide_buckets
+
+  statement {
+    sid     = "DenyInsecureTransport"
+    effect  = "Deny"
+    actions = ["s3:*"]
+
+    resources = [
+      each.value.arn,
+      "${each.value.arn}/*",
+    ]
+
+    condition {
+      test     = "Bool"
+      variable = "aws:SecureTransport"
+      values   = ["false"]
+    }
+
+    principals {
+      type        = "*"
+      identifiers = ["*"]
     }
   }
 }


### PR DESCRIPTION
Closes out three Infracost findings that surfaced on a downstream plan, all on the DR replica buckets, plus the same SSL gap found on the primary buckets while fixing it.

- DR replicas: expire noncurrent versions at 30 days. They are versioned for replication and had no rule, so every superseded version accumulated forever. The long-term undo history already lives in the primary buckets' Deep Archive transition, so a second indefinite copy in the DR region was redundant.
- DR replicas: transition current objects to Intelligent-Tiering on day 0. A replica is write-only until a restore. IT keeps millisecond access with no retrieval fee, so RTO is unaffected (unlike IA or archive tiers), and sub-128K objects are exempt from the monitoring fee.
- SecureTransport deny policies on the DR replicas, primary guide buckets, and logging bucket (merged into its existing policy document). Previously only the vpn module bucket had one. All access paths (app, replication, presigned URLs, log delivery) are TLS already.

Pure adds, no destroys. Module-level tofu validate adds no new diagnostics beyond the known aliased-provider noise; real validation happens in the terragrunt harness plan.