### PR TITLE
fix(physical): give the DR secondary a Serverless v2 scaling config

### DIFF
--- a/terraform/physical/dr_aurora.tf
+++ b/terraform/physical/dr_aurora.tf
@@ -124,6 +124,18 @@ resource "aws_rds_cluster" "dr_aurora_secondary" {
   db_subnet_group_name   = aws_db_subnet_group.dr_aurora[0].name
   vpc_security_group_ids = [aws_security_group.dr_aurora[0].id]
 
+  # Serverless v2 scaling config, mirroring the primary. Costs nothing while headless
+  # (the config bills nothing without instances) but is REQUIRED for a failover to
+  # create db.serverless instances - without it, CreateDBInstance with
+  # db.serverless fails and the runbook's own step 1 errors at the worst possible
+  # moment. Found by the harness's promotion drill, which had to fall back to a
+  # provisioned class because this was missing. With it, failover compute matches
+  # the fleet's serverless posture.
+  serverlessv2_scaling_configuration {
+    min_capacity = var.aurora_min_acu
+    max_capacity = var.aurora_max_acu
+  }
+
   # master_username / master_password / database_name are inherited from the global
   # primary and must NOT be set on a secondary.
   skip_final_snapshot = !var.protect_resources


### PR DESCRIPTION
Fallout from the DR promotion drill. The headless secondary in `dr_aurora.tf` had no `serverlessv2_scaling_configuration`, so a failover cannot create `db.serverless` instances on it - `CreateDBInstance` fails when the cluster lacks the config. The failover runbook's own first step ("create a db.serverless instance") would error during the exact emergency it exists for; the drill had to use a provisioned `db.r6g.large` to work around it.

Mirrors the primary's scaling block (`aurora_min_acu`/`aurora_max_acu`). Free while headless - the config bills nothing without instances - and an in-place modify on existing DR clusters, no replacement.

Companion (already on master): the drill now picks its instance class by inspecting the promoted cluster - `db.serverless` when the scaling config is present, provisioned fallback for refs predating this fix - so once this releases, every full-config run exercises the same serverless failover path the runbook prescribes.