### PR TITLE
fix(physical): restore acl support on the pdf bucket

### DIFF
--- a/terraform/physical/README.md
+++ b/terraform/physical/README.md
@@ -15,11 +15,11 @@
 | Name | Version |
 |------|---------|
 | <a name="provider_archive"></a> [archive](#provider\_archive) | 2.8.0 |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.54.0 |
-| <a name="provider_aws.dns"></a> [aws.dns](#provider\_aws.dns) | 6.54.0 |
-| <a name="provider_aws.dr"></a> [aws.dr](#provider\_aws.dr) | 6.54.0 |
-| <a name="provider_null"></a> [null](#provider\_null) | 3.3.0 |
-| <a name="provider_random"></a> [random](#provider\_random) | 3.9.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 6.0 |
+| <a name="provider_aws.dns"></a> [aws.dns](#provider\_aws.dns) | ~> 6.0 |
+| <a name="provider_aws.dr"></a> [aws.dr](#provider\_aws.dr) | ~> 6.0 |
+| <a name="provider_null"></a> [null](#provider\_null) | ~> 3.0 |
+| <a name="provider_random"></a> [random](#provider\_random) | ~> 3.0 |
 | <a name="provider_terraform"></a> [terraform](#provider\_terraform) | n/a |
 
 ## Modules
@@ -138,6 +138,8 @@
 | [aws_s3_bucket_lifecycle_configuration.guide_buckets](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_lifecycle_configuration) | resource |
 | [aws_s3_bucket_lifecycle_configuration.logging_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_lifecycle_configuration) | resource |
 | [aws_s3_bucket_logging.guide_buckets_logging](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_logging) | resource |
+| [aws_s3_bucket_ownership_controls.dr_guide_pdf_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_ownership_controls) | resource |
+| [aws_s3_bucket_ownership_controls.guide_pdf_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_ownership_controls) | resource |
 | [aws_s3_bucket_ownership_controls.logging_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_ownership_controls) | resource |
 | [aws_s3_bucket_policy.logging_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |
 | [aws_s3_bucket_public_access_block.dr_guide_buckets](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block) | resource |

--- a/terraform/physical/dr.tf
+++ b/terraform/physical/dr.tf
@@ -209,15 +209,32 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "dr_guide_buckets"
   }
 }
 
+# Replica of the primary pdf bucket's ACL carve-out (s3.tf): replication of
+# ACL'd objects needs the destination to accept ACLs too. Same removal
+# condition as the primary.
+resource "aws_s3_bucket_ownership_controls" "dr_guide_pdf_bucket" {
+  for_each = contains(keys(aws_s3_bucket.dr_guide_buckets), "pdf") ? { pdf = aws_s3_bucket.dr_guide_buckets["pdf"] } : {}
+  provider = aws.dr
+
+  bucket = each.value.id
+
+  rule {
+    object_ownership = "ObjectWriter"
+  }
+}
+
+#tfsec:ignore:aws-s3-block-public-acls
+#tfsec:ignore:aws-s3-ignore-public-acls
+#tfsec:ignore:aws-s3-no-public-buckets
 resource "aws_s3_bucket_public_access_block" "dr_guide_buckets" {
   for_each = aws_s3_bucket.dr_guide_buckets
   provider = aws.dr
 
   bucket                  = each.value.id
-  block_public_acls       = true
+  block_public_acls       = each.key == "pdf" ? false : true
   block_public_policy     = true
-  ignore_public_acls      = true
-  restrict_public_buckets = true
+  ignore_public_acls      = each.key == "pdf" ? false : true
+  restrict_public_buckets = each.key == "pdf" ? false : true
 }
 
 data "aws_iam_policy_document" "dr_s3_replication_assume" {

--- a/terraform/physical/dr.tf
+++ b/terraform/physical/dr.tf
@@ -209,9 +209,9 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "dr_guide_buckets"
   }
 }
 
-# Replica of the primary pdf bucket's ACL carve-out (s3.tf): replication of
-# ACL'd objects needs the destination to accept ACLs too. Same removal
-# condition as the primary.
+# Replica of the primary pdf bucket's ACL carve-out (s3.tf): replicating an
+# object that carries an ACL needs the destination to accept ACLs too. Same
+# removal condition as the primary. Public access stays blocked here as well.
 resource "aws_s3_bucket_ownership_controls" "dr_guide_pdf_bucket" {
   for_each = contains(keys(aws_s3_bucket.dr_guide_buckets), "pdf") ? { pdf = aws_s3_bucket.dr_guide_buckets["pdf"] } : {}
   provider = aws.dr
@@ -223,18 +223,15 @@ resource "aws_s3_bucket_ownership_controls" "dr_guide_pdf_bucket" {
   }
 }
 
-#tfsec:ignore:aws-s3-block-public-acls
-#tfsec:ignore:aws-s3-ignore-public-acls
-#tfsec:ignore:aws-s3-no-public-buckets
 resource "aws_s3_bucket_public_access_block" "dr_guide_buckets" {
   for_each = aws_s3_bucket.dr_guide_buckets
   provider = aws.dr
 
   bucket                  = each.value.id
-  block_public_acls       = each.key == "pdf" ? false : true
+  block_public_acls       = true
   block_public_policy     = true
-  ignore_public_acls      = each.key == "pdf" ? false : true
-  restrict_public_buckets = each.key == "pdf" ? false : true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
 }
 
 data "aws_iam_policy_document" "dr_s3_replication_assume" {

--- a/terraform/physical/s3.tf
+++ b/terraform/physical/s3.tf
@@ -439,15 +439,39 @@ resource "aws_s3_bucket_logging" "guide_buckets_logging" {
   target_bucket = aws_s3_bucket.logging_bucket.bucket
   target_prefix = "${each.key}/"
 }
+# The pdf bucket is the one bucket whose objects the app manages with per-object
+# ACLs: guide PDFs flip between public-read / authenticated-read / private when
+# a guide's privacy changes, and public guides are served by their bare object
+# URL. Buckets created after S3 switched its default to BucketOwnerEnforced
+# (Apr 2023) reject every one of those calls with AccessControlListNotSupported,
+# which breaks the privacy flip (500s the guide PATCH), PDF regeneration, and
+# public-guide PDF serving. ObjectWriter restores the pre-2023 semantics the app
+# was built against. Scoped to pdf only; every other bucket stays ACL-disabled.
+# Remove when the app can run ACL-free (deployment flag + presigned-only serving).
+resource "aws_s3_bucket_ownership_controls" "guide_pdf_bucket" {
+  for_each = contains(local.create_s3_bucket_names, "pdf") ? { pdf = aws_s3_bucket.guide_buckets["pdf"] } : {}
+
+  bucket = each.value.id
+
+  rule {
+    object_ownership = "ObjectWriter"
+  }
+}
+
+# pdf carve-outs below: ACL-based public reads need BlockPublicAcls and
+# RestrictPublicBuckets off. Public bucket POLICIES stay blocked everywhere.
+#tfsec:ignore:aws-s3-block-public-acls
+#tfsec:ignore:aws-s3-ignore-public-acls
+#tfsec:ignore:aws-s3-no-public-buckets
 resource "aws_s3_bucket_public_access_block" "guide_buckets_acl_block" {
   for_each = local.s3_public_access_block_buckets
 
   bucket = each.value.id
 
-  block_public_acls       = true
+  block_public_acls       = each.key == "pdf" ? false : true
   block_public_policy     = true
-  ignore_public_acls      = true
-  restrict_public_buckets = true
+  ignore_public_acls      = each.key == "pdf" ? false : true
+  restrict_public_buckets = each.key == "pdf" ? false : true
 }
 resource "aws_s3_bucket_versioning" "guide_buckets_versioning" {
   for_each = aws_s3_bucket.guide_buckets

--- a/terraform/physical/s3.tf
+++ b/terraform/physical/s3.tf
@@ -460,6 +460,17 @@ resource "aws_s3_bucket_ownership_controls" "guide_pdf_bucket" {
     object_ownership = "ObjectWriter"
   }
 }
+
+resource "aws_s3_bucket_public_access_block" "guide_buckets_acl_block" {
+  for_each = local.s3_public_access_block_buckets
+
+  bucket = each.value.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
 resource "aws_s3_bucket_versioning" "guide_buckets_versioning" {
   for_each = aws_s3_bucket.guide_buckets
 

--- a/terraform/physical/s3.tf
+++ b/terraform/physical/s3.tf
@@ -440,14 +440,17 @@ resource "aws_s3_bucket_logging" "guide_buckets_logging" {
   target_prefix = "${each.key}/"
 }
 # The pdf bucket is the one bucket whose objects the app manages with per-object
-# ACLs: guide PDFs flip between public-read / authenticated-read / private when
-# a guide's privacy changes, and public guides are served by their bare object
-# URL. Buckets created after S3 switched its default to BucketOwnerEnforced
-# (Apr 2023) reject every one of those calls with AccessControlListNotSupported,
-# which breaks the privacy flip (500s the guide PATCH), PDF regeneration, and
-# public-guide PDF serving. ObjectWriter restores the pre-2023 semantics the app
-# was built against. Scoped to pdf only; every other bucket stays ACL-disabled.
-# Remove when the app can run ACL-free (deployment flag + presigned-only serving).
+# ACLs: GuidePDFLib sets an ACL on every upload and flips it when a guide's
+# privacy changes. Buckets created after S3 switched its default to
+# BucketOwnerEnforced (Apr 2023) reject those calls with
+# AccessControlListNotSupported, which 500s the guide privacy PATCH (after the
+# DB write, so state splits) and breaks PDF regeneration. ObjectWriter lets the
+# calls succeed again.
+#
+# Public access stays fully blocked. On a private site - which every MPC site is
+# - the app only ever sets `private`, and PDFs are served by presigned URL, so
+# no object ACL is ever load-bearing for delivery. This carve-out exists purely
+# so the ACL calls stop throwing. Remove it once the app can run ACL-free.
 resource "aws_s3_bucket_ownership_controls" "guide_pdf_bucket" {
   for_each = contains(local.create_s3_bucket_names, "pdf") ? { pdf = aws_s3_bucket.guide_buckets["pdf"] } : {}
 
@@ -456,22 +459,6 @@ resource "aws_s3_bucket_ownership_controls" "guide_pdf_bucket" {
   rule {
     object_ownership = "ObjectWriter"
   }
-}
-
-# pdf carve-outs below: ACL-based public reads need BlockPublicAcls and
-# RestrictPublicBuckets off. Public bucket POLICIES stay blocked everywhere.
-#tfsec:ignore:aws-s3-block-public-acls
-#tfsec:ignore:aws-s3-ignore-public-acls
-#tfsec:ignore:aws-s3-no-public-buckets
-resource "aws_s3_bucket_public_access_block" "guide_buckets_acl_block" {
-  for_each = local.s3_public_access_block_buckets
-
-  bucket = each.value.id
-
-  block_public_acls       = each.key == "pdf" ? false : true
-  block_public_policy     = true
-  ignore_public_acls      = each.key == "pdf" ? false : true
-  restrict_public_buckets = each.key == "pdf" ? false : true
 }
 resource "aws_s3_bucket_versioning" "guide_buckets_versioning" {
   for_each = aws_s3_bucket.guide_buckets


### PR DESCRIPTION
The guide pdf privacy model in the app is acl-based: GuidePDFLib sets an ACL on every pdf upload and flips it when a guide's privacy changes. Buckets created after S3 changed its default to BucketOwnerEnforced reject those calls with AccessControlListNotSupported. On affected stacks that 500s the guide privacy PATCH (after the DB write, so state splits) and breaks pdf regeneration. Surfaced as PHP-PROD-9VJ on a newly cut-over stack.

Fix: ObjectWriter ownership controls on the pdf bucket and its DR replica, so the acl calls succeed again. Scoped to pdf; every other bucket stays acl-disabled.

Public access stays fully blocked, unchanged from master. Every MPC site is a private site, so the app only ever sets a private ACL there and pdfs are served by presigned url - no object ACL is ever load-bearing for delivery. This carve-out exists purely so the calls stop throwing.

Already applied by hand to the affected buckets, so terraform sees matching state. Durable fix remains an app-side acl-free mode, after which this reverts.