### PR TITLE
fix(physical): replicate the DB credentials secret to the DR region

### DIFF
--- a/terraform/physical/README.md
+++ b/terraform/physical/README.md
@@ -15,11 +15,11 @@
 | Name | Version |
 | ---- | ------- |
 | <a name="provider_archive"></a> [archive](#provider\_archive) | 2.8.0 |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 6.0 |
-| <a name="provider_aws.dns"></a> [aws.dns](#provider\_aws.dns) | ~> 6.0 |
-| <a name="provider_aws.dr"></a> [aws.dr](#provider\_aws.dr) | ~> 6.0 |
-| <a name="provider_null"></a> [null](#provider\_null) | ~> 3.0 |
-| <a name="provider_random"></a> [random](#provider\_random) | ~> 3.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.54.0 |
+| <a name="provider_aws.dns"></a> [aws.dns](#provider\_aws.dns) | 6.54.0 |
+| <a name="provider_aws.dr"></a> [aws.dr](#provider\_aws.dr) | 6.54.0 |
+| <a name="provider_null"></a> [null](#provider\_null) | 3.3.0 |
+| <a name="provider_random"></a> [random](#provider\_random) | 3.9.0 |
 | <a name="provider_terraform"></a> [terraform](#provider\_terraform) | n/a |
 
 ## Modules

--- a/terraform/physical/rds.tf
+++ b/terraform/physical/rds.tf
@@ -222,6 +222,18 @@ resource "aws_secretsmanager_secret" "primary_database_credentials" {
 
   recovery_window_in_days = var.protect_resources ? 7 : 0
 
+  # When the Aurora DR secondary exists, replicate the credentials to the DR region.
+  # A failover has to read this secret while the primary region is unreachable; the
+  # replica ARN is the primary's with the region swapped, which is what the failover
+  # tooling constructs. DB users travel with the cluster storage, so the replicated
+  # credentials are valid on the promoted secondary as-is.
+  dynamic "replica" {
+    for_each = local.aurora_dr_enabled ? [var.dr_region] : []
+    content {
+      region = replica.value
+    }
+  }
+
   lifecycle {
     ignore_changes = [
       name,


### PR DESCRIPTION
The in-VPC DR probe (and any real failover) needs the DB credentials from the surviving region, but the secret lived only in the primary region, which is exactly what is unreachable in the incident it serves. Adds a Secrets Manager replica in var.dr_region, gated on the same aurora_dr_enabled condition as the DR secondary.

DB users travel with cluster storage, so the replicated credentials are valid on the promoted secondary unchanged. The replica ARN is the primary ARN with the region swapped; no new output needed. In-place update on existing DR-enabled stacks, no-op elsewhere.