### PR TITLE
fix(loadtest): authenticate page GETs with the real session cookie

### DIFF
--- a/loadtest/README.md
+++ b/loadtest/README.md
@@ -8,11 +8,17 @@ creds; runs the load generator as an in-cluster Kubernetes Job.
 - Admin credentials for the target stack (email + password).
 
 ## 1. Seed a dataset (once per env)
+Prefer `./run.sh --seed ...` (step 2 flags plus `--seed`): it runs the seed and writes
+`pool.json` for you. Seeding by hand needs the extraction too - seed.js PRINTS the pool on
+stdout as a `POOL_JSON:` line and writes no file, so a bare `k6 run` leaves you with no
+pool and step 2 refuses to start:
 ```bash
 K6_TARGET="https://<stack-fqdn>" ADMIN_EMAIL=... ADMIN_PASSWORD=... \
   SEED_GUIDES=300 SEED_COURSES=30 SEED_USERS=50 \
-  k6 run seed/seed.js     # writes loadtest/pool.json (created IDs)
+  k6 run --log-format=raw seed/seed.js \
+  | awk -F'POOL_JSON:' '/POOL_JSON:/{print $2}' | tail -1 > pool.json
 ```
+Do not pipe the run through `head`/`tail` on its own - that drops the POOL_JSON line.
 
 ## 2. Run a load test (in-cluster Job)
 ```bash

--- a/loadtest/scenarios/auth.js
+++ b/loadtest/scenarios/auth.js
@@ -12,20 +12,33 @@ export function login(base, email, password) {
   if (res.status !== 200 && res.status !== 201) {
     throw new Error(`login failed: ${res.status} ${res.body}`);
   }
-  // The session id is the token. Prefer an explicit body field; fall back to the
-  // PHPSESSID-style session cookie set on the response.
+  // API auth and browser auth are DIFFERENT credentials here and both are needed:
+  // the body's authToken authenticates /api/2.0 calls, while page GETs need the
+  // session cookie the same response sets. They are distinct values, so sending
+  // the API token as a cookie silently 302s every page to /Login - the load test
+  // then measures redirects instead of rendered pages (which is what it did until
+  // this was fixed; the guide journey never touched a guide).
   let token = '';
   try {
     const b = res.json();
     token = b.authToken || b.token || (b.user && b.user.authToken) || '';
-  } catch (e) { /* non-JSON; fall back to cookie */ }
-  if (!token) {
-    for (const name of Object.keys(res.cookies || {})) {
-      if (/sess/i.test(name) && res.cookies[name].length) { token = res.cookies[name][0].value; break; }
+  } catch (e) { /* non-JSON; the cookie below is the fallback */ }
+
+  // The cookie is named per site (session_<siteid>, e.g. session_2), not PHPSESSID,
+  // so match on the pattern rather than hardcoding a name. Several are set,
+  // including deleted ones carrying the literal value "deleted"; take the last
+  // real value.
+  let cookieName = '', cookieValue = '';
+  for (const name of Object.keys(res.cookies || {})) {
+    if (!/^session/i.test(name)) continue;
+    for (const c of res.cookies[name]) {
+      if (c.value && c.value !== 'deleted') { cookieName = name; cookieValue = c.value; }
     }
   }
+  if (!token) token = cookieValue;
   if (!token) throw new Error(`could not extract session token from login response: ${res.body}`);
-  return { token };
+  if (!cookieValue) throw new Error(`login set no usable session cookie: ${JSON.stringify(Object.keys(res.cookies || {}))}`);
+  return { token, cookieName, cookieValue };
 }
 
 // Headers for authenticated API calls.
@@ -33,6 +46,7 @@ export function apiHeaders(token) {
   return { 'Authorization': `api ${token}`, 'Content-Type': 'application/json' };
 }
 // Headers for authenticated browser GET pages (session cookie; GETs are CSRF-exempt).
-export function pageHeaders(token) {
-  return { 'Cookie': `PHPSESSID=${token}` };
+// Takes the whole login() result, not a token: the cookie name is site-specific.
+export function pageHeaders(auth) {
+  return { 'Cookie': `${auth.cookieName}=${auth.cookieValue}` };
 }

--- a/loadtest/scenarios/journeys.js
+++ b/loadtest/scenarios/journeys.js
@@ -44,8 +44,11 @@ export default function (data) {
     const id = pick(POOL.guides);
     // Guide URLs are /Guide/<title-slug>/<id> - the id is the LAST segment (any
     // slug 302s to the canonical page, which k6 follows and measures).
-    const res = http.get(`${BASE}/Guide/x/${id}`, { headers: pageHeaders(token), tags: { journey: 'guide' } });
-    check(res, { 'guide 2xx/3xx': (x) => x.status < 400 });
+    const res = http.get(`${BASE}/Guide/x/${id}`, { headers: pageHeaders(data), tags: { journey: 'guide' } });
+    // Assert a RENDERED guide, not just a non-error: an unauthenticated request
+    // 302s to /Login, which k6 follows to a 200, so a bare status check passes
+    // while measuring the login page. The canonical guide URL ends in the id.
+    check(res, { 'guide rendered': (x) => x.status === 200 && new RegExp(`/${id}$`).test(x.url) });
   } else if (r < 0.8) {
     const q = pick(SEARCH_TERMS);
     const res = http.get(`${BASE}/api/2.0/search/${encodeURIComponent(q)}?limit=20`,


### PR DESCRIPTION
The load harness's guide journey never loaded a guide.

`pageHeaders()` sent the API `authToken` as `PHPSESSID`. Page auth uses a per-site cookie (`session_<siteid>`) whose value is different from the API token, so every guide request 302'd to `/Login`, k6 followed the redirect to a 200, and the `status < 400` check passed. The run reported healthy numbers while measuring the login page.

`login()` now returns the cookie name and value alongside the API token, and the guide check asserts the response landed on the canonical guide URL rather than accepting any non-error status.

Verified against a live stack, 40 VUs for 7 minutes:

| | before | after |
|---|---|---|
| request failures | 21.8% | 12.1% |
| p95 | 69ms | 104ms |

p95 rising is the point: the run is rendering guides now instead of redirects. The residual 12% is separate and pre-existing, not attributable from the harness's own output because the custom `handleSummary` replaces k6's per-metric breakdown with a single line - worth a follow-up.

Also fixes the README's manual seed command, which silently produced no `pool.json`: `seed.js` prints the pool and `run.sh` does the extraction, so seeding by hand needs the same awk (prefer `run.sh --seed`).