### PR TITLE
fix(physical): aurora fence drain-proof must stop the task before asserting the checkpoint

### DIFF
--- a/terraform/physical/README.md
+++ b/terraform/physical/README.md
@@ -15,11 +15,11 @@
 | Name | Version |
 |------|---------|
 | <a name="provider_archive"></a> [archive](#provider\_archive) | 2.8.0 |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.54.0 |
-| <a name="provider_aws.dns"></a> [aws.dns](#provider\_aws.dns) | 6.54.0 |
-| <a name="provider_aws.dr"></a> [aws.dr](#provider\_aws.dr) | 6.54.0 |
-| <a name="provider_null"></a> [null](#provider\_null) | 3.3.0 |
-| <a name="provider_random"></a> [random](#provider\_random) | 3.9.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 6.0 |
+| <a name="provider_aws.dns"></a> [aws.dns](#provider\_aws.dns) | ~> 6.0 |
+| <a name="provider_aws.dr"></a> [aws.dr](#provider\_aws.dr) | ~> 6.0 |
+| <a name="provider_null"></a> [null](#provider\_null) | ~> 3.0 |
+| <a name="provider_random"></a> [random](#provider\_random) | ~> 3.0 |
 | <a name="provider_terraform"></a> [terraform](#provider\_terraform) | n/a |
 
 ## Modules

--- a/terraform/physical/monitoring.tf
+++ b/terraform/physical/monitoring.tf
@@ -384,7 +384,11 @@ module "rds_write_latency_alarm" {
 
 
 resource "aws_cloudwatch_event_rule" "dms_task_state_changed_rule" {
-  count = var.enable_bi ? 1 : 0
+  # Present whenever ANY dms task this env owns exists: the BI task OR the
+  # aurora migration task. Gating on enable_bi alone left a migration on an
+  # enable_bi=false env alertless - with the STOP_TASK apply-error policies a
+  # soak-phase stop must page, or it sits unnoticed past binlog retention.
+  count = var.enable_bi || local.aurora_migration_dms ? 1 : 0
 
   name        = "${local.identifier}-dms-task-changed-rule"
   description = "Capture change state of DMS replication tasks"
@@ -408,7 +412,7 @@ resource "aws_cloudwatch_event_rule" "dms_task_state_changed_rule" {
 }
 
 resource "aws_cloudwatch_event_target" "dms_task_state_changed_target" {
-  count = var.enable_bi ? 1 : 0
+  count = var.enable_bi || local.aurora_migration_dms ? 1 : 0
 
   rule      = aws_cloudwatch_event_rule.dms_task_state_changed_rule[0].name
   target_id = "DmsTaskChangedTarget"

--- a/terraform/physical/static/aurora_migration_settings.json
+++ b/terraform/physical/static/aurora_migration_settings.json
@@ -26,7 +26,11 @@
     "DataErrorPolicy": "STOP_TASK",
     "DataTruncationErrorPolicy": "STOP_TASK",
     "TableErrorPolicy": "STOP_TASK",
-    "DataErrorEscalationPolicy": "STOP_TASK"
+    "DataErrorEscalationPolicy": "STOP_TASK",
+    "ApplyErrorInsertPolicy": "STOP_TASK",
+    "ApplyErrorUpdatePolicy": "STOP_TASK",
+    "ApplyErrorDeletePolicy": "STOP_TASK",
+    "ApplyErrorEscalationPolicy": "STOP_TASK"
   },
   "Logging": { "EnableLogging": true },
   "ControlTablesSettings": { "ControlSchema": "awsdms_control" }

--- a/terraform/physical/util/aurora-migration-runner.sh
+++ b/terraform/physical/util/aurora-migration-runner.sh
@@ -475,7 +475,7 @@ EOF
     wait_task_status stopped 900
   done
   # Final validation epoch, AFTER the drain - a FRESH validation-only DMS task
-  # scoped to the tables the fence window touched. Why fresh: the main task's
+  # over the main task's entire mapping scope. Why fresh: the main task's
   # validation is asynchronous with no resume barrier and no epoch token, so
   # ANY observation of its state can be stale. A fresh task has no history -
   # every selected table starts unvalidated in THIS epoch, so Validated on it is
@@ -489,9 +489,10 @@ EOF
   # eviction-NULLed, performance_schema is off on the fleet, and an SSM-fetched
   # catalog silently truncates at 24k chars of stdout. The mappings clone has
   # no such channel: it travels via DMS APIs with real pagination.)
-  # Completion requires the fresh task's enumerated count to MATCH the main
-  # task's stats count (same mappings + frozen source = same set), every row
-  # in {Validated, No primary key} (no-PK rows reported - the documented
+  # Completion requires EXACT set equality with the main task's statistics
+  # identities in both directions (count alone can hide an equal-cardinality
+  # substitution from rename/DDL outside CDC), every main-set table terminal in
+  # {Validated, No primary key} (no-PK rows reported - the documented
   # users-table exception), and the marker table's row Validated: that row
   # exists only if THIS fence's write replicated, so the epoch is self-proving.
   say "gate: final validation epoch over the drained dataset (fresh validation-only task, mappings-clone scope)"
@@ -528,15 +529,20 @@ EOF
   aws dms describe-replication-tasks --region "$REGION" --filters "Name=replication-task-id,Values=$TASK_ID" \
     --query 'ReplicationTasks[0].TableMappings' --output text > "$VDIR/mappings.json"
   jq -e '.rules | length >= 1' "$VDIR/mappings.json" >/dev/null || die "could not clone the main task's TableMappings - do not trust this epoch"
-  # the authoritative table count: the main task's own statistics (stable on a
-  # stopped task; survives the stop - proven live on the gca cutover).
-  # NO --query aggregates here: JMESPath functions evaluate PER PAGE under CLI
-  # pagination (observed live: length() returned one line per 100-row page).
-  # jq -s normalizes whether the CLI emits one merged doc or one doc per page.
-  MAIN_COUNT=$(aws dms describe-table-statistics --replication-task-arn "$(task_arn)" --region "$REGION" \
-    --output json | jq -s '[.[].TableStatistics[]] | length')
-  [ "$MAIN_COUNT" -ge 1 ] 2>/dev/null || die "main task reports no table statistics - cannot anchor the epoch's expected table count"
-  say "  scope: main-task mappings clone; expected table count $MAIN_COUNT"
+  # the authoritative table SET: the main task's own statistics identities
+  # (stable on a stopped task; survives the stop - proven live on the gca
+  # cutover). The completion gate requires exact set equality with the fresh
+  # task's enumeration, not count equality - equal counts can hide an
+  # equal-cardinality substitution (e.g. a rename DDL that MySQL CDC does not
+  # replicate leaves the two enumerations different but same-sized).
+  # NO --query aggregates/projections here: JMESPath evaluates PER PAGE under
+  # CLI pagination (observed live: length() returned one line per 100-row
+  # page). jq -s normalizes one merged doc or one doc per page alike.
+  aws dms describe-table-statistics --replication-task-arn "$(task_arn)" --region "$REGION" \
+    --output json | jq -s '[.[].TableStatistics[] | {s: .SchemaName, t: .TableName}]' > "$VDIR/mainset.json"
+  MAIN_COUNT=$(jq 'length' "$VDIR/mainset.json")
+  [ "$MAIN_COUNT" -ge 1 ] 2>/dev/null || die "main task reports no table statistics - cannot anchor the epoch's expected table set"
+  say "  scope: main-task mappings clone; expected table set size $MAIN_COUNT"
   RIARN=$(aws dms describe-replication-instances --region "$REGION" --filters "Name=replication-instance-id,Values=${ID}-aurora-migration" --query 'ReplicationInstances[0].ReplicationInstanceArn' --output text)
   SEP=$(aws dms describe-endpoints --region "$REGION" --filters "Name=endpoint-id,Values=${ID}-aurora-migration-source" --query 'Endpoints[0].EndpointArn' --output text)
   TEP=$(aws dms describe-endpoints --region "$REGION" --filters "Name=endpoint-id,Values=${ID}-aurora-migration-target" --query 'Endpoints[0].EndpointArn' --output text)
@@ -557,16 +563,26 @@ EOF
     # same pagination rule: raw json + jq -s, never --query aggregates/projections
     aws dms describe-table-statistics --replication-task-arn "$VARN" --region "$REGION" \
       --output json | jq -s '[.[].TableStatistics[] | {s: .SchemaName, t: .TableName, v: .ValidationState}]' > "$VDIR/vstats.json"
-    NROWS=$(jq 'length' "$VDIR/vstats.json")
     # terminal-bad states die immediately; "no primary key" is the accepted,
     # reported exception (those tables cannot be row-validated at all)
     NBAD=$(jq '[.[] | select(.v | test("mismatch|error|suspend"; "i"))] | length' "$VDIR/vstats.json")
-    NDONE=$(jq '[.[] | select((.v | ascii_downcase) == "validated" or (.v | ascii_downcase) == "no primary key")] | length' "$VDIR/vstats.json")
+    # exact SET equality with the main task's identities, both directions:
+    # MISSING = main-set tables not yet terminal-clean in the fresh task;
+    # EXTRA = fresh-task tables outside the main set (enumeration drift - the
+    # fresh enumeration is fixed at its start, so EXTRA never resolves: die).
+    MISSING=$(jq -n --slurpfile main "$VDIR/mainset.json" --slurpfile now "$VDIR/vstats.json" '
+      ($now[0] | map(select((.v | ascii_downcase) == "validated" or (.v | ascii_downcase) == "no primary key")
+                     | {key: ([.s, .t] | tojson), value: true}) | from_entries) as $ok
+      | [ $main[0][] | select(($ok[[.s, .t] | tojson] // false) | not) ] | length')
+    EXTRA=$(jq -n --slurpfile main "$VDIR/mainset.json" --slurpfile now "$VDIR/vstats.json" '
+      ($main[0] | map({key: ([.s, .t] | tojson), value: true}) | from_entries) as $known
+      | [ $now[0][] | select(($known[[.s, .t] | tojson] // false) | not) ] | length')
     MARKER_OK=$(jq '[.[] | select(.s == "aurora_mig_ctl" and .t == "marker" and ((.v | ascii_downcase) == "validated"))] | length' "$VDIR/vstats.json")
-    say "  done=$NDONE/$NROWS enumerated (expect $MAIN_COUNT; bad states: $NBAD; marker validated: $MARKER_OK)"
+    say "  missing=$MISSING/$MAIN_COUNT extra=$EXTRA bad=$NBAD marker_validated=$MARKER_OK"
     [ "$NBAD" -gt 0 ] && die "fence-epoch validation found non-clean tables - inspect $VTASK_ID table statistics before touching anything"
-    if [ "$NROWS" = "$MAIN_COUNT" ] && [ "$NDONE" = "$NROWS" ] && [ "$MARKER_OK" = "1" ]; then break; fi
-    VWAIT=$((VWAIT+20)); [ "$VWAIT" -gt 3600 ] && die "fence-epoch validation did not complete in 60m (done=$NDONE/$NROWS, expected $MAIN_COUNT, marker=$MARKER_OK) - inspect $VTASK_ID"
+    [ "$EXTRA" -gt 0 ] && die "the fresh task enumerated tables outside the main task's set - enumeration drift (rename/DDL outside CDC?); inspect before touching anything"
+    if [ "$MISSING" = "0" ] && [ "$MARKER_OK" = "1" ]; then break; fi
+    VWAIT=$((VWAIT+20)); [ "$VWAIT" -gt 3600 ] && die "fence-epoch validation did not complete in 60m (missing=$MISSING/$MAIN_COUNT, marker=$MARKER_OK) - inspect $VTASK_ID"
     sleep 20
   done
   NOPK_LIST=$(jq -r '[.[] | select((.v | ascii_downcase) == "no primary key") | .s + "." + .t] | join(" ")' "$VDIR/vstats.json")
@@ -575,7 +591,7 @@ EOF
   vtask_teardown
   rm -rf "$VDIR"
   # main-task whole-task whitelist gate (its stats survive the stop): catches a
-  # table that went Mismatched/Suspended during soak outside the touched set.
+  # table that went Mismatched/Suspended during soak.
   U=$(unclean_validation_count)
   [ "$U" = "0" ] || die "main-task validation states are not clean (unclean=$U) - inspect before promoting"
   say "checkpoint: $(aws dms describe-replication-tasks --region "$REGION" --filters "Name=replication-task-id,Values=$TASK_ID" --query 'ReplicationTasks[0].RecoveryCheckpoint' --output text)"

--- a/terraform/physical/util/aurora-migration-runner.sh
+++ b/terraform/physical/util/aurora-migration-runner.sh
@@ -543,7 +543,12 @@ EOF
   # matched table could then satisfy a count-based gate while a real touched
   # table was still pending. Belt and braces: the completion gate below also
   # compares the exact validated (schema, table) SET, never counts.
-  VMAP=$(echo "$TOUCHED" | jq '{rules: [to_entries[] | {"rule-type":"selection","rule-id":(.key+1|tostring),"rule-name":(.key+1|tostring),"object-locator":{"schema-name":.value.SchemaName,"table-name":.value.TableName},"rule-action":"explicit"}]}')
+  # Large JSON blobs (thousands of rules/rows) travel via FILES, never argv:
+  # a full-catalog mapping can exceed ARG_MAX and would kill the fence mid-
+  # read-only window with "argument list too long".
+  VDIR=$(mktemp -d "/tmp/fence-epoch-${ID}.XXXXXX")
+  echo "$TOUCHED" > "$VDIR/want.json"
+  echo "$TOUCHED" | jq '{rules: [to_entries[] | {"rule-type":"selection","rule-id":(.key+1|tostring),"rule-name":(.key+1|tostring),"object-locator":{"schema-name":.value.SchemaName,"table-name":.value.TableName},"rule-action":"explicit"}]}' > "$VDIR/mappings.json"
   RIARN=$(aws dms describe-replication-instances --region "$REGION" --filters "Name=replication-instance-id,Values=${ID}-aurora-migration" --query 'ReplicationInstances[0].ReplicationInstanceArn' --output text)
   SEP=$(aws dms describe-endpoints --region "$REGION" --filters "Name=endpoint-id,Values=${ID}-aurora-migration-source" --query 'Endpoints[0].EndpointArn' --output text)
   TEP=$(aws dms describe-endpoints --region "$REGION" --filters "Name=endpoint-id,Values=${ID}-aurora-migration-target" --query 'Endpoints[0].EndpointArn' --output text)
@@ -553,23 +558,23 @@ EOF
     --replication-instance-arn "$RIARN" \
     --source-endpoint-arn "$SEP" --target-endpoint-arn "$TEP" \
     --migration-type full-load \
-    --table-mappings "$VMAP" \
+    --table-mappings "file://$VDIR/mappings.json" \
     --replication-task-settings '{"FullLoadSettings":{"TargetTablePrepMode":"DO_NOTHING"},"ValidationSettings":{"EnableValidation":true,"ValidationOnly":true,"ThreadCount":10,"FailureMaxCount":10000},"Logging":{"EnableLogging":true}}' \
     --query 'ReplicationTask.ReplicationTaskArn' --output text)
   vwait_status ready 600
   aws dms start-replication-task --replication-task-arn "$VARN" --start-replication-task-type start-replication --region "$REGION" >/dev/null
-  say "  validating the touched set (every touched table must reach Validated in this epoch)"
+  say "  validating the PK catalog (every table must reach Validated in this epoch)"
   VWAIT=0
   while :; do
-    VSTATS=$(aws dms describe-table-statistics --replication-task-arn "$VARN" --region "$REGION" \
-      --query 'TableStatistics[].{s:SchemaName,t:TableName,v:ValidationState}' --output json)
-    NBAD=$(echo "$VSTATS" | jq '[.[] | select(.v | test("mismatch|error|suspend|no primary"; "i"))] | length')
-    # exact SET comparison: every table in TOUCHED must appear in the fresh
+    aws dms describe-table-statistics --replication-task-arn "$VARN" --region "$REGION" \
+      --query 'TableStatistics[].{s:SchemaName,t:TableName,v:ValidationState}' --output json > "$VDIR/vstats.json"
+    NBAD=$(jq '[.[] | select(.v | test("mismatch|error|suspend|no primary"; "i"))] | length' "$VDIR/vstats.json")
+    # exact SET comparison: every table in the catalog must appear in the fresh
     # task's stats as Validated. Counts alone could be satisfied by a stray
     # extra match while a real table is still pending.
-    PENDING=$(jq -n --argjson want "$TOUCHED" --argjson now "$VSTATS" '
-      ($now | map(select((.v | ascii_downcase) == "validated") | {key: ([.s, .t] | tojson), value: true}) | from_entries) as $ok
-      | [ $want[] | select(($ok[[.SchemaName, .TableName] | tojson] // false) | not) ] | length')
+    PENDING=$(jq -n --slurpfile want "$VDIR/want.json" --slurpfile now "$VDIR/vstats.json" '
+      ($now[0] | map(select((.v | ascii_downcase) == "validated") | {key: ([.s, .t] | tojson), value: true}) | from_entries) as $ok
+      | [ $want[0][] | select(($ok[[.SchemaName, .TableName] | tojson] // false) | not) ] | length')
     say "  pending=$PENDING/$NTOUCH (bad states: $NBAD)"
     [ "$NBAD" -gt 0 ] && die "fence-epoch validation found non-clean tables - inspect $VTASK_ID table statistics before touching anything"
     [ "$PENDING" = "0" ] && break
@@ -578,6 +583,7 @@ EOF
   done
   say "  epoch validation PASSED - removing the validation task"
   vtask_teardown
+  rm -rf "$VDIR"
   # main-task whole-task whitelist gate (its stats survive the stop): catches a
   # table that went Mismatched/Suspended during soak outside the touched set.
   U=$(unclean_validation_count)

--- a/terraform/physical/util/aurora-migration-runner.sh
+++ b/terraform/physical/util/aurora-migration-runner.sh
@@ -20,6 +20,10 @@
 #                    removal while stopped + endpoint re-test, CDC resume
 #   validate       - DMS validation whitelist gate + table checksums
 #                    (CHECKSUM_TABLES="db.t1 db.t2" env var adds tables)
+#   harden         - install the STOP_TASK apply-error policies into the task's
+#                    EFFECTIVE settings (stop/modify/resume). Required once per
+#                    task provisioned before the policies landed in the JSON;
+#                    fence refuses to run without them. Safe mid-soak.
 #   fence          - marker + Terraform-owned read_only fence + negative test +
 #                    go-live gate + object install + final task stop.
 #                    Interactive: pauses for the fenced=true Spacelift apply.
@@ -77,6 +81,16 @@ unclean_validation_count() {
   aws dms describe-table-statistics --replication-task-arn "$(task_arn)" --region "$REGION" \
     --query 'TableStatistics[].ValidationState' --output text | tr '\t' '\n' | \
     awk '{ l=tolower($0) } l != "validated" && l != "no primary key" && NF { c++ } END { print c+0 }'
+}
+
+# The four CDC apply-error policies, from the task's EFFECTIVE settings (what
+# the task actually runs with - the Terraform JSON is create-time only, its
+# replication_task_settings is under ignore_changes, so an already-provisioned
+# task keeps whatever it was born with).
+effective_apply_policies() {
+  aws dms describe-replication-tasks --region "$REGION" --filters "Name=replication-task-id,Values=$TASK_ID" \
+    --query 'ReplicationTasks[0].ReplicationTaskSettings' --output text | \
+    jq -r '.ErrorBehavior | [.ApplyErrorInsertPolicy, .ApplyErrorUpdatePolicy, .ApplyErrorDeletePolicy, .ApplyErrorEscalationPolicy] | join(",")'
 }
 
 # Bounded task-state wait. Dies on the DMS failure states and on timeout - an
@@ -305,8 +319,52 @@ EOF
   say "VALIDATION GATE PASS"
   ;;
 
+harden)
+  # Roll the STOP_TASK apply-error policies into the task's EFFECTIVE settings.
+  # Terraform cannot: replication_task_settings is ignore_changes (create-time
+  # only), so tasks provisioned before the policies landed keep the permissive
+  # defaults (insert/update LOG_ERROR, delete IGNORE_RECORD) - under which a CDC
+  # apply conflict is logged and skipped, and the fence's positional drain proof
+  # would pass over a row that never landed. Modify requires a stopped task;
+  # resume-processing continues CDC from the checkpoint afterwards.
+  WANT="STOP_TASK,STOP_TASK,STOP_TASK,STOP_TASK"
+  if [ "$(effective_apply_policies)" = "$WANT" ]; then say "apply-error policies already STOP_TASK - nothing to do"; exit 0; fi
+  ST=$(task_status)
+  case "$ST" in running|stopped) :;; *) die "task is '$ST' - harden expects running or stopped";; esac
+  if [ "$ST" = "running" ]; then
+    say "stopping the task to modify settings (CDC resumes from the checkpoint after)"
+    aws dms stop-replication-task --replication-task-arn "$(task_arn)" --region "$REGION" >/dev/null
+    wait_task_status stopped 900
+  fi
+  say "merging STOP_TASK apply-error policies into the effective settings"
+  NEWSET=$(aws dms describe-replication-tasks --region "$REGION" --filters "Name=replication-task-id,Values=$TASK_ID" \
+    --query 'ReplicationTasks[0].ReplicationTaskSettings' --output text | \
+    jq '.ErrorBehavior.ApplyErrorInsertPolicy = "STOP_TASK"
+      | .ErrorBehavior.ApplyErrorUpdatePolicy = "STOP_TASK"
+      | .ErrorBehavior.ApplyErrorDeletePolicy = "STOP_TASK"
+      | .ErrorBehavior.ApplyErrorEscalationPolicy = "STOP_TASK"
+      | del(.Logging.CloudWatchLogGroup, .Logging.CloudWatchLogStream)')
+  aws dms modify-replication-task --replication-task-arn "$(task_arn)" --region "$REGION" \
+    --replication-task-settings "$NEWSET" >/dev/null
+  # modify transitions through "modifying"; wait for it to settle back
+  sleep 15; wait_task_status stopped 600
+  GOT=$(effective_apply_policies)
+  [ "$GOT" = "$WANT" ] || die "effective policies after modify are '$GOT', wanted '$WANT'"
+  if [ "$ST" = "running" ]; then
+    say "resuming CDC"
+    aws dms start-replication-task --replication-task-arn "$(task_arn)" --start-replication-task-type resume-processing --region "$REGION" >/dev/null
+    wait_task_status running 300
+  fi
+  say "HARDENED: effective apply-error policies are STOP_TASK"
+  ;;
+
 fence)
   say "PRECONDITIONS (yours): app writers scaled to zero + DDL freeze in effect"
+  # The drain proof leans on the STOP_TASK apply-error policies (a conflict must
+  # stop the task, never advance the checkpoint past a missing row). Terraform
+  # only sets them at task creation - assert the EFFECTIVE settings.
+  [ "$(effective_apply_policies)" = "STOP_TASK,STOP_TASK,STOP_TASK,STOP_TASK" ] || \
+    die "the task's effective apply-error policies are not STOP_TASK - run the 'harden' phase first"
   prep_cnfs
   # Epoch baseline for the final revalidation gate: per-table CDC apply counters
   # BEFORE anything in this fence commits (marker included). After the drain,
@@ -412,59 +470,83 @@ EOF
     aws dms stop-replication-task --replication-task-arn "$(task_arn)" --region "$REGION" >/dev/null
     wait_task_status stopped 900
   done
-  # Final validation epoch, AFTER the drain - epoch-SPECIFIC, not timed. DMS
-  # validation is asynchronous with no resume barrier, so any number of clean
-  # whole-task reads can be stale snapshots taken before the validator even
-  # identified the final-window changes. Instead: diff the per-table apply
-  # counters against the fence-start baseline to get exactly the tables the
-  # fence window touched (the aurora_mig_ctl.marker table is always in the set,
-  # so the epoch machinery is self-canarying), force revalidation of that set
-  # via reload-tables validate-only, and require each table to come back
-  # Validated WITH a changed LastUpdateTime - demonstrable this-epoch proof.
-  # Row-level validation compares actual data, not positions: the guard against
-  # a CDC apply discrepancy no error policy reports.
-  say "gate: final validation epoch over the drained dataset (epoch-specific)"
-  aws dms start-replication-task --replication-task-arn "$(task_arn)" --start-replication-task-type resume-processing --region "$REGION" >/dev/null
-  wait_task_status running 300
+  # Final validation epoch, AFTER the drain - a FRESH validation-only DMS task
+  # scoped to the tables the fence window touched. Why fresh: the main task's
+  # validation is asynchronous with no resume barrier and no epoch token
+  # (LastUpdateTime is "stats record touched", not "this validation completed"),
+  # so ANY observation of its state can be stale. A fresh task has no history -
+  # every selected table starts unvalidated in THIS epoch, so Validated on it is
+  # necessarily epoch-new, with an unambiguous completion boundary. Both sides
+  # are quiescent (source fenced, main task stopped after the drain proof), so
+  # it is a clean full row compare. The touched set comes from diffing per-table
+  # source-observed counters (Inserts+Updates+Deletes - deliberately NOT the
+  # Applied* counters: an attempted change counts as touched even if its apply
+  # failed) against the fence-start baseline. aurora_mig_ctl.marker is always in
+  # the set (its insert is part of this fence), so the machinery self-canaries.
+  # FK-cascaded child rows are not binlogged by MySQL and so not in the set;
+  # identical FK DDL on both sides (preload md5 gate) makes their outcomes
+  # equal by construction.
+  say "gate: final validation epoch over the drained dataset (fresh validation-only task)"
   STATS1="/tmp/fence-stats1-${ID}.json"
   aws dms describe-table-statistics --replication-task-arn "$(task_arn)" --region "$REGION" \
-    --query 'TableStatistics[].{s:SchemaName,t:TableName,c:sum([Inserts,Updates,Deletes]),v:ValidationState,u:LastUpdateTime}' \
+    --query 'TableStatistics[].{s:SchemaName,t:TableName,c:sum([Inserts,Updates,Deletes]),v:ValidationState}' \
     --output json > "$STATS1"
-  # touched = counters moved since fence start; exclude no-PK tables (cannot be
-  # row-validated - the whole-task whitelist gate below still covers their state)
   TOUCHED=$(jq -n --slurpfile a "$STATS0" --slurpfile b "$STATS1" '
     ($a[0] | map({key: (.s + "|" + .t), value: .c}) | from_entries) as $base
     | [ $b[0][]
         | select((($base[.s + "|" + .t] // -1) != .c) and ((.v | ascii_downcase) != "no primary key"))
-        | {SchemaName: .s, TableName: .t, before: .u} ]')
+        | {SchemaName: .s, TableName: .t} ]')
   NTOUCH=$(echo "$TOUCHED" | jq length)
   say "  tables touched in the fence window (revalidation set): $NTOUCH"
   [ "$NTOUCH" -ge 1 ] || die "revalidation set is empty - the marker table alone should be in it; the counter baseline is broken, do not trust this epoch"
-  echo "$TOUCHED" | jq -c '[.[] | {SchemaName, TableName}] as $all | range(0; ($all | length); 50) as $i | $all[$i:$i+50]' | while read -r batch; do
-    aws dms reload-tables --replication-task-arn "$(task_arn)" --region "$REGION" \
-      --tables-to-reload "$batch" --reload-option validate-only >/dev/null
-  done
-  say "  revalidation requested; waiting for every touched table to return Validated with a new LastUpdateTime"
+  VTASK_ID="${ID}-aurora-migration-fencevalidate"
+  vtask_arn() { aws dms describe-replication-tasks --region "$REGION" --filters "Name=replication-task-id,Values=$VTASK_ID" --query 'ReplicationTasks[0].ReplicationTaskArn' --output text 2>/dev/null | grep -v '^None$' || true; }
+  OLD=$(vtask_arn)
+  if [ -n "$OLD" ]; then
+    say "  deleting a leftover fence-validation task from a prior attempt"
+    ST=$(aws dms describe-replication-tasks --region "$REGION" --filters "Name=replication-task-id,Values=$VTASK_ID" --query 'ReplicationTasks[0].Status' --output text)
+    [ "$ST" = "running" ] && { aws dms stop-replication-task --replication-task-arn "$OLD" --region "$REGION" >/dev/null; while [ "$(aws dms describe-replication-tasks --region "$REGION" --filters "Name=replication-task-id,Values=$VTASK_ID" --query 'ReplicationTasks[0].Status' --output text)" != "stopped" ]; do sleep 10; done; }
+    aws dms delete-replication-task --replication-task-arn "$OLD" --region "$REGION" >/dev/null
+    while [ -n "$(vtask_arn)" ]; do sleep 10; done
+  fi
+  VMAP=$(echo "$TOUCHED" | jq '{rules: [to_entries[] | {"rule-type":"selection","rule-id":(.key+1|tostring),"rule-name":(.key+1|tostring),"object-locator":{"schema-name":.value.SchemaName,"table-name":.value.TableName},"rule-action":"include"}]}')
+  RIARN=$(aws dms describe-replication-instances --region "$REGION" --filters "Name=replication-instance-id,Values=${ID}-aurora-migration" --query 'ReplicationInstances[0].ReplicationInstanceArn' --output text)
+  SEP=$(aws dms describe-endpoints --region "$REGION" --filters "Name=endpoint-id,Values=${ID}-aurora-migration-source" --query 'Endpoints[0].EndpointArn' --output text)
+  TEP=$(aws dms describe-endpoints --region "$REGION" --filters "Name=endpoint-id,Values=${ID}-aurora-migration-target" --query 'Endpoints[0].EndpointArn' --output text)
+  say "  creating the validation-only task ($VTASK_ID)"
+  VARN=$(aws dms create-replication-task --region "$REGION" \
+    --replication-task-identifier "$VTASK_ID" \
+    --replication-instance-arn "$RIARN" \
+    --source-endpoint-arn "$SEP" --target-endpoint-arn "$TEP" \
+    --migration-type full-load \
+    --table-mappings "$VMAP" \
+    --replication-task-settings '{"FullLoadSettings":{"TargetTablePrepMode":"DO_NOTHING"},"ValidationSettings":{"EnableValidation":true,"ValidationOnly":true,"ThreadCount":5,"FailureMaxCount":10000},"Logging":{"EnableLogging":true}}' \
+    --query 'ReplicationTask.ReplicationTaskArn' --output text)
+  while [ "$(aws dms describe-replication-tasks --region "$REGION" --filters "Name=replication-task-id,Values=$VTASK_ID" --query 'ReplicationTasks[0].Status' --output text)" != "ready" ]; do sleep 10; done
+  aws dms start-replication-task --replication-task-arn "$VARN" --start-replication-task-type start-replication --region "$REGION" >/dev/null
+  say "  validating the touched set (all tables must reach Validated in this epoch)"
   VWAIT=0
   while :; do
-    aws dms describe-table-statistics --replication-task-arn "$(task_arn)" --region "$REGION" \
-      --query 'TableStatistics[].{s:SchemaName,t:TableName,v:ValidationState,u:LastUpdateTime}' \
-      --output json > "$STATS1"
-    PENDING=$(jq -n --slurpfile want <(echo "$TOUCHED") --slurpfile now "$STATS1" '
-      ($now[0] | map({key: (.s + "|" + .t), value: {v: (.v | ascii_downcase), u: .u}}) | from_entries) as $cur
-      | [ $want[0][]
-          | ($cur[.SchemaName + "|" + .TableName]) as $c
-          | select(($c == null) or ($c.v != "validated") or ($c.u == .before)) ] | length')
-    U=$(unclean_validation_count)
-    say "  revalidation pending=$PENDING unclean=$U"
-    [ "$PENDING" = "0" ] && [ "$U" = "0" ] && break
-    VWAIT=$((VWAIT+20)); [ "$VWAIT" -gt 1800 ] && die "epoch revalidation did not complete clean in 30m - inspect table statistics for the touched set"
+    VSTATES=$(aws dms describe-table-statistics --replication-task-arn "$VARN" --region "$REGION" \
+      --query 'TableStatistics[].ValidationState' --output text | tr '\t' '\n' | grep . || true)
+    NDONE=$(echo "$VSTATES" | grep -ic '^validated$' || true)
+    # terminal-bad states fail immediately; anything else (pending/validating)
+    # is in-progress and covered by the bound
+    NBAD=$(echo "$VSTATES" | grep -icE 'mismatch|error|suspend|no primary key' || true)
+    say "  validated $NDONE/$NTOUCH (bad states: $NBAD)"
+    [ "$NBAD" -gt 0 ] && die "fence-epoch validation found non-clean tables - inspect $VTASK_ID table statistics before touching anything"
+    [ "$NDONE" -eq "$NTOUCH" ] && break
+    VWAIT=$((VWAIT+20)); [ "$VWAIT" -gt 2700 ] && die "fence-epoch validation did not complete in 45m - inspect $VTASK_ID"
     sleep 20
   done
-  say "FINAL task stop (definitive)"
-  aws dms stop-replication-task --replication-task-arn "$(task_arn)" --region "$REGION" >/dev/null
-  wait_task_status stopped 900
-  checkpoint_reached "$FINAL_FILE" "$FINAL_POS" || die "checkpoint fell short of the final coordinate after the validation epoch - inspect the task"
+  say "  epoch validation PASSED - removing the validation task"
+  VST=$(aws dms describe-replication-tasks --region "$REGION" --filters "Name=replication-task-id,Values=$VTASK_ID" --query 'ReplicationTasks[0].Status' --output text)
+  [ "$VST" = "running" ] && { aws dms stop-replication-task --replication-task-arn "$VARN" --region "$REGION" >/dev/null; while [ "$(aws dms describe-replication-tasks --region "$REGION" --filters "Name=replication-task-id,Values=$VTASK_ID" --query 'ReplicationTasks[0].Status' --output text)" != "stopped" ]; do sleep 10; done; }
+  aws dms delete-replication-task --replication-task-arn "$VARN" --region "$REGION" >/dev/null
+  # main-task whole-task whitelist gate (its stats survive the stop): catches a
+  # table that went Mismatched/Suspended during soak outside the touched set.
+  U=$(unclean_validation_count)
+  [ "$U" = "0" ] || die "main-task validation states are not clean (unclean=$U) - inspect before promoting"
   say "checkpoint: $(aws dms describe-replication-tasks --region "$REGION" --filters "Name=replication-task-id,Values=$TASK_ID" --query 'ReplicationTasks[0].RecoveryCheckpoint' --output text)"
   say "installing object artifacts AFTER the final stop (DMS can never apply DML"
   say "through freshly installed triggers). Dumped FRESH from the fenced source -"

--- a/terraform/physical/util/aurora-migration-runner.sh
+++ b/terraform/physical/util/aurora-migration-runner.sh
@@ -308,6 +308,15 @@ EOF
 fence)
   say "PRECONDITIONS (yours): app writers scaled to zero + DDL freeze in effect"
   prep_cnfs
+  # Epoch baseline for the final revalidation gate: per-table CDC apply counters
+  # BEFORE anything in this fence commits (marker included). After the drain,
+  # every table whose counters moved is a table the fence window touched - the
+  # exact set the epoch-specific revalidation must re-prove.
+  STATS0="/tmp/fence-stats0-${ID}.json"
+  say "snapshotting per-table apply counters (revalidation epoch baseline)"
+  aws dms describe-table-statistics --replication-task-arn "$(task_arn)" --region "$REGION" \
+    --query 'TableStatistics[].{s:SchemaName,t:TableName,c:sum([Inserts,Updates,Deletes]),v:ValidationState,u:LastUpdateTime}' \
+    --output json > "$STATS0"
   # BI task must stop BEFORE the cutover apply mutates its source endpoint
   # (DMS rejects endpoint modification on a running task).
   if [ "$(bi_task_status)" = "running" ]; then
@@ -403,26 +412,53 @@ EOF
     aws dms stop-replication-task --replication-task-arn "$(task_arn)" --region "$REGION" >/dev/null
     wait_task_status stopped 900
   done
-  # Final validation epoch, AFTER the drain. A validation observation taken
-  # before the stop cannot cover writes DMS had not yet processed (the
-  # marker->read_only window), and validation only runs while the task runs -
-  # so resume against the fenced source (no new events can arrive), give the
-  # validator a settle window, and require consecutive clean reads over the
-  # complete drained dataset. This is the guard against a CDC apply silently
-  # dropping a row (defense in depth beside the STOP_TASK ApplyError policies):
-  # row-level validation compares actual data, not positions.
-  say "gate: final validation epoch over the drained dataset"
+  # Final validation epoch, AFTER the drain - epoch-SPECIFIC, not timed. DMS
+  # validation is asynchronous with no resume barrier, so any number of clean
+  # whole-task reads can be stale snapshots taken before the validator even
+  # identified the final-window changes. Instead: diff the per-table apply
+  # counters against the fence-start baseline to get exactly the tables the
+  # fence window touched (the aurora_mig_ctl.marker table is always in the set,
+  # so the epoch machinery is self-canarying), force revalidation of that set
+  # via reload-tables validate-only, and require each table to come back
+  # Validated WITH a changed LastUpdateTime - demonstrable this-epoch proof.
+  # Row-level validation compares actual data, not positions: the guard against
+  # a CDC apply discrepancy no error policy reports.
+  say "gate: final validation epoch over the drained dataset (epoch-specific)"
   aws dms start-replication-task --replication-task-arn "$(task_arn)" --start-replication-task-type resume-processing --region "$REGION" >/dev/null
   wait_task_status running 300
-  say "  validator settling..."
-  sleep 60
-  VCLEAN=0; VWAIT=0
+  STATS1="/tmp/fence-stats1-${ID}.json"
+  aws dms describe-table-statistics --replication-task-arn "$(task_arn)" --region "$REGION" \
+    --query 'TableStatistics[].{s:SchemaName,t:TableName,c:sum([Inserts,Updates,Deletes]),v:ValidationState,u:LastUpdateTime}' \
+    --output json > "$STATS1"
+  # touched = counters moved since fence start; exclude no-PK tables (cannot be
+  # row-validated - the whole-task whitelist gate below still covers their state)
+  TOUCHED=$(jq -n --slurpfile a "$STATS0" --slurpfile b "$STATS1" '
+    ($a[0] | map({key: (.s + "|" + .t), value: .c}) | from_entries) as $base
+    | [ $b[0][]
+        | select((($base[.s + "|" + .t] // -1) != .c) and ((.v | ascii_downcase) != "no primary key"))
+        | {SchemaName: .s, TableName: .t, before: .u} ]')
+  NTOUCH=$(echo "$TOUCHED" | jq length)
+  say "  tables touched in the fence window (revalidation set): $NTOUCH"
+  [ "$NTOUCH" -ge 1 ] || die "revalidation set is empty - the marker table alone should be in it; the counter baseline is broken, do not trust this epoch"
+  echo "$TOUCHED" | jq -c '[.[] | {SchemaName, TableName}] as $all | range(0; ($all | length); 50) as $i | $all[$i:$i+50]' | while read -r batch; do
+    aws dms reload-tables --replication-task-arn "$(task_arn)" --region "$REGION" \
+      --tables-to-reload "$batch" --reload-option validate-only >/dev/null
+  done
+  say "  revalidation requested; waiting for every touched table to return Validated with a new LastUpdateTime"
+  VWAIT=0
   while :; do
+    aws dms describe-table-statistics --replication-task-arn "$(task_arn)" --region "$REGION" \
+      --query 'TableStatistics[].{s:SchemaName,t:TableName,v:ValidationState,u:LastUpdateTime}' \
+      --output json > "$STATS1"
+    PENDING=$(jq -n --slurpfile want <(echo "$TOUCHED") --slurpfile now "$STATS1" '
+      ($now[0] | map({key: (.s + "|" + .t), value: {v: (.v | ascii_downcase), u: .u}}) | from_entries) as $cur
+      | [ $want[0][]
+          | ($cur[.SchemaName + "|" + .TableName]) as $c
+          | select(($c == null) or ($c.v != "validated") or ($c.u == .before)) ] | length')
     U=$(unclean_validation_count)
-    if [ "$U" = "0" ]; then VCLEAN=$((VCLEAN+1)); else VCLEAN=0; fi
-    say "  unclean=$U (consecutive clean $VCLEAN/3)"
-    [ "$VCLEAN" -ge 3 ] && break
-    VWAIT=$((VWAIT+20)); [ "$VWAIT" -gt 1200 ] && die "validation did not settle clean in 20m after the drain - inspect table statistics"
+    say "  revalidation pending=$PENDING unclean=$U"
+    [ "$PENDING" = "0" ] && [ "$U" = "0" ] && break
+    VWAIT=$((VWAIT+20)); [ "$VWAIT" -gt 1800 ] && die "epoch revalidation did not complete clean in 30m - inspect table statistics for the touched set"
     sleep 20
   done
   say "FINAL task stop (definitive)"

--- a/terraform/physical/util/aurora-migration-runner.sh
+++ b/terraform/physical/util/aurora-migration-runner.sh
@@ -81,8 +81,10 @@ unclean_validation_count() {
 
 # Parse "mysql-bin-changelog.NNNN / POS" style coordinates out of the task's
 # RecoveryCheckpoint ("checkpoint:V1#...#$.NNNN:POS:...") and compare with the
-# fenced source's final coordinate. DMS stopping is NOT a drain gate by itself;
-# this comparison is what proves every fenced-source event was consumed.
+# fenced source's final coordinate. Call this ONLY after the task has stopped:
+# RecoveryCheckpoint is a stopped-task safepoint that lags the live apply while
+# the task runs and flushes to the true applied commit position only on stop.
+# Stop + this comparison together are the drain proof.
 checkpoint_reached() { # $1=final_file_seq $2=final_pos
   local ck m seq pos
   ck=$(aws dms describe-replication-tasks --region "$REGION" --filters "Name=replication-task-id,Values=$TASK_ID" --query 'ReplicationTasks[0].RecoveryCheckpoint' --output text)
@@ -317,8 +319,13 @@ for sweep in 1 2 3; do
   sleep 2
 done
 LEFT=\$(\$M -e "SELECT COUNT(*) FROM information_schema.processlist WHERE id != CONNECTION_ID() AND user NOT IN ('rdsadmin') AND command != 'Binlog Dump'")
-echo "foreign_sessions_remaining=\$LEFT"
-[ "\$LEFT" = "0" ] || exit 1
+# Best-effort with a LIVE app: its connection pool reconnects between sweeps, so
+# zero is unreachable in a fence-only cutover (writers are NOT scaled to zero).
+# Correctness does not depend on it - the write cutoff is read_only=1 itself.
+# Anything a lingering session commits before the fence lands in the binlog
+# BEFORE the final coordinate (captured post-fence), so the checkpoint drain
+# proof covers it; the post-fence sweep + negative test are the hard guarantees.
+echo "foreign_sessions_remaining=\$LEFT (best-effort; fence is the cutoff)"
 mariadb --defaults-extra-file=/tmp/mig-src.cnf -e "INSERT INTO aurora_mig_ctl.marker (tag) VALUES ('$MARK');"
 echo MARKER_COMMITTED
 EOF
@@ -354,19 +361,33 @@ EOF
 mariadb --defaults-extra-file=/tmp/mig-tgt.cnf --batch --skip-column-names -e "SELECT COUNT(*) FROM aurora_mig_ctl.marker WHERE tag='$MARK'" 2>/dev/null || echo 0
 EOF
 ); N=$(echo "$N" | tr -d '[:space:]'); say "  marker_on_aurora=$N"; [ "$N" = "1" ] && break; sleep 10; done
-  say "gate: DMS checkpoint at or past the final coordinate (the actual drain proof)"
-  FINAL_FILE=$((10#$FINAL_FILE))
-  CKTRIES=0
-  while :; do
-    if checkpoint_reached "$FINAL_FILE" "$FINAL_POS"; then say "  checkpoint reached"; break; fi
-    CKTRIES=$((CKTRIES+1)); [ "$CKTRIES" -gt 60 ] && die "checkpoint did not reach the final coordinate in 15m - inspect the task (unparseable checkpoint formats also land here; RecoveryCheckpoint: $(aws dms describe-replication-tasks --region "$REGION" --filters "Name=replication-task-id,Values=$TASK_ID" --query 'ReplicationTasks[0].RecoveryCheckpoint' --output text))"
-    say "  waiting for checkpoint..."; sleep 15
-  done
-  say "gate: validation fully clean (whitelist)"
+  say "gate: validation fully clean (whitelist) - checked while the task still runs"
   while :; do U=$(unclean_validation_count); say "  unclean=$U"; [ "$U" = "0" ] && break; sleep 20; done
-  say "FINAL task stop + checkpoint record"
+  # Drain proof - STOP FIRST, then assert the checkpoint. RecoveryCheckpoint is a
+  # stopped-task safepoint: it advances to the true applied position only when the
+  # task stops, NOT while it runs. The old code asserted checkpoint >= coordinate
+  # while the task ran, which can never pass once the source's filtered-schema
+  # tail (rds_heartbeat and other mysql-schema system writes DMS excludes) rotates
+  # the binlog past the last applied real event - the checkpoint parks at the last
+  # consumable event and the app stays fenced until the 15m timeout. So: stop,
+  # read the flushed checkpoint, and if a genuine backlog left it short of the
+  # fenced source's final coordinate, resume to drain and re-stop. Bounded.
+  FINAL_FILE=$((10#$FINAL_FILE))
+  say "FINAL task stop (flushes RecoveryCheckpoint to the true applied position)"
   aws dms stop-replication-task --replication-task-arn "$(task_arn)" --region "$REGION" >/dev/null
   while [ "$(task_status)" != "stopped" ]; do sleep 10; done
+  say "gate: post-stop checkpoint at or past the final coordinate (the drain proof)"
+  CKTRIES=0
+  while :; do
+    if checkpoint_reached "$FINAL_FILE" "$FINAL_POS"; then say "  checkpoint reached (post-stop)"; break; fi
+    CKTRIES=$((CKTRIES+1)); [ "$CKTRIES" -gt 10 ] && die "post-stop checkpoint short of the final coordinate after 10 resume/stop cycles - inspect the task (RecoveryCheckpoint: $(aws dms describe-replication-tasks --region "$REGION" --filters "Name=replication-task-id,Values=$TASK_ID" --query 'ReplicationTasks[0].RecoveryCheckpoint' --output text); final=$FINAL_FILE:$FINAL_POS)"
+    say "  checkpoint short of final - resuming to drain the backlog, then re-stopping (cycle $CKTRIES)"
+    aws dms start-replication-task --replication-task-arn "$(task_arn)" --start-replication-task-type resume-processing --region "$REGION" >/dev/null
+    while [ "$(task_status)" != "running" ]; do sleep 5; done
+    sleep 45
+    aws dms stop-replication-task --replication-task-arn "$(task_arn)" --region "$REGION" >/dev/null
+    while [ "$(task_status)" != "stopped" ]; do sleep 10; done
+  done
   say "checkpoint: $(aws dms describe-replication-tasks --region "$REGION" --filters "Name=replication-task-id,Values=$TASK_ID" --query 'ReplicationTasks[0].RecoveryCheckpoint' --output text)"
   say "installing object artifacts AFTER the final stop (DMS can never apply DML"
   say "through freshly installed triggers). Dumped FRESH from the fenced source -"

--- a/terraform/physical/util/aurora-migration-runner.sh
+++ b/terraform/physical/util/aurora-migration-runner.sh
@@ -366,15 +366,19 @@ fence)
   [ "$(effective_apply_policies)" = "STOP_TASK,STOP_TASK,STOP_TASK,STOP_TASK" ] || \
     die "the task's effective apply-error policies are not STOP_TASK - run the 'harden' phase first"
   prep_cnfs
-  # Epoch baseline for the final revalidation gate: per-table CDC apply counters
-  # BEFORE anything in this fence commits (marker included). After the drain,
-  # every table whose counters moved is a table the fence window touched - the
-  # exact set the epoch-specific revalidation must re-prove.
-  STATS0="/tmp/fence-stats0-${ID}.json"
-  say "snapshotting per-table apply counters (revalidation epoch baseline)"
-  aws dms describe-table-statistics --replication-task-arn "$(task_arn)" --region "$REGION" \
-    --query 'TableStatistics[].{s:SchemaName,t:TableName,c:sum([Inserts,Updates,Deletes]),v:ValidationState,u:LastUpdateTime}' \
-    --output json > "$STATS0"
+  # Epoch anchor for the final revalidation gate: the SOURCE server's own clock,
+  # captured before anything in this fence commits (marker included). The
+  # touched set is later derived from information_schema.tables.update_time on
+  # the fenced source - engine truth, immune to DMS task-statistics counters
+  # resetting across task stop/resume cycles.
+  say "capturing the source epoch anchor (for the touched-table derivation)"
+  SRC_EPOCH=$(ssm_run <<'EOF'
+mariadb --defaults-extra-file=/tmp/mig-src.cnf --batch --skip-column-names -e "SELECT NOW(6)"
+EOF
+)
+  SRC_EPOCH=$(echo "$SRC_EPOCH" | tr -d '\r' | grep . | head -1)
+  [ -n "$SRC_EPOCH" ] || die "could not capture the source epoch anchor"
+  say "  source epoch: $SRC_EPOCH"
   # BI task must stop BEFORE the cutover apply mutates its source endpoint
   # (DMS rejects endpoint modification on a running task).
   if [ "$(bi_task_status)" = "running" ]; then
@@ -472,44 +476,80 @@ EOF
   done
   # Final validation epoch, AFTER the drain - a FRESH validation-only DMS task
   # scoped to the tables the fence window touched. Why fresh: the main task's
-  # validation is asynchronous with no resume barrier and no epoch token
-  # (LastUpdateTime is "stats record touched", not "this validation completed"),
-  # so ANY observation of its state can be stale. A fresh task has no history -
+  # validation is asynchronous with no resume barrier and no epoch token, so
+  # ANY observation of its state can be stale. A fresh task has no history -
   # every selected table starts unvalidated in THIS epoch, so Validated on it is
   # necessarily epoch-new, with an unambiguous completion boundary. Both sides
   # are quiescent (source fenced, main task stopped after the drain proof), so
-  # it is a clean full row compare. The touched set comes from diffing per-table
-  # source-observed counters (Inserts+Updates+Deletes - deliberately NOT the
-  # Applied* counters: an attempted change counts as touched even if its apply
-  # failed) against the fence-start baseline. aurora_mig_ctl.marker is always in
-  # the set (its insert is part of this fence), so the machinery self-canaries.
-  # FK-cascaded child rows are not binlogged by MySQL and so not in the set;
-  # identical FK DDL on both sides (preload md5 gate) makes their outcomes
-  # equal by construction.
+  # it is a clean full row compare. The touched set comes from the SOURCE
+  # engine's information_schema.tables.update_time against the fence-start
+  # epoch anchor - NOT from DMS table-statistics counters, which reset across
+  # task stop/resume and would silently drop a baseline-zero table from the
+  # set. Partitioned tables (update_time is NULL for them) are included
+  # unconditionally - a safe superset. Tables without a PK/UNIQUE key cannot be
+  # row-validated and are excluded (the pre-existing documented exception).
+  # aurora_mig_ctl.marker is always in the set (its insert is part of this
+  # fence and it has a PK), so the machinery self-canaries. FK-cascaded child
+  # rows are not binlogged by MySQL and so not in the set; identical FK DDL on
+  # both sides (preload md5 gate) makes their outcomes equal by construction.
   say "gate: final validation epoch over the drained dataset (fresh validation-only task)"
-  STATS1="/tmp/fence-stats1-${ID}.json"
-  aws dms describe-table-statistics --replication-task-arn "$(task_arn)" --region "$REGION" \
-    --query 'TableStatistics[].{s:SchemaName,t:TableName,c:sum([Inserts,Updates,Deletes]),v:ValidationState}' \
-    --output json > "$STATS1"
-  TOUCHED=$(jq -n --slurpfile a "$STATS0" --slurpfile b "$STATS1" '
-    ($a[0] | map({key: (.s + "|" + .t), value: .c}) | from_entries) as $base
-    | [ $b[0][]
-        | select((($base[.s + "|" + .t] // -1) != .c) and ((.v | ascii_downcase) != "no primary key"))
-        | {SchemaName: .s, TableName: .t} ]')
+  RAWTOUCH=$(ssm_run <<EOF
+mariadb --defaults-extra-file=/tmp/mig-src.cnf --batch --skip-column-names <<'SQL'
+SELECT t.table_schema, t.table_name
+FROM information_schema.tables t
+WHERE t.table_type = 'BASE TABLE'
+  AND t.table_schema NOT IN ('mysql','information_schema','performance_schema','sys','innodb','tmp')
+  AND t.table_schema NOT LIKE 'awsdms%'
+  AND (t.update_time >= DATE_SUB('$SRC_EPOCH', INTERVAL 5 SECOND)
+       OR EXISTS (SELECT 1 FROM information_schema.partitions p
+                  WHERE p.table_schema = t.table_schema AND p.table_name = t.table_name
+                    AND p.partition_name IS NOT NULL))
+  AND EXISTS (SELECT 1 FROM information_schema.table_constraints tc
+              WHERE tc.table_schema = t.table_schema AND tc.table_name = t.table_name
+                AND tc.constraint_type IN ('PRIMARY KEY','UNIQUE'))
+SQL
+EOF
+)
+  TOUCHED=$(echo "$RAWTOUCH" | tr -d '\r' | grep . | jq -Rn '[inputs | split("\t") | select(length == 2) | {SchemaName: .[0], TableName: .[1]}]')
   NTOUCH=$(echo "$TOUCHED" | jq length)
   say "  tables touched in the fence window (revalidation set): $NTOUCH"
-  [ "$NTOUCH" -ge 1 ] || die "revalidation set is empty - the marker table alone should be in it; the counter baseline is broken, do not trust this epoch"
+  echo "$TOUCHED" | jq -r '.[] | "    " + .SchemaName + "." + .TableName' | head -30
+  [ "$NTOUCH" -ge 1 ] || die "revalidation set is empty - the marker table alone should be in it; the update_time derivation is broken, do not trust this epoch"
+  echo "$TOUCHED" | jq -e '[.[] | select(.SchemaName == "aurora_mig_ctl" and .TableName == "marker")] | length == 1' >/dev/null || \
+    die "the marker table is missing from the touched set - the update_time derivation is broken, do not trust this epoch"
   VTASK_ID="${ID}-aurora-migration-fencevalidate"
   vtask_arn() { aws dms describe-replication-tasks --region "$REGION" --filters "Name=replication-task-id,Values=$VTASK_ID" --query 'ReplicationTasks[0].ReplicationTaskArn' --output text 2>/dev/null | grep -v '^None$' || true; }
-  OLD=$(vtask_arn)
-  if [ -n "$OLD" ]; then
+  vtask_status() { aws dms describe-replication-tasks --region "$REGION" --filters "Name=replication-task-id,Values=$VTASK_ID" --query 'ReplicationTasks[0].Status' --output text 2>/dev/null || echo none; }
+  vwait_status() { # $1=wanted $2=timeout seconds - bounded, dies on failure states
+    local waited=0 s
+    while :; do
+      s=$(vtask_status)
+      [ "$s" = "$1" ] && return 0
+      case "$s" in failed|stopped-after-fail|deleting) [ "$1" = "deleting" ] || die "validation task entered '$s' while waiting for '$1'";; esac
+      [ "$waited" -ge "$2" ] && die "validation task did not reach '$1' in ${2}s (status=$s)"
+      sleep 10; waited=$((waited+10))
+    done
+  }
+  vtask_teardown() { # stop if running, delete, wait gone - every wait bounded
+    local arn; arn=$(vtask_arn); [ -n "$arn" ] || return 0
+    [ "$(vtask_status)" = "running" ] && { aws dms stop-replication-task --replication-task-arn "$arn" --region "$REGION" >/dev/null; vwait_status stopped 900; }
+    aws dms delete-replication-task --replication-task-arn "$arn" --region "$REGION" >/dev/null
+    local waited=0
+    while [ -n "$(vtask_arn)" ]; do
+      [ "$waited" -ge 600 ] && die "validation task did not delete in 600s"
+      sleep 10; waited=$((waited+10))
+    done
+  }
+  if [ -n "$(vtask_arn)" ]; then
     say "  deleting a leftover fence-validation task from a prior attempt"
-    ST=$(aws dms describe-replication-tasks --region "$REGION" --filters "Name=replication-task-id,Values=$VTASK_ID" --query 'ReplicationTasks[0].Status' --output text)
-    [ "$ST" = "running" ] && { aws dms stop-replication-task --replication-task-arn "$OLD" --region "$REGION" >/dev/null; while [ "$(aws dms describe-replication-tasks --region "$REGION" --filters "Name=replication-task-id,Values=$VTASK_ID" --query 'ReplicationTasks[0].Status' --output text)" != "stopped" ]; do sleep 10; done; }
-    aws dms delete-replication-task --replication-task-arn "$OLD" --region "$REGION" >/dev/null
-    while [ -n "$(vtask_arn)" ]; do sleep 10; done
+    vtask_teardown
   fi
-  VMAP=$(echo "$TOUCHED" | jq '{rules: [to_entries[] | {"rule-type":"selection","rule-id":(.key+1|tostring),"rule-name":(.key+1|tostring),"object-locator":{"schema-name":.value.SchemaName,"table-name":.value.TableName},"rule-action":"include"}]}')
+  # rule-action "explicit" = exact-name match. "include" treats _ and % as
+  # wildcards, so e.g. server_lock would also select serverXlock - an extra
+  # matched table could then satisfy a count-based gate while a real touched
+  # table was still pending. Belt and braces: the completion gate below also
+  # compares the exact validated (schema, table) SET, never counts.
+  VMAP=$(echo "$TOUCHED" | jq '{rules: [to_entries[] | {"rule-type":"selection","rule-id":(.key+1|tostring),"rule-name":(.key+1|tostring),"object-locator":{"schema-name":.value.SchemaName,"table-name":.value.TableName},"rule-action":"explicit"}]}')
   RIARN=$(aws dms describe-replication-instances --region "$REGION" --filters "Name=replication-instance-id,Values=${ID}-aurora-migration" --query 'ReplicationInstances[0].ReplicationInstanceArn' --output text)
   SEP=$(aws dms describe-endpoints --region "$REGION" --filters "Name=endpoint-id,Values=${ID}-aurora-migration-source" --query 'Endpoints[0].EndpointArn' --output text)
   TEP=$(aws dms describe-endpoints --region "$REGION" --filters "Name=endpoint-id,Values=${ID}-aurora-migration-target" --query 'Endpoints[0].EndpointArn' --output text)
@@ -522,27 +562,28 @@ EOF
     --table-mappings "$VMAP" \
     --replication-task-settings '{"FullLoadSettings":{"TargetTablePrepMode":"DO_NOTHING"},"ValidationSettings":{"EnableValidation":true,"ValidationOnly":true,"ThreadCount":5,"FailureMaxCount":10000},"Logging":{"EnableLogging":true}}' \
     --query 'ReplicationTask.ReplicationTaskArn' --output text)
-  while [ "$(aws dms describe-replication-tasks --region "$REGION" --filters "Name=replication-task-id,Values=$VTASK_ID" --query 'ReplicationTasks[0].Status' --output text)" != "ready" ]; do sleep 10; done
+  vwait_status ready 600
   aws dms start-replication-task --replication-task-arn "$VARN" --start-replication-task-type start-replication --region "$REGION" >/dev/null
-  say "  validating the touched set (all tables must reach Validated in this epoch)"
+  say "  validating the touched set (every touched table must reach Validated in this epoch)"
   VWAIT=0
   while :; do
-    VSTATES=$(aws dms describe-table-statistics --replication-task-arn "$VARN" --region "$REGION" \
-      --query 'TableStatistics[].ValidationState' --output text | tr '\t' '\n' | grep . || true)
-    NDONE=$(echo "$VSTATES" | grep -ic '^validated$' || true)
-    # terminal-bad states fail immediately; anything else (pending/validating)
-    # is in-progress and covered by the bound
-    NBAD=$(echo "$VSTATES" | grep -icE 'mismatch|error|suspend|no primary key' || true)
-    say "  validated $NDONE/$NTOUCH (bad states: $NBAD)"
+    VSTATS=$(aws dms describe-table-statistics --replication-task-arn "$VARN" --region "$REGION" \
+      --query 'TableStatistics[].{s:SchemaName,t:TableName,v:ValidationState}' --output json)
+    NBAD=$(echo "$VSTATS" | jq '[.[] | select(.v | test("mismatch|error|suspend|no primary"; "i"))] | length')
+    # exact SET comparison: every table in TOUCHED must appear in the fresh
+    # task's stats as Validated. Counts alone could be satisfied by a stray
+    # extra match while a real table is still pending.
+    PENDING=$(jq -n --argjson want "$TOUCHED" --argjson now "$VSTATS" '
+      ($now | map(select((.v | ascii_downcase) == "validated") | {key: (.s + "|" + .t), value: true}) | from_entries) as $ok
+      | [ $want[] | select(($ok[.SchemaName + "|" + .TableName] // false) | not) ] | length')
+    say "  pending=$PENDING/$NTOUCH (bad states: $NBAD)"
     [ "$NBAD" -gt 0 ] && die "fence-epoch validation found non-clean tables - inspect $VTASK_ID table statistics before touching anything"
-    [ "$NDONE" -eq "$NTOUCH" ] && break
+    [ "$PENDING" = "0" ] && break
     VWAIT=$((VWAIT+20)); [ "$VWAIT" -gt 2700 ] && die "fence-epoch validation did not complete in 45m - inspect $VTASK_ID"
     sleep 20
   done
   say "  epoch validation PASSED - removing the validation task"
-  VST=$(aws dms describe-replication-tasks --region "$REGION" --filters "Name=replication-task-id,Values=$VTASK_ID" --query 'ReplicationTasks[0].Status' --output text)
-  [ "$VST" = "running" ] && { aws dms stop-replication-task --replication-task-arn "$VARN" --region "$REGION" >/dev/null; while [ "$(aws dms describe-replication-tasks --region "$REGION" --filters "Name=replication-task-id,Values=$VTASK_ID" --query 'ReplicationTasks[0].Status' --output text)" != "stopped" ]; do sleep 10; done; }
-  aws dms delete-replication-task --replication-task-arn "$VARN" --region "$REGION" >/dev/null
+  vtask_teardown
   # main-task whole-task whitelist gate (its stats survive the stop): catches a
   # table that went Mismatched/Suspended during soak outside the touched set.
   U=$(unclean_validation_count)

--- a/terraform/physical/util/aurora-migration-runner.sh
+++ b/terraform/physical/util/aurora-migration-runner.sh
@@ -366,19 +366,17 @@ fence)
   [ "$(effective_apply_policies)" = "STOP_TASK,STOP_TASK,STOP_TASK,STOP_TASK" ] || \
     die "the task's effective apply-error policies are not STOP_TASK - run the 'harden' phase first"
   prep_cnfs
-  # Epoch anchor for the final revalidation gate: the SOURCE server's own clock,
-  # captured before anything in this fence commits (marker included). The
-  # touched set is later derived from information_schema.tables.update_time on
-  # the fenced source - engine truth, immune to DMS task-statistics counters
-  # resetting across task stop/resume cycles.
-  say "capturing the source epoch anchor (for the touched-table derivation)"
-  SRC_EPOCH=$(ssm_run <<'EOF'
-mariadb --defaults-extra-file=/tmp/mig-src.cnf --batch --skip-column-names -e "SELECT NOW(6)"
-EOF
-)
-  SRC_EPOCH=$(echo "$SRC_EPOCH" | tr -d '\r' | grep . | head -1)
-  [ -n "$SRC_EPOCH" ] || die "could not capture the source epoch anchor"
-  say "  source epoch: $SRC_EPOCH"
+  # NOTE on the validation-epoch scope (see the epoch block after the drain
+  # proof): the fresh task validates the FULL PK-table catalog, not a derived
+  # "touched during the fence" subset. Every cheap touched-signal was tried and
+  # has a documented false-negative hole: DMS table-statistics counters reset
+  # across task lifecycle events, information_schema.tables.update_time is
+  # cached (information_schema_stats_expiry, default 24h) and silently NULLed
+  # by InnoDB dictionary-cache eviction, and performance_schema is OFF on the
+  # fleet's RDS sources (static parameter; enabling needs a reboot). A missed
+  # table in that set would be a silent data-divergence pass, so the epoch
+  # validates everything validatable instead - minutes of extra fence time on
+  # a quiescent pair, zero signal-validity risk.
   # BI task must stop BEFORE the cutover apply mutates its source endpoint
   # (DMS rejects endpoint modification on a running task).
   if [ "$(bi_task_status)" = "running" ]; then
@@ -481,42 +479,38 @@ EOF
   # every selected table starts unvalidated in THIS epoch, so Validated on it is
   # necessarily epoch-new, with an unambiguous completion boundary. Both sides
   # are quiescent (source fenced, main task stopped after the drain proof), so
-  # it is a clean full row compare. The touched set comes from the SOURCE
-  # engine's information_schema.tables.update_time against the fence-start
-  # epoch anchor - NOT from DMS table-statistics counters, which reset across
-  # task stop/resume and would silently drop a baseline-zero table from the
-  # set. Partitioned tables (update_time is NULL for them) are included
-  # unconditionally - a safe superset. Tables without a PK/UNIQUE key cannot be
-  # row-validated and are excluded (the pre-existing documented exception).
-  # aurora_mig_ctl.marker is always in the set (its insert is part of this
-  # fence and it has a PK), so the machinery self-canaries. FK-cascaded child
-  # rows are not binlogged by MySQL and so not in the set; identical FK DDL on
-  # both sides (preload md5 gate) makes their outcomes equal by construction.
-  say "gate: final validation epoch over the drained dataset (fresh validation-only task)"
-  RAWTOUCH=$(ssm_run <<EOF
+  # it is a clean full row compare. Scope = the FULL PK-table catalog (see the
+  # note at fence start: every derived touched-subset signal has a documented
+  # false-negative hole, and a missed table would be a silent divergence pass).
+  # The catalog comes from information_schema.tables + table_constraints -
+  # existence queries with no caching hazard. Tables without a PK/UNIQUE key
+  # cannot be row-validated and are excluded but REPORTED (the documented
+  # users-table exception). aurora_mig_ctl.marker is asserted present: its row
+  # exists only if THIS fence's write replicated, so its Validated verdict
+  # proves the epoch task compared current data.
+  say "gate: final validation epoch over the drained dataset (fresh validation-only task, full PK catalog)"
+  RAWCAT=$(ssm_run <<'EOF'
 mariadb --defaults-extra-file=/tmp/mig-src.cnf --batch --skip-column-names <<'SQL'
-SELECT t.table_schema, t.table_name
+SELECT t.table_schema, t.table_name,
+       EXISTS (SELECT 1 FROM information_schema.table_constraints tc
+               WHERE tc.table_schema = t.table_schema AND tc.table_name = t.table_name
+                 AND tc.constraint_type IN ('PRIMARY KEY','UNIQUE'))
 FROM information_schema.tables t
 WHERE t.table_type = 'BASE TABLE'
   AND t.table_schema NOT IN ('mysql','information_schema','performance_schema','sys','innodb','tmp')
   AND t.table_schema NOT LIKE 'awsdms%'
-  AND (t.update_time >= DATE_SUB('$SRC_EPOCH', INTERVAL 5 SECOND)
-       OR EXISTS (SELECT 1 FROM information_schema.partitions p
-                  WHERE p.table_schema = t.table_schema AND p.table_name = t.table_name
-                    AND p.partition_name IS NOT NULL))
-  AND EXISTS (SELECT 1 FROM information_schema.table_constraints tc
-              WHERE tc.table_schema = t.table_schema AND tc.table_name = t.table_name
-                AND tc.constraint_type IN ('PRIMARY KEY','UNIQUE'))
 SQL
 EOF
 )
-  TOUCHED=$(echo "$RAWTOUCH" | tr -d '\r' | grep . | jq -Rn '[inputs | split("\t") | select(length == 2) | {SchemaName: .[0], TableName: .[1]}]')
+  CATALOG=$(echo "$RAWCAT" | tr -d '\r' | grep . | jq -Rn '[inputs | split("\t") | select(length == 3) | {s: .[0], t: .[1], pk: (.[2] == "1")}]')
+  TOUCHED=$(echo "$CATALOG" | jq '[.[] | select(.pk) | {SchemaName: .s, TableName: .t}]')
+  NOPK_LIST=$(echo "$CATALOG" | jq -r '[.[] | select(.pk | not) | .s + "." + .t] | join(" ")')
+  [ -z "$NOPK_LIST" ] || say "  no-PK tables excluded from row validation (documented exception): $NOPK_LIST"
   NTOUCH=$(echo "$TOUCHED" | jq length)
-  say "  tables touched in the fence window (revalidation set): $NTOUCH"
-  echo "$TOUCHED" | jq -r '.[] | "    " + .SchemaName + "." + .TableName' | head -30
-  [ "$NTOUCH" -ge 1 ] || die "revalidation set is empty - the marker table alone should be in it; the update_time derivation is broken, do not trust this epoch"
+  say "  PK-table validation set: $NTOUCH tables"
+  [ "$NTOUCH" -ge 1 ] || die "the PK-table catalog is empty - the catalog query is broken, do not trust this epoch"
   echo "$TOUCHED" | jq -e '[.[] | select(.SchemaName == "aurora_mig_ctl" and .TableName == "marker")] | length == 1' >/dev/null || \
-    die "the marker table is missing from the touched set - the update_time derivation is broken, do not trust this epoch"
+    die "the marker table is missing from the catalog - it must exist by this point in the fence; do not trust this epoch"
   VTASK_ID="${ID}-aurora-migration-fencevalidate"
   vtask_arn() { aws dms describe-replication-tasks --region "$REGION" --filters "Name=replication-task-id,Values=$VTASK_ID" --query 'ReplicationTasks[0].ReplicationTaskArn' --output text 2>/dev/null | grep -v '^None$' || true; }
   vtask_status() { aws dms describe-replication-tasks --region "$REGION" --filters "Name=replication-task-id,Values=$VTASK_ID" --query 'ReplicationTasks[0].Status' --output text 2>/dev/null || echo none; }
@@ -560,7 +554,7 @@ EOF
     --source-endpoint-arn "$SEP" --target-endpoint-arn "$TEP" \
     --migration-type full-load \
     --table-mappings "$VMAP" \
-    --replication-task-settings '{"FullLoadSettings":{"TargetTablePrepMode":"DO_NOTHING"},"ValidationSettings":{"EnableValidation":true,"ValidationOnly":true,"ThreadCount":5,"FailureMaxCount":10000},"Logging":{"EnableLogging":true}}' \
+    --replication-task-settings '{"FullLoadSettings":{"TargetTablePrepMode":"DO_NOTHING"},"ValidationSettings":{"EnableValidation":true,"ValidationOnly":true,"ThreadCount":10,"FailureMaxCount":10000},"Logging":{"EnableLogging":true}}' \
     --query 'ReplicationTask.ReplicationTaskArn' --output text)
   vwait_status ready 600
   aws dms start-replication-task --replication-task-arn "$VARN" --start-replication-task-type start-replication --region "$REGION" >/dev/null
@@ -574,12 +568,12 @@ EOF
     # task's stats as Validated. Counts alone could be satisfied by a stray
     # extra match while a real table is still pending.
     PENDING=$(jq -n --argjson want "$TOUCHED" --argjson now "$VSTATS" '
-      ($now | map(select((.v | ascii_downcase) == "validated") | {key: (.s + "|" + .t), value: true}) | from_entries) as $ok
-      | [ $want[] | select(($ok[.SchemaName + "|" + .TableName] // false) | not) ] | length')
+      ($now | map(select((.v | ascii_downcase) == "validated") | {key: ([.s, .t] | tojson), value: true}) | from_entries) as $ok
+      | [ $want[] | select(($ok[[.SchemaName, .TableName] | tojson] // false) | not) ] | length')
     say "  pending=$PENDING/$NTOUCH (bad states: $NBAD)"
     [ "$NBAD" -gt 0 ] && die "fence-epoch validation found non-clean tables - inspect $VTASK_ID table statistics before touching anything"
     [ "$PENDING" = "0" ] && break
-    VWAIT=$((VWAIT+20)); [ "$VWAIT" -gt 2700 ] && die "fence-epoch validation did not complete in 45m - inspect $VTASK_ID"
+    VWAIT=$((VWAIT+20)); [ "$VWAIT" -gt 3600 ] && die "fence-epoch validation did not complete in 60m - inspect $VTASK_ID"
     sleep 20
   done
   say "  epoch validation PASSED - removing the validation task"

--- a/terraform/physical/util/aurora-migration-runner.sh
+++ b/terraform/physical/util/aurora-migration-runner.sh
@@ -367,16 +367,18 @@ fence)
     die "the task's effective apply-error policies are not STOP_TASK - run the 'harden' phase first"
   prep_cnfs
   # NOTE on the validation-epoch scope (see the epoch block after the drain
-  # proof): the fresh task validates the FULL PK-table catalog, not a derived
-  # "touched during the fence" subset. Every cheap touched-signal was tried and
-  # has a documented false-negative hole: DMS table-statistics counters reset
-  # across task lifecycle events, information_schema.tables.update_time is
-  # cached (information_schema_stats_expiry, default 24h) and silently NULLed
-  # by InnoDB dictionary-cache eviction, and performance_schema is OFF on the
-  # fleet's RDS sources (static parameter; enabling needs a reboot). A missed
-  # table in that set would be a silent data-divergence pass, so the epoch
-  # validates everything validatable instead - minutes of extra fence time on
-  # a quiescent pair, zero signal-validity risk.
+  # proof): the fresh task validates the main task's ENTIRE mapping scope (a
+  # clone of its TableMappings), not a derived "touched during the fence"
+  # subset. Every cheap touched-signal was tried and has a documented
+  # false-negative hole: DMS table-statistics counters reset across task
+  # lifecycle events, information_schema.tables.update_time is cached
+  # (information_schema_stats_expiry, default 24h) and silently NULLed by
+  # InnoDB dictionary-cache eviction, performance_schema is OFF on the fleet's
+  # RDS sources (static parameter; enabling needs a reboot), and any catalog
+  # fetched over SSM truncates at 24k chars of stdout. A missed table would be
+  # a silent data-divergence pass, so the epoch validates everything the
+  # migration migrated instead - minutes of extra fence time on a quiescent
+  # pair, zero signal-validity risk.
   # BI task must stop BEFORE the cutover apply mutates its source endpoint
   # (DMS rejects endpoint modification on a running task).
   if [ "$(bi_task_status)" = "running" ]; then
@@ -479,38 +481,20 @@ EOF
   # every selected table starts unvalidated in THIS epoch, so Validated on it is
   # necessarily epoch-new, with an unambiguous completion boundary. Both sides
   # are quiescent (source fenced, main task stopped after the drain proof), so
-  # it is a clean full row compare. Scope = the FULL PK-table catalog (see the
-  # note at fence start: every derived touched-subset signal has a documented
-  # false-negative hole, and a missed table would be a silent divergence pass).
-  # The catalog comes from information_schema.tables + table_constraints -
-  # existence queries with no caching hazard. Tables without a PK/UNIQUE key
-  # cannot be row-validated and are excluded but REPORTED (the documented
-  # users-table exception). aurora_mig_ctl.marker is asserted present: its row
-  # exists only if THIS fence's write replicated, so its Validated verdict
-  # proves the epoch task compared current data.
-  say "gate: final validation epoch over the drained dataset (fresh validation-only task, full PK catalog)"
-  RAWCAT=$(ssm_run <<'EOF'
-mariadb --defaults-extra-file=/tmp/mig-src.cnf --batch --skip-column-names <<'SQL'
-SELECT t.table_schema, t.table_name,
-       EXISTS (SELECT 1 FROM information_schema.table_constraints tc
-               WHERE tc.table_schema = t.table_schema AND tc.table_name = t.table_name
-                 AND tc.constraint_type IN ('PRIMARY KEY','UNIQUE'))
-FROM information_schema.tables t
-WHERE t.table_type = 'BASE TABLE'
-  AND t.table_schema NOT IN ('mysql','information_schema','performance_schema','sys','innodb','tmp')
-  AND t.table_schema NOT LIKE 'awsdms%'
-SQL
-EOF
-)
-  CATALOG=$(echo "$RAWCAT" | tr -d '\r' | grep . | jq -Rn '[inputs | split("\t") | select(length == 3) | {s: .[0], t: .[1], pk: (.[2] == "1")}]')
-  TOUCHED=$(echo "$CATALOG" | jq '[.[] | select(.pk) | {SchemaName: .s, TableName: .t}]')
-  NOPK_LIST=$(echo "$CATALOG" | jq -r '[.[] | select(.pk | not) | .s + "." + .t] | join(" ")')
-  [ -z "$NOPK_LIST" ] || say "  no-PK tables excluded from row validation (documented exception): $NOPK_LIST"
-  NTOUCH=$(echo "$TOUCHED" | jq length)
-  say "  PK-table validation set: $NTOUCH tables"
-  [ "$NTOUCH" -ge 1 ] || die "the PK-table catalog is empty - the catalog query is broken, do not trust this epoch"
-  echo "$TOUCHED" | jq -e '[.[] | select(.SchemaName == "aurora_mig_ctl" and .TableName == "marker")] | length == 1' >/dev/null || \
-    die "the marker table is missing from the catalog - it must exist by this point in the fence; do not trust this epoch"
+  # it is a clean full row compare. Scope = a CLONE of the main task's own
+  # TableMappings: the mappings that DEFINE what was migrated. Against the
+  # frozen source the fresh task enumerates exactly the migrated table set -
+  # no operator-side catalog derivation at all. (Every derived-catalog path
+  # failed adversarial review: DMS counters reset, update_time is cached and
+  # eviction-NULLed, performance_schema is off on the fleet, and an SSM-fetched
+  # catalog silently truncates at 24k chars of stdout. The mappings clone has
+  # no such channel: it travels via DMS APIs with real pagination.)
+  # Completion requires the fresh task's enumerated count to MATCH the main
+  # task's stats count (same mappings + frozen source = same set), every row
+  # in {Validated, No primary key} (no-PK rows reported - the documented
+  # users-table exception), and the marker table's row Validated: that row
+  # exists only if THIS fence's write replicated, so the epoch is self-proving.
+  say "gate: final validation epoch over the drained dataset (fresh validation-only task, mappings-clone scope)"
   VTASK_ID="${ID}-aurora-migration-fencevalidate"
   vtask_arn() { aws dms describe-replication-tasks --region "$REGION" --filters "Name=replication-task-id,Values=$VTASK_ID" --query 'ReplicationTasks[0].ReplicationTaskArn' --output text 2>/dev/null | grep -v '^None$' || true; }
   vtask_status() { aws dms describe-replication-tasks --region "$REGION" --filters "Name=replication-task-id,Values=$VTASK_ID" --query 'ReplicationTasks[0].Status' --output text 2>/dev/null || echo none; }
@@ -538,17 +522,21 @@ EOF
     say "  deleting a leftover fence-validation task from a prior attempt"
     vtask_teardown
   fi
-  # rule-action "explicit" = exact-name match. "include" treats _ and % as
-  # wildcards, so e.g. server_lock would also select serverXlock - an extra
-  # matched table could then satisfy a count-based gate while a real touched
-  # table was still pending. Belt and braces: the completion gate below also
-  # compares the exact validated (schema, table) SET, never counts.
-  # Large JSON blobs (thousands of rules/rows) travel via FILES, never argv:
-  # a full-catalog mapping can exceed ARG_MAX and would kill the fence mid-
-  # read-only window with "argument list too long".
+  # The mappings clone + all large JSON travel via FILES, never argv (a large
+  # mapping can exceed ARG_MAX and would kill the fence mid-read-only window).
   VDIR=$(mktemp -d "/tmp/fence-epoch-${ID}.XXXXXX")
-  echo "$TOUCHED" > "$VDIR/want.json"
-  echo "$TOUCHED" | jq '{rules: [to_entries[] | {"rule-type":"selection","rule-id":(.key+1|tostring),"rule-name":(.key+1|tostring),"object-locator":{"schema-name":.value.SchemaName,"table-name":.value.TableName},"rule-action":"explicit"}]}' > "$VDIR/mappings.json"
+  aws dms describe-replication-tasks --region "$REGION" --filters "Name=replication-task-id,Values=$TASK_ID" \
+    --query 'ReplicationTasks[0].TableMappings' --output text > "$VDIR/mappings.json"
+  jq -e '.rules | length >= 1' "$VDIR/mappings.json" >/dev/null || die "could not clone the main task's TableMappings - do not trust this epoch"
+  # the authoritative table count: the main task's own statistics (stable on a
+  # stopped task; survives the stop - proven live on the gca cutover).
+  # NO --query aggregates here: JMESPath functions evaluate PER PAGE under CLI
+  # pagination (observed live: length() returned one line per 100-row page).
+  # jq -s normalizes whether the CLI emits one merged doc or one doc per page.
+  MAIN_COUNT=$(aws dms describe-table-statistics --replication-task-arn "$(task_arn)" --region "$REGION" \
+    --output json | jq -s '[.[].TableStatistics[]] | length')
+  [ "$MAIN_COUNT" -ge 1 ] 2>/dev/null || die "main task reports no table statistics - cannot anchor the epoch's expected table count"
+  say "  scope: main-task mappings clone; expected table count $MAIN_COUNT"
   RIARN=$(aws dms describe-replication-instances --region "$REGION" --filters "Name=replication-instance-id,Values=${ID}-aurora-migration" --query 'ReplicationInstances[0].ReplicationInstanceArn' --output text)
   SEP=$(aws dms describe-endpoints --region "$REGION" --filters "Name=endpoint-id,Values=${ID}-aurora-migration-source" --query 'Endpoints[0].EndpointArn' --output text)
   TEP=$(aws dms describe-endpoints --region "$REGION" --filters "Name=endpoint-id,Values=${ID}-aurora-migration-target" --query 'Endpoints[0].EndpointArn' --output text)
@@ -563,24 +551,26 @@ EOF
     --query 'ReplicationTask.ReplicationTaskArn' --output text)
   vwait_status ready 600
   aws dms start-replication-task --replication-task-arn "$VARN" --start-replication-task-type start-replication --region "$REGION" >/dev/null
-  say "  validating the PK catalog (every table must reach Validated in this epoch)"
+  say "  validating (every enumerated table must reach Validated or No-primary-key in this epoch)"
   VWAIT=0
   while :; do
+    # same pagination rule: raw json + jq -s, never --query aggregates/projections
     aws dms describe-table-statistics --replication-task-arn "$VARN" --region "$REGION" \
-      --query 'TableStatistics[].{s:SchemaName,t:TableName,v:ValidationState}' --output json > "$VDIR/vstats.json"
-    NBAD=$(jq '[.[] | select(.v | test("mismatch|error|suspend|no primary"; "i"))] | length' "$VDIR/vstats.json")
-    # exact SET comparison: every table in the catalog must appear in the fresh
-    # task's stats as Validated. Counts alone could be satisfied by a stray
-    # extra match while a real table is still pending.
-    PENDING=$(jq -n --slurpfile want "$VDIR/want.json" --slurpfile now "$VDIR/vstats.json" '
-      ($now[0] | map(select((.v | ascii_downcase) == "validated") | {key: ([.s, .t] | tojson), value: true}) | from_entries) as $ok
-      | [ $want[0][] | select(($ok[[.SchemaName, .TableName] | tojson] // false) | not) ] | length')
-    say "  pending=$PENDING/$NTOUCH (bad states: $NBAD)"
+      --output json | jq -s '[.[].TableStatistics[] | {s: .SchemaName, t: .TableName, v: .ValidationState}]' > "$VDIR/vstats.json"
+    NROWS=$(jq 'length' "$VDIR/vstats.json")
+    # terminal-bad states die immediately; "no primary key" is the accepted,
+    # reported exception (those tables cannot be row-validated at all)
+    NBAD=$(jq '[.[] | select(.v | test("mismatch|error|suspend"; "i"))] | length' "$VDIR/vstats.json")
+    NDONE=$(jq '[.[] | select((.v | ascii_downcase) == "validated" or (.v | ascii_downcase) == "no primary key")] | length' "$VDIR/vstats.json")
+    MARKER_OK=$(jq '[.[] | select(.s == "aurora_mig_ctl" and .t == "marker" and ((.v | ascii_downcase) == "validated"))] | length' "$VDIR/vstats.json")
+    say "  done=$NDONE/$NROWS enumerated (expect $MAIN_COUNT; bad states: $NBAD; marker validated: $MARKER_OK)"
     [ "$NBAD" -gt 0 ] && die "fence-epoch validation found non-clean tables - inspect $VTASK_ID table statistics before touching anything"
-    [ "$PENDING" = "0" ] && break
-    VWAIT=$((VWAIT+20)); [ "$VWAIT" -gt 3600 ] && die "fence-epoch validation did not complete in 60m - inspect $VTASK_ID"
+    if [ "$NROWS" = "$MAIN_COUNT" ] && [ "$NDONE" = "$NROWS" ] && [ "$MARKER_OK" = "1" ]; then break; fi
+    VWAIT=$((VWAIT+20)); [ "$VWAIT" -gt 3600 ] && die "fence-epoch validation did not complete in 60m (done=$NDONE/$NROWS, expected $MAIN_COUNT, marker=$MARKER_OK) - inspect $VTASK_ID"
     sleep 20
   done
+  NOPK_LIST=$(jq -r '[.[] | select((.v | ascii_downcase) == "no primary key") | .s + "." + .t] | join(" ")' "$VDIR/vstats.json")
+  [ -z "$NOPK_LIST" ] || say "  no-PK tables outside row validation (documented exception): $NOPK_LIST"
   say "  epoch validation PASSED - removing the validation task"
   vtask_teardown
   rm -rf "$VDIR"

--- a/terraform/physical/util/aurora-migration-runner.sh
+++ b/terraform/physical/util/aurora-migration-runner.sh
@@ -79,6 +79,21 @@ unclean_validation_count() {
     awk '{ l=tolower($0) } l != "validated" && l != "no primary key" && NF { c++ } END { print c+0 }'
 }
 
+# Bounded task-state wait. Dies on the DMS failure states and on timeout - an
+# unbounded poll here would hang the fence (source read-only, customers waiting)
+# on a task that will never reach the wanted state.
+wait_task_status() { # $1=wanted status $2=timeout seconds
+  local waited=0 s
+  while :; do
+    s=$(task_status)
+    [ "$s" = "$1" ] && return 0
+    case "$s" in failed|stopped-after-fail|deleting) die "task entered '$s' while waiting for '$1'";; esac
+    # "none" (describe hiccup) is NOT fatal here - the timeout bounds it.
+    [ "$waited" -ge "$2" ] && die "task did not reach '$1' in ${2}s (status=$s)"
+    sleep 10; waited=$((waited+10))
+  done
+}
+
 # Parse "mysql-bin-changelog.NNNN / POS" style coordinates out of the task's
 # RecoveryCheckpoint ("checkpoint:V1#...#$.NNNN:POS:...") and compare with the
 # fenced source's final coordinate. Call this ONLY after the task has stopped:
@@ -361,8 +376,6 @@ EOF
 mariadb --defaults-extra-file=/tmp/mig-tgt.cnf --batch --skip-column-names -e "SELECT COUNT(*) FROM aurora_mig_ctl.marker WHERE tag='$MARK'" 2>/dev/null || echo 0
 EOF
 ); N=$(echo "$N" | tr -d '[:space:]'); say "  marker_on_aurora=$N"; [ "$N" = "1" ] && break; sleep 10; done
-  say "gate: validation fully clean (whitelist) - checked while the task still runs"
-  while :; do U=$(unclean_validation_count); say "  unclean=$U"; [ "$U" = "0" ] && break; sleep 20; done
   # Drain proof - STOP FIRST, then assert the checkpoint. RecoveryCheckpoint is a
   # stopped-task safepoint: it advances to the true applied position only when the
   # task stops, NOT while it runs. The old code asserted checkpoint >= coordinate
@@ -371,11 +384,13 @@ EOF
   # the binlog past the last applied real event - the checkpoint parks at the last
   # consumable event and the app stays fenced until the 15m timeout. So: stop,
   # read the flushed checkpoint, and if a genuine backlog left it short of the
-  # fenced source's final coordinate, resume to drain and re-stop. Bounded.
+  # fenced source's final coordinate, resume to drain and re-stop. Bounded, and
+  # every state transition is a bounded wait (a fenced source must never hang on
+  # a task that silently failed).
   FINAL_FILE=$((10#$FINAL_FILE))
-  say "FINAL task stop (flushes RecoveryCheckpoint to the true applied position)"
+  say "task stop (flushes RecoveryCheckpoint to the true applied position)"
   aws dms stop-replication-task --replication-task-arn "$(task_arn)" --region "$REGION" >/dev/null
-  while [ "$(task_status)" != "stopped" ]; do sleep 10; done
+  wait_task_status stopped 900
   say "gate: post-stop checkpoint at or past the final coordinate (the drain proof)"
   CKTRIES=0
   while :; do
@@ -383,11 +398,37 @@ EOF
     CKTRIES=$((CKTRIES+1)); [ "$CKTRIES" -gt 10 ] && die "post-stop checkpoint short of the final coordinate after 10 resume/stop cycles - inspect the task (RecoveryCheckpoint: $(aws dms describe-replication-tasks --region "$REGION" --filters "Name=replication-task-id,Values=$TASK_ID" --query 'ReplicationTasks[0].RecoveryCheckpoint' --output text); final=$FINAL_FILE:$FINAL_POS)"
     say "  checkpoint short of final - resuming to drain the backlog, then re-stopping (cycle $CKTRIES)"
     aws dms start-replication-task --replication-task-arn "$(task_arn)" --start-replication-task-type resume-processing --region "$REGION" >/dev/null
-    while [ "$(task_status)" != "running" ]; do sleep 5; done
+    wait_task_status running 300
     sleep 45
     aws dms stop-replication-task --replication-task-arn "$(task_arn)" --region "$REGION" >/dev/null
-    while [ "$(task_status)" != "stopped" ]; do sleep 10; done
+    wait_task_status stopped 900
   done
+  # Final validation epoch, AFTER the drain. A validation observation taken
+  # before the stop cannot cover writes DMS had not yet processed (the
+  # marker->read_only window), and validation only runs while the task runs -
+  # so resume against the fenced source (no new events can arrive), give the
+  # validator a settle window, and require consecutive clean reads over the
+  # complete drained dataset. This is the guard against a CDC apply silently
+  # dropping a row (defense in depth beside the STOP_TASK ApplyError policies):
+  # row-level validation compares actual data, not positions.
+  say "gate: final validation epoch over the drained dataset"
+  aws dms start-replication-task --replication-task-arn "$(task_arn)" --start-replication-task-type resume-processing --region "$REGION" >/dev/null
+  wait_task_status running 300
+  say "  validator settling..."
+  sleep 60
+  VCLEAN=0; VWAIT=0
+  while :; do
+    U=$(unclean_validation_count)
+    if [ "$U" = "0" ]; then VCLEAN=$((VCLEAN+1)); else VCLEAN=0; fi
+    say "  unclean=$U (consecutive clean $VCLEAN/3)"
+    [ "$VCLEAN" -ge 3 ] && break
+    VWAIT=$((VWAIT+20)); [ "$VWAIT" -gt 1200 ] && die "validation did not settle clean in 20m after the drain - inspect table statistics"
+    sleep 20
+  done
+  say "FINAL task stop (definitive)"
+  aws dms stop-replication-task --replication-task-arn "$(task_arn)" --region "$REGION" >/dev/null
+  wait_task_status stopped 900
+  checkpoint_reached "$FINAL_FILE" "$FINAL_POS" || die "checkpoint fell short of the final coordinate after the validation epoch - inspect the task"
   say "checkpoint: $(aws dms describe-replication-tasks --region "$REGION" --filters "Name=replication-task-id,Values=$TASK_ID" --query 'ReplicationTasks[0].RecoveryCheckpoint' --output text)"
   say "installing object artifacts AFTER the final stop (DMS can never apply DML"
   say "through freshly installed triggers). Dumped FRESH from the fenced source -"


### PR DESCRIPTION
The fence phase asserted `checkpoint >= final coordinate` while the DMS task was still running, then stopped it. But `RecoveryCheckpoint` is a stopped-task safepoint - it only flushes to the true applied commit position on stop. On the live gca cutover the excluded mysql-schema tail (rds_heartbeat) rotated the binlog past the last applied real event, the running checkpoint parked there, and the gate FATALed at its 15m timeout with the source fenced - the data was already fully drained. Proven by hand: stop -> checkpoint flushed to 584423, past the final coordinate 584419:153 -> clean promotion.

Nine adversarial review rounds against this fix surfaced and closed a chain of deeper defects:

**Drain proof**: reordered to validate -> STOP -> assert the post-stop checkpoint, with a bounded resume/re-stop loop for a genuine backlog. All task-state transitions go through bounded waits that die on failure states (a fenced source must never hang on a dead task).

**Effective settings**: `replication_task_settings` is under `ignore_changes`, so the new fail-closed `ApplyError*Policy = STOP_TASK` settings never reach already-provisioned tasks (verified live: the gca task ran the permissive defaults; its logs show zero apply conflicts occurred). New `harden` phase rolls the policies into the task's effective settings (stop/merge/modify/verify/resume) and the fence refuses to start without them. The DMS state-change alert rule is now present whenever the migration rig exists, not only with `enable_bi` (a soak-phase STOP_TASK must page).

**Epoch validation**: after the drain proof, a FRESH validation-only DMS task (full-load + ValidationOnly + DO_NOTHING) re-proves row equality - a fresh task has no history, so `Validated` on it is necessarily this epoch's verdict, with both sides quiescent. Scope is a clone of the main task's own `TableMappings`, and completion requires exact bidirectional `{schema, table}` set equality with the main task's statistics identities, every table `Validated`/`No primary key` (no-PK reported - the known `users` exception), and the fence marker row `Validated` (it exists only if this fence's write replicated).

Rejected along the way, each with a demonstrated false-negative or false-pass hole: running-task checkpoint polling, timed clean-read validation, `reload-tables` + `LastUpdateTime` epochs, DMS counter diffs (reset across lifecycle), `update_time` derivation (stats-cache TTL + dictionary-eviction NULLing), `performance_schema` counters (off on the fleet's RDS sources), SSM-fetched catalogs (24k stdout truncation), count-only completion (equal-cardinality substitution), CLI `--query` aggregates (evaluate per page under pagination), argv-passed mappings (ARG_MAX).

Scope: the operator runner, the task-settings JSON (create-time; live tasks get `harden`), and the monitoring rule gate. gca is already cut over; this unblocks the apac/latam fences.