### PR TITLE
chore(harness): migrate to the post-0.78 terragrunt CLI and current toolchain

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -38,7 +38,10 @@ jobs:
       if: matrix.tool == 'tofu'
       uses: opentofu/setup-opentofu@v1
       with:
-        tofu_version: "1.12.2"
+        # Match what the fleet runs (infra-live/_spacelift/stacks.tf). Validating on a
+        # different version than Spacelift applies with is how a module change passes
+        # CI and then fails on a real stack.
+        tofu_version: "1.12.5"
 
     - name: Setup Terraform
       if: matrix.tool == 'terraform'

--- a/.github/workflows/upgrade-tests.yml
+++ b/.github/workflows/upgrade-tests.yml
@@ -46,12 +46,15 @@ jobs:
 
       - uses: opentofu/setup-opentofu@v1
         with:
-          tofu_version: "1.11.8" # highest 1.11.x in Spacelift's bundled set; pairs with Terragrunt 0.99.4, satisfies physical's >= 1.11.1
+          # Keep in step with infra-live/_spacelift/stacks.tf. The pair moves together:
+          # OpenTofu 1.12.x needs Terragrunt >= 1.0.5, which is why the fleet sat on
+          # 1.11.8 while it was on Terragrunt 0.99.4.
+          tofu_version: "1.12.5"
 
       - name: Install terragrunt
         run: |
           curl -fsSLo /usr/local/bin/terragrunt \
-            https://github.com/gruntwork-io/terragrunt/releases/download/v0.99.4/terragrunt_linux_amd64
+            https://github.com/gruntwork-io/terragrunt/releases/download/v1.1.1/terragrunt_linux_amd64
           chmod +x /usr/local/bin/terragrunt
 
       - uses: actions/setup-go@v5

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -12,6 +12,11 @@ self-contained deploy kit and its runbook in [`azure-config/README.md`](./azure-
 # OpenTofu drives both layers locally — the physical layer requires >= 1.11.1, and
 # OpenTofu runs the logical layer too. Terragrunt orchestrates them.
 brew install opentofu terragrunt
+# Terragrunt matters here: the harness and these docs use the post-0.78 CLI
+# (`run --all`, `--non-interactive`). The old `--terragrunt-*` flags were REMOVED in
+# 0.85.0 with no grace period, so an old binary fails with "flag provided but not
+# defined". Check with `terragrunt --version`; if brew gives you something older,
+# `tgenv install 1.1.1 && tgenv use 1.1.1`.
 
 # Everything else
 brew install awscli helm kubectl hashicorp/tap/vault
@@ -22,8 +27,8 @@ export TERRAGRUNT_TFPATH=tofu
 
 | Tool | Version | Verify |
 |------|---------|--------|
-| OpenTofu | >= 1.11.1 | `tofu version` |
-| Terragrunt | 0.99.x | `terragrunt --version` |
+| OpenTofu | 1.12.5 (module floor `>= 1.11.1`) | `tofu version` |
+| Terragrunt | >= 1.0 (fleet runs 1.1.1) | `terragrunt --version` |
 | AWS CLI | 2.x | `aws --version` |
 | Helm | 3.x | `helm version` |
 | kubectl | 1.28+ | `kubectl version --client` |

--- a/live/clean.sh
+++ b/live/clean.sh
@@ -31,7 +31,7 @@ cleanPrefixes() {
         # If you're having issues with stuck kubernetes auth configmaps (which happens sometimes on an un-clean delete)
         # uncomment this function invocation and re-run the script.
         #cleanK8Auth
-        SKIP_LOGICAL=true TG_STATE_PREFIX="test/$p/" terragrunt run-all destroy --terragrunt-non-interactive
+        SKIP_LOGICAL=true TG_STATE_PREFIX="test/$p/" terragrunt run --all destroy --non-interactive
     done
 }
 

--- a/live/isolated_run.sh
+++ b/live/isolated_run.sh
@@ -145,7 +145,7 @@ container_id=$(docker run -d \
   --name "${CONTAINER_NAME}" \
   -v "${WORKTREE_DIR}:/data" \
   -v ~/.aws:/root/.aws \
-  terraform-live-env:latest sh -c "${INITIAL_CMD} cd live/standard/${AWS_REGION}/${ENV} && terragrunt ${TERRAGRUNT_COMMAND} --terragrunt-non-interactive")
+  terraform-live-env:latest sh -c "${INITIAL_CMD} cd live/standard/${AWS_REGION}/${ENV} && terragrunt ${TERRAGRUNT_COMMAND} --non-interactive")
 
 # Fetch the logs from the container and write them to a log file
 docker logs -f "$container_id" > "$LOG_FILE" 2>&1 &

