### PR TITLE
fix(physical): derive the secret replica region from the aws.dr provider

### DIFF
--- a/terraform/physical/README.md
+++ b/terraform/physical/README.md
@@ -58,6 +58,7 @@
 | ---- | ---- |
 | [aws_cloudwatch_event_rule.dms_task_state_changed_rule](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_rule) | resource |
 | [aws_cloudwatch_event_target.dms_task_state_changed_target](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_target) | resource |
+| [aws_cloudwatch_log_group.dr_aurora](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
 | [aws_cloudwatch_metric_alarm.aurora_acu](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
 | [aws_cloudwatch_metric_alarm.aurora_connections](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
 | [aws_cloudwatch_metric_alarm.aurora_cpu](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
@@ -216,6 +217,7 @@
 | [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
 | [aws_rds_orderable_db_instance.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/rds_orderable_db_instance) | data source |
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
+| [aws_region.dr](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 | [aws_route53_zone.subdomain](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/route53_zone) | data source |
 | [aws_s3_bucket.guide_buckets](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/s3_bucket) | data source |
 | [aws_subnets.private](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnets) | data source |

--- a/terraform/physical/dr_aurora.tf
+++ b/terraform/physical/dr_aurora.tf
@@ -17,6 +17,18 @@ locals {
   aurora_dr_enabled      = local.db_is_aurora && var.enable_dr && local.aurora_dr_partition_ok
 }
 
+# The authoritative DR region: the aws.dr provider's own region. var.dr_region is NOT a
+# reliable source - the harness (and any stack whose env.hcl omits it) leaves it "",
+# because live/root.hcl only feeds TG_AWS_DR_REGION into the generated provider, never
+# into inputs. Everything cosmetic may fall back to var.dr_region; anything that USES
+# the value as a region (the secret replica) must read this instead. Found by the first
+# SCENARIO=recover run: CreateSecret failed with "Invalid replica region" on replica
+# region "".
+data "aws_region" "dr" {
+  count    = local.aurora_dr_enabled ? 1 : 0
+  provider = aws.dr
+}
+
 # DR-region AZs (aws.dr is the Terragrunt-generated DR provider).
 data "aws_availability_zones" "dr" {
   count    = local.aurora_dr_enabled ? 1 : 0

--- a/terraform/physical/rds.tf
+++ b/terraform/physical/rds.tf
@@ -227,8 +227,12 @@ resource "aws_secretsmanager_secret" "primary_database_credentials" {
   # replica ARN is the primary's with the region swapped, which is what the failover
   # tooling constructs. DB users travel with the cluster storage, so the replicated
   # credentials are valid on the promoted secondary as-is.
+  #
+  # The region comes from the aws.dr PROVIDER (data.aws_region.dr), never var.dr_region:
+  # that variable is "" wherever env.hcl doesn't set it (the harness, notably), and an
+  # empty replica region fails CreateSecret with "Invalid replica region".
   dynamic "replica" {
-    for_each = local.aurora_dr_enabled ? [var.dr_region] : []
+    for_each = local.aurora_dr_enabled ? [data.aws_region.dr[0].region] : []
     content {
       region = replica.value
     }


### PR DESCRIPTION
Follow-up to #355, found by the first SCENARIO=recover harness run: `var.dr_region` is "" wherever env.hcl doesn't set it, because live/root.hcl feeds TG_AWS_DR_REGION only into the generated aws.dr provider block, never into inputs. The replica block therefore rendered `replica { region = "" }` and every fresh DR-enabled apply died at CreateSecret with 'Invalid replica region' (the run's teardown was clean, 244 resources).

Fix: read the region off the aws.dr provider itself via `data.aws_region.dr` - the region the DR secondary actually lives in, correct whether or not env.hcl sets the variable. Stacks with dr_region properly set see no change (same value); the data source is count-gated on the same aurora_dr_enabled condition as everything else DR.