### PR TITLE
fix(physical): wave-2 followups - re-enterable fence, xlarge migration instance default

### DIFF
--- a/terraform/physical/README.md
+++ b/terraform/physical/README.md
@@ -15,11 +15,11 @@
 | Name | Version |
 | ---- | ------- |
 | <a name="provider_archive"></a> [archive](#provider\_archive) | 2.8.0 |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.54.0 |
-| <a name="provider_aws.dns"></a> [aws.dns](#provider\_aws.dns) | 6.54.0 |
-| <a name="provider_aws.dr"></a> [aws.dr](#provider\_aws.dr) | 6.54.0 |
-| <a name="provider_null"></a> [null](#provider\_null) | 3.3.0 |
-| <a name="provider_random"></a> [random](#provider\_random) | 3.9.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 6.0 |
+| <a name="provider_aws.dns"></a> [aws.dns](#provider\_aws.dns) | ~> 6.0 |
+| <a name="provider_aws.dr"></a> [aws.dr](#provider\_aws.dr) | ~> 6.0 |
+| <a name="provider_null"></a> [null](#provider\_null) | ~> 3.0 |
+| <a name="provider_random"></a> [random](#provider\_random) | ~> 3.0 |
 | <a name="provider_terraform"></a> [terraform](#provider\_terraform) | n/a |
 
 ## Modules
@@ -240,7 +240,7 @@
 | <a name="input_aurora_engine_version"></a> [aurora\_engine\_version](#input\_aurora\_engine\_version) | Aurora MySQL engine version, full aws RDS format (e.g. 8.4.mysql\_aurora.8.4.7 — the bare 8.4.7 is rejected with 'Cannot find version'). Fresh cluster: an 8.4 version. Snapshot-restore migration: an 8.0-compatible version first, then upgrade. | `string` | `"8.4.mysql_aurora.8.4.7"` | no |
 | <a name="input_aurora_max_acu"></a> [aurora\_max\_acu](#input\_aurora\_max\_acu) | Aurora Serverless v2 maximum capacity (ACUs). | `number` | `16` | no |
 | <a name="input_aurora_migration_dms_engine_version"></a> [aurora\_migration\_dms\_engine\_version](#input\_aurora\_migration\_dms\_engine\_version) | Pinned DMS engine version for the migration rig (run-to-run reproducibility; 3.6.1 = the rehearsal-proven version). | `string` | `"3.6.1"` | no |
-| <a name="input_aurora_migration_dms_instance_type"></a> [aurora\_migration\_dms\_instance\_type](#input\_aurora\_migration\_dms\_instance\_type) | Replication instance class for the Aurora migration DMS rig. | `string` | `"dms.c5.large"` | no |
+| <a name="input_aurora_migration_dms_instance_type"></a> [aurora\_migration\_dms\_instance\_type](#input\_aurora\_migration\_dms\_instance\_type) | Replication instance class for the Aurora migration DMS rig. | `string` | `"dms.c5.xlarge"` | no |
 | <a name="input_aurora_migration_dms_storage"></a> [aurora\_migration\_dms\_storage](#input\_aurora\_migration\_dms\_storage) | Allocated storage (GB) for the Aurora migration DMS replication instance. | `number` | `100` | no |
 | <a name="input_aurora_migration_source_fenced"></a> [aurora\_migration\_source\_fenced](#input\_aurora\_migration\_source\_fenced) | Cutover write-fence for the RDS source during an Aurora migration. When true,<br/>read\_only=1 is injected into the RDS parameter group AS CONFIG, so the fence<br/>is Terraform-owned: no concurrent or subsequent apply can silently revert it<br/>(an out-of-band fence would be reset by any refreshed apply mid-cutover).<br/>Set true (gated apply) at the runner's fence step; back to false only on a<br/>pre-cutover abort. On RDS MySQL 8.0.36+ read\_only=1 is a complete fence for<br/>every customer account - no grantable privilege bypasses it. | `bool` | `false` | no |
 | <a name="input_aurora_migration_state"></a> [aurora\_migration\_state](#input\_aurora\_migration\_state) | RDS -> Aurora DMS migration state machine (aurora-migration.tf). off = no<br/>migration (default). provision = Aurora comes up empty alongside the live RDS,<br/>guarded to DMS+bastion, with the DMS rig created but not started. cutover =<br/>connection facts (secret/outputs/BI DMS/bastion) flip to Aurora and the app SG<br/>path opens - apply only at the migration runner's go-live gate. cleanup = the<br/>DMS rig is removed; Aurora stays primary, the RDS survives as the fail-forward<br/>net until the env's final db\_engine="aurora" flip. Only meaningful while<br/>db\_engine="rds". | `string` | `"off"` | no |

--- a/terraform/physical/util/aurora-migration-runner.sh
+++ b/terraform/physical/util/aurora-migration-runner.sh
@@ -483,6 +483,9 @@ EOF
 mariadb --defaults-extra-file=/tmp/mig-tgt.cnf --batch --skip-column-names -e "SELECT COUNT(*) FROM aurora_mig_ctl.marker WHERE tag='$MARK'" 2>/dev/null || echo 0
 EOF
 ); N=$(echo "$N" | tr -d '[:space:]'); say "  marker_on_aurora=$N"; [ "$N" = "1" ] && break
+    # re-check after the probe: a probe that started before the deadline but
+    # failed after it must not go on to start a resume
+    [ "$SECONDS" -lt "$MDEADLINE" ] || die "marker did not reach Aurora within the 15m deadline - inspect the main task's CDC"
     S=$(task_status)
     case "$S" in
       stopped)

--- a/terraform/physical/util/aurora-migration-runner.sh
+++ b/terraform/physical/util/aurora-migration-runner.sh
@@ -386,6 +386,28 @@ fence)
     aws dms stop-replication-task --replication-task-arn "$(bi_task_arn)" --region "$REGION" >/dev/null
     while [ "$(bi_task_status)" != "stopped" ]; do sleep 10; done
   fi
+  # Re-entry detection: a previous fence attempt that died AFTER the Terraform
+  # fence applied (e.g. mid-epoch failure) leaves the source read_only=1. The
+  # marker step below writes to the source, so on a fenced source it would be
+  # refused by the very fence it created (error 1290, hit live on latam). On
+  # re-entry: reuse the previous attempt's marker (reads still work) and skip
+  # the sweep + marker write + interactive fence pause entirely - every proof
+  # downstream (negative test, coordinate, marker gate, drain, epoch) re-runs.
+  RO0=$(ssm_run <<'EOF'
+mariadb --defaults-extra-file=/tmp/mig-src.cnf --batch --skip-column-names -e "SELECT @@read_only"
+EOF
+)
+  RO0=$(echo "$RO0" | tr -d '[:space:]')
+  if [ "$RO0" = "1" ]; then
+    say "source is ALREADY fenced (read_only=1) - re-entering a prior fence attempt"
+    MARK=$(ssm_run <<'EOF'
+mariadb --defaults-extra-file=/tmp/mig-src.cnf --batch --skip-column-names -e "SELECT tag FROM aurora_mig_ctl.marker ORDER BY id DESC LIMIT 1" 2>/dev/null
+EOF
+)
+    MARK=$(echo "$MARK" | tr -d '[:space:]' | grep . | head -1) || true
+    [ -n "$MARK" ] || die "re-entry: no marker found on the fenced source - cannot anchor the epoch; unfence and start over"
+    say "  reusing marker '$MARK' from the prior attempt"
+  else
   MARK="cutover-$(date -u +%s)"
   say "kill sweep (by connection id - app and runner share the master user) + marker '$MARK'"
   ssm_run <<EOF
@@ -423,6 +445,7 @@ EOF
 mariadb --defaults-extra-file=/tmp/mig-src.cnf --batch --skip-column-names -e "SELECT @@read_only"
 EOF
 ); RO=$(echo "$RO" | tr -d '[:space:]'); say "  read_only=$RO"; [ "$RO" = "1" ] && break; sleep 30; done
+  fi
   say "post-fence kill sweep (anything that connected during the apply window;"
   say "read_only already blocks their writes, this just tidies sessions)"
   ssm_run <<'EOF'
@@ -443,10 +466,23 @@ EOF
   [ -n "$FINAL_FILE" ] && [ -n "$FINAL_POS" ] || die "could not capture the final binlog coordinate"
   say "final coordinate: file-seq=$FINAL_FILE pos=$FINAL_POS"
   say "gate: marker on Aurora"
+  # On re-entry the main task may be stopped with the marker not yet replicated
+  # (a prior attempt that died between the fence apply and the drain proof) -
+  # CDC must run for the marker to cross. Bounded: an unbounded gate here held
+  # a fence open indefinitely in review scenarios.
+  MWAIT=0
   while :; do N=$(ssm_run <<EOF
 mariadb --defaults-extra-file=/tmp/mig-tgt.cnf --batch --skip-column-names -e "SELECT COUNT(*) FROM aurora_mig_ctl.marker WHERE tag='$MARK'" 2>/dev/null || echo 0
 EOF
-); N=$(echo "$N" | tr -d '[:space:]'); say "  marker_on_aurora=$N"; [ "$N" = "1" ] && break; sleep 10; done
+); N=$(echo "$N" | tr -d '[:space:]'); say "  marker_on_aurora=$N"; [ "$N" = "1" ] && break
+    if [ "$(task_status)" != "running" ]; then
+      say "  marker not on Aurora and the task is not running - resuming CDC to replicate it"
+      aws dms start-replication-task --replication-task-arn "$(task_arn)" --start-replication-task-type resume-processing --region "$REGION" >/dev/null
+      wait_task_status running 300
+    fi
+    MWAIT=$((MWAIT+10)); [ "$MWAIT" -gt 900 ] && die "marker did not reach Aurora in 15m - inspect the main task's CDC"
+    sleep 10
+  done
   # Drain proof - STOP FIRST, then assert the checkpoint. RecoveryCheckpoint is a
   # stopped-task safepoint: it advances to the true applied position only when the
   # task stops, NOT while it runs. The old code asserted checkpoint >= coordinate
@@ -460,8 +496,11 @@ EOF
   # a task that silently failed).
   FINAL_FILE=$((10#$FINAL_FILE))
   say "task stop (flushes RecoveryCheckpoint to the true applied position)"
-  aws dms stop-replication-task --replication-task-arn "$(task_arn)" --region "$REGION" >/dev/null
-  wait_task_status stopped 900
+  # tolerate an already-stopped task (re-entry after a prior drain-proof stop)
+  if [ "$(task_status)" != "stopped" ]; then
+    aws dms stop-replication-task --replication-task-arn "$(task_arn)" --region "$REGION" >/dev/null
+    wait_task_status stopped 900
+  fi
   say "gate: post-stop checkpoint at or past the final coordinate (the drain proof)"
   CKTRIES=0
   while :; do

--- a/terraform/physical/util/aurora-migration-runner.sh
+++ b/terraform/physical/util/aurora-migration-runner.sh
@@ -490,7 +490,11 @@ EOF
     case "$S" in
       stopped)
         say "  marker not on Aurora and the task is stopped - resuming CDC to replicate it"
-        aws dms start-replication-task --replication-task-arn "$(task_arn)" --start-replication-task-type resume-processing --region "$REGION" >/dev/null
+        MARN=$(task_arn)
+        # final gate immediately before the mutation: the describe calls above
+        # block too, and the resume commits us to up to 300s of waiting
+        [ "$SECONDS" -lt "$MDEADLINE" ] || die "marker did not reach Aurora within the 15m deadline - inspect the main task's CDC"
+        aws dms start-replication-task --replication-task-arn "$MARN" --start-replication-task-type resume-processing --region "$REGION" >/dev/null
         wait_task_status running 300
         ;;
       running|starting|stopping|modifying) : ;; # in flight - poll again

--- a/terraform/physical/util/aurora-migration-runner.sh
+++ b/terraform/physical/util/aurora-migration-runner.sh
@@ -474,7 +474,12 @@ EOF
   # must never be blindly resumed). Wall-clock bounded via SECONDS so nested
   # waits and slow SSM round-trips count against the deadline.
   MDEADLINE=$((SECONDS + 900))
-  while :; do N=$(ssm_run <<EOF
+  while :; do
+    # deadline gates STARTING new work: a blocking probe (ssm_run can run long)
+    # that begins before the deadline may finish after it, and a late success
+    # is still a success - but no new probe/resume ever starts past it.
+    [ "$SECONDS" -lt "$MDEADLINE" ] || die "marker did not reach Aurora within the 15m deadline - inspect the main task's CDC"
+    N=$(ssm_run <<EOF
 mariadb --defaults-extra-file=/tmp/mig-tgt.cnf --batch --skip-column-names -e "SELECT COUNT(*) FROM aurora_mig_ctl.marker WHERE tag='$MARK'" 2>/dev/null || echo 0
 EOF
 ); N=$(echo "$N" | tr -d '[:space:]'); say "  marker_on_aurora=$N"; [ "$N" = "1" ] && break
@@ -488,7 +493,6 @@ EOF
       running|starting|stopping|modifying) : ;; # in flight - poll again
       *) die "task is '$S' while waiting for the marker to replicate - inspect it before continuing" ;;
     esac
-    [ "$SECONDS" -ge "$MDEADLINE" ] && die "marker did not reach Aurora within the 15m deadline - inspect the main task's CDC"
     sleep 10
   done
   # Drain proof - STOP FIRST, then assert the checkpoint. RecoveryCheckpoint is a

--- a/terraform/physical/util/aurora-migration-runner.sh
+++ b/terraform/physical/util/aurora-migration-runner.sh
@@ -468,19 +468,27 @@ EOF
   say "gate: marker on Aurora"
   # On re-entry the main task may be stopped with the marker not yet replicated
   # (a prior attempt that died between the fence apply and the drain proof) -
-  # CDC must run for the marker to cross. Bounded: an unbounded gate here held
-  # a fence open indefinitely in review scenarios.
-  MWAIT=0
+  # CDC must run for the marker to cross. Resume ONLY from a clean "stopped"
+  # (start-replication-task on a transitional state throws
+  # InvalidResourceStateFault, and a task felled by the STOP_TASK error policy
+  # must never be blindly resumed). Wall-clock bounded via SECONDS so nested
+  # waits and slow SSM round-trips count against the deadline.
+  MDEADLINE=$((SECONDS + 900))
   while :; do N=$(ssm_run <<EOF
 mariadb --defaults-extra-file=/tmp/mig-tgt.cnf --batch --skip-column-names -e "SELECT COUNT(*) FROM aurora_mig_ctl.marker WHERE tag='$MARK'" 2>/dev/null || echo 0
 EOF
 ); N=$(echo "$N" | tr -d '[:space:]'); say "  marker_on_aurora=$N"; [ "$N" = "1" ] && break
-    if [ "$(task_status)" != "running" ]; then
-      say "  marker not on Aurora and the task is not running - resuming CDC to replicate it"
-      aws dms start-replication-task --replication-task-arn "$(task_arn)" --start-replication-task-type resume-processing --region "$REGION" >/dev/null
-      wait_task_status running 300
-    fi
-    MWAIT=$((MWAIT+10)); [ "$MWAIT" -gt 900 ] && die "marker did not reach Aurora in 15m - inspect the main task's CDC"
+    S=$(task_status)
+    case "$S" in
+      stopped)
+        say "  marker not on Aurora and the task is stopped - resuming CDC to replicate it"
+        aws dms start-replication-task --replication-task-arn "$(task_arn)" --start-replication-task-type resume-processing --region "$REGION" >/dev/null
+        wait_task_status running 300
+        ;;
+      running|starting|stopping|modifying) : ;; # in flight - poll again
+      *) die "task is '$S' while waiting for the marker to replicate - inspect it before continuing" ;;
+    esac
+    [ "$SECONDS" -ge "$MDEADLINE" ] && die "marker did not reach Aurora within the 15m deadline - inspect the main task's CDC"
     sleep 10
   done
   # Drain proof - STOP FIRST, then assert the checkpoint. RecoveryCheckpoint is a
@@ -496,11 +504,22 @@ EOF
   # a task that silently failed).
   FINAL_FILE=$((10#$FINAL_FILE))
   say "task stop (flushes RecoveryCheckpoint to the true applied position)"
-  # tolerate an already-stopped task (re-entry after a prior drain-proof stop)
-  if [ "$(task_status)" != "stopped" ]; then
-    aws dms stop-replication-task --replication-task-arn "$(task_arn)" --region "$REGION" >/dev/null
-    wait_task_status stopped 900
-  fi
+  # tolerate re-entry states: already stopped (prior drain-proof stop), already
+  # stopping (don't double-issue stop - InvalidResourceStateFault), or starting
+  # (wait for running before a stop is accepted)
+  case "$(task_status)" in
+    stopped) : ;;
+    stopping) wait_task_status stopped 900 ;;
+    starting)
+      wait_task_status running 300
+      aws dms stop-replication-task --replication-task-arn "$(task_arn)" --region "$REGION" >/dev/null
+      wait_task_status stopped 900
+      ;;
+    *)
+      aws dms stop-replication-task --replication-task-arn "$(task_arn)" --region "$REGION" >/dev/null
+      wait_task_status stopped 900
+      ;;
+  esac
   say "gate: post-stop checkpoint at or past the final coordinate (the drain proof)"
   CKTRIES=0
   while :; do

--- a/terraform/physical/variables.tf
+++ b/terraform/physical/variables.tf
@@ -492,9 +492,12 @@ variable "aurora_migration_state" {
 }
 
 variable "aurora_migration_dms_instance_type" {
+  # xlarge default: c5.large (4GB) OOM-crash-looped apac's full load AND
+  # OOM-killed latam's fence validation epoch mid-cutover (source fenced,
+  # customers waiting on the resize). The bigger box costs cents per soak day.
   description = "Replication instance class for the Aurora migration DMS rig."
   type        = string
-  default     = "dms.c5.large"
+  default     = "dms.c5.xlarge"
 }
 
 variable "aurora_migration_dms_storage" {


### PR DESCRIPTION
Two operational defects hit live during the latam cutover (2026-07-29), fixed for emea/usac.

**Re-enterable fence.** A fence attempt that dies after the Terraform fence applies (latam: the validation epoch OOMed) leaves the source `read_only=1`. Re-running the fence phase then fails immediately: its own marker `CREATE DATABASE`/`INSERT` are refused with error 1290 by the fence it created, and the tail had to be completed by hand. The phase now detects an already-fenced source, reuses the prior attempt's marker (reads still work), and skips the kill sweep / marker write / interactive pause - the negative test, coordinate capture, marker gate, drain proof, and validation epoch all re-run. The marker-on-Aurora gate is bounded at 15m and resumes CDC if the marker has not crossed yet; the drain-proof stop tolerates an already-stopped task.

**xlarge by default.** `dms.c5.large` (4GB) has OOMed twice now: apac's full load and latam's fence validation epoch - the latter mid-fence, extending the customer write window while the instance was resized out-of-band. Default flips to `dms.c5.xlarge`; latam already pins it in env.hcl, gca/apac rigs are past their fences and get retired at cleanup.

Not in this PR: the ESO-refresh race at cutover (the db-migrations Job can read the pre-cutover DB secret; gca/apac won the race, latam lost it) - that fix belongs in the chart (writable-DB guard in the migration job), PR incoming there.