--- a/live/tests/cleanup-orphans.sh
+++ b/live/tests/cleanup-orphans.sh
@@ -244,7 +244,7 @@ print(json.dumps({'Objects':o}) if o else '', end='')
       ( cd "$tgt/logical" 2>/dev/null && rm -rf .terragrunt-cache && \
         TG_AWS_ACCT_ID="$ACCT" TG_AWS_PROFILE="$P" TG_AWS_REGION="$region" TG_STATE_PREFIX="$pfx/" \
         TF_VAR_customer="$cust" TF_VAR_enable_dr=false \
-          terragrunt destroy --terragrunt-non-interactive -auto-approve -input=false ) \
+          terragrunt destroy --non-interactive -auto-approve -input=false ) \
         || echo "  logical destroy failed (continuing to physical so infra isn't stranded)" >&2
       # Physical destroy, retried. A single pass routinely fails on transient
       # DependencyViolation: a killed run can leave MSK/EKS/NAT still creating or
@@ -261,7 +261,7 @@ print(json.dumps({'Objects':o}) if o else '', end='')
           rm -rf .terragrunt-cache
           TG_AWS_ACCT_ID="$ACCT" TG_AWS_PROFILE="$P" TG_AWS_REGION="$region" TG_STATE_PREFIX="$pfx/" \
           TF_VAR_customer="$cust" TF_VAR_enable_dr=false \
-            terragrunt destroy --terragrunt-non-interactive -auto-approve -input=false ) 2>&1 | tee "$_dlog"
+            terragrunt destroy --non-interactive -auto-approve -input=false ) 2>&1 | tee "$_dlog"
         destroyed_ok=${PIPESTATUS[0]}
         [ "$destroyed_ok" -eq 0 ] && break
         # Only retry things that can actually clear on their own. A config-resolution

--- a/live/tests/harness/diagnostics.go
+++ b/live/tests/harness/diagnostics.go
@@ -60,7 +60,11 @@ func captureTG(o TGOptions, module, dir string) {
 		return
 	}
 	for name, args := range map[string][]string{
-		"state-list": {"state", "list"},
+		// `output` is one of terragrunt's shortcut commands, but `state` is not, and
+		// since v0.88.0 terragrunt no longer forwards unrecognised commands to tofu -
+		// it errors with "unknown command" instead. Non-shortcut subcommands have to
+		// go through `run --`.
+		"state-list": {"run", "--", "state", "list"},
 		"output":     {"output"},
 	} {
 		cmd := exec.Command("terragrunt", args...)

--- a/live/tests/harness/phases.go
+++ b/live/tests/harness/phases.go
@@ -146,7 +146,7 @@ func (p PhaseParams) Provision(ctx context.Context, scenario, fromRef, toRef, de
 	}
 	defer wt.removeUnlessFailed(p.RepoDir, &err)
 
-	step("PROVISION apply: %s (terragrunt run-all apply)", applyRef)
+	step("PROVISION apply: %s (terragrunt run --all apply)", applyRef)
 	if aerr := tg.Apply(); aerr != nil {
 		return fmt.Errorf("provision apply: %w", aerr)
 	}

--- a/live/tests/harness/terragrunt.go
+++ b/live/tests/harness/terragrunt.go
@@ -71,7 +71,7 @@ func (o TGOptions) Apply() error {
 	var err error
 	for attempt := 1; attempt <= maxAttempts; attempt++ {
 		var out string
-		out, err = o.execCapture("run-all", "apply", "--terragrunt-non-interactive", "-auto-approve")
+		out, err = o.execCapture("run", "--all", "apply", "--non-interactive", "-auto-approve")
 		if err == nil {
 			return nil
 		}
@@ -86,10 +86,10 @@ func (o TGOptions) Apply() error {
 	return err
 }
 
-// destroyModule destroys a single layer in its own directory (not run-all), so
+// destroyModule destroys a single layer in its own directory (not run --all), so
 // one layer's failure doesn't abort the others.
 func (o TGOptions) destroyModule(module string) error {
-	cmd := exec.Command("terragrunt", "destroy", "--terragrunt-non-interactive", "-auto-approve")
+	cmd := exec.Command("terragrunt", "destroy", "--non-interactive", "-auto-approve")
 	cmd.Dir = filepath.Join(o.WorkingDir, module)
 	cmd.Env = o.env()
 	cmd.Stdout = os.Stderr
@@ -97,7 +97,7 @@ func (o TGOptions) destroyModule(module string) error {
 	return cmd.Run()
 }
 
-// Destroy tears the stack down resiliently. `run-all destroy` aborts the whole
+// Destroy tears the stack down resiliently. `run --all destroy` aborts the whole
 // stack if any module fails — so a broken in-cluster helm release (common after a
 // failed upgrade apply) would strand the expensive physical infra (VPC/EKS/RDS),
 // forcing a manual teardown. Instead: destroy logical best-effort, then ALWAYS

--- a/live/tests/run.sh
+++ b/live/tests/run.sh
@@ -225,6 +225,38 @@ for bin in $REQUIRED_BINS; do
   command -v "$bin" >/dev/null || { echo "missing required tool: $bin" >&2; exit 1; }
 done
 
+# Presence is not enough. Terragrunt removed the --terragrunt-* flags in 0.85.0 and
+# `run-all` in 0.84.0, with no deprecation grace period, and this harness now uses the
+# post-0.78 CLI exclusively. An older terragrunt on PATH fails with a bare "flag
+# provided but not defined" ~20 minutes into a run rather than up front. Nothing pins
+# the local binary (no tgenv/asdf config in the repo, and DEPLOYMENT.md just says
+# `brew install`), so assert it here.
+#
+# The floor is 0.78 (where `run --all` and the unprefixed flags landed), NOT the
+# version the fleet pins. Verified against real binaries: 0.99.4 accepts the new CLI
+# and already REJECTS --terragrunt-*, so anything >= 0.78 runs this harness. Gating on
+# the fleet pin instead would reject a working setup for no reason.
+TG_MIN_MAJOR=0
+TG_MIN_MINOR=78
+tg_raw="$(terragrunt --version 2>/dev/null | head -1)"
+tg_ver="$(printf '%s' "$tg_raw" | sed -nE 's/.*v?([0-9]+)\.([0-9]+)\.([0-9]+).*/\1 \2/p')"
+if [ -z "$tg_ver" ]; then
+  echo "WARNING: could not parse a terragrunt version from: $tg_raw" >&2
+else
+  tg_major="${tg_ver% *}"; tg_minor="${tg_ver#* }"
+  if [ "$tg_major" -lt "$TG_MIN_MAJOR" ] || { [ "$tg_major" -eq "$TG_MIN_MAJOR" ] && [ "$tg_minor" -lt "$TG_MIN_MINOR" ]; }; then
+    cat >&2 <<EOF
+ERROR: terragrunt ${tg_major}.${tg_minor}.x is too old for this harness (need >= ${TG_MIN_MAJOR}.${TG_MIN_MINOR}).
+  The harness uses the post-0.78 CLI (\`run --all\`, \`--non-interactive\`). An older
+  binary fails with a bare "flag provided but not defined" partway into a run.
+  Install a current one, e.g.:  tgenv install 1.1.1 && tgenv use 1.1.1
+  Note tgenv switches the ACTIVE version globally - do not switch while a run is in flight.
+EOF
+    exit 1
+  fi
+  echo ">> terragrunt ${tg_major}.${tg_minor}.x — OK"
+fi
+
 [ "$DO_VAULT" = 1 ] && setup_vault
 
 # Generate a throwaway self-signed cert and supply it as tls_cert/tls_key so the

--- a/live/tests/teardown-orphans.sh
+++ b/live/tests/teardown-orphans.sh
@@ -22,7 +22,7 @@ export AWS_PROFILE=default
 destroy() { # <env> <layer>
   local env=$1 layer=$2
   echo; echo "==================== destroy $env/$layer ===================="
-  ( cd "$env/$layer" && terragrunt destroy --terragrunt-non-interactive -input=false )
+  ( cd "$env/$layer" && terragrunt destroy --non-interactive -input=false )
 }
 
 CONFIGS="${CONFIGS:-usac latam min}"


### PR DESCRIPTION
First of three steps toward running current Terragrunt/OpenTofu everywhere. This one is CPI-only and touches no live infrastructure.

## The harness was already broken, not just stale

Terragrunt dropped the `--terragrunt-*` prefix in **0.78.0** and **removed** the old flags in **0.85.0**, taking `run-all` with them. No deprecation grace period — they hard-fail.

I verified against real binaries rather than trusting release notes:

```
$ terragrunt-0.99.4 init --terragrunt-non-interactive
Error: flag provided but not defined: -terragrunt-non-interactive

$ terragrunt-0.99.4 run --all init --non-interactive
Succeeded 1
```

**0.99.4 is the version `infra-live/_spacelift/stacks.tf` pins for every Spacelift stack today.** So the harness's flags are already rejected by the fleet's own terragrunt. It ran locally only because this laptop happened to have **0.53.0** on PATH, and `upgrade-tests.yml` — which downloads 0.99.4 — cannot have been passing.

## Changes

| Old | New |
|---|---|
| `run-all apply --terragrunt-non-interactive` | `run --all apply --non-interactive` |
| `destroy --terragrunt-non-interactive` | `destroy --non-interactive` |
| `state list` | `run -- state list` |

That last one isn't cosmetic. Since **0.88.0** terragrunt no longer forwards unrecognised commands to tofu, and `state` is not one of its shortcuts, so diagnostics capture would die with "unknown command". `output` *is* a shortcut and is left alone.

Also migrated: `cleanup-orphans.sh`, `teardown-orphans.sh`, `live/clean.sh`, `live/isolated_run.sh`.

## Why this went unnoticed for so long

Nothing pinned the local binary — no tgenv/asdf config anywhere in the repo, and `DEPLOYMENT.md` just said `brew install opentofu terragrunt`. `run.sh` checked only that the binaries *existed*. It now asserts **>= 0.78** up front instead of failing twenty minutes into a run.

The floor is deliberately what the *code* needs, not what the fleet pins — gating on 1.1.1 would reject a perfectly working 0.99.4 setup for no reason.

## Version targets

CI moves to **OpenTofu 1.12.5** + **Terragrunt 1.1.1**, both confirmed present in Spacelift's bundled set (queried live via GraphQL).

These two move **together**: `stacks.tf` pins 1.11.8 specifically because Terragrunt 0.99.4 only pairs with 1.11.x, and 1.12.x requires Terragrunt >= 1.0.5. Moving to 1.1.1 is what unlocks 1.12.5. `terraform.yml` also goes 1.12.2 -> 1.12.5 so we stop validating on a different version than we apply with.

## Next steps (not in this PR)

1. **Validate**: a full `SCENARIO=recover` harness cycle on tofu 1.12.5 + terragrunt 1.1.1. Blocked on the currently-running cycle finishing, since `tgenv` switches the active binary globally.
2. **infra-live**: bump `stacks.tf` to 1.12.5 / 1.1.1. Fleet-wide, so it goes after validation. **Open question before that lands:** `terragrunt_version` applies to *all* stacks including the Vault ones on `TERRAFORM_FOSS` 1.5.7 — Terragrunt 1.1.1 against Terraform 1.5.7 needs confirming.

## Also noticed, deliberately not fixed here

- `terraform/logical/main.tf` declares `required_version >= 1.7.0`, which understates the real floor (OpenTofu >= 1.9 for `provider for_each`; docs say >= 1.11.1). Tightening it is a behavioural change for consumers and wants its own PR.
- `live/Dockerfile` pins `tf-1.5.2-tg-0.48.1` and cannot run the physical layer at all (`>= 1.11.1`). That container path looks abandoned — worth deleting or rebuilding rather than leaving as a trap.