### PR TITLE
fix(logical): stop karpenter evicting helm-controller mid-upgrade

### DIFF
--- a/terraform/logical/flux.tf
+++ b/terraform/logical/flux.tf
@@ -322,8 +322,33 @@ resource "helm_release" "flux" {
     imageReflectionController = { create = false }
     kustomizeController       = { create = false }
     notificationController    = { create = var.flux_slack_webhook_url != "" }
-    helmController            = { create = true }
-    sourceController          = { create = true }
+    # do-not-disrupt on helm-controller ONLY. Karpenter consolidation was evicting
+    # it mid-upgrade, which kills the reconciliation context and fails the release:
+    #
+    #   17:25:41  helm upgrade running, "checking resources for changes: 220"
+    #   17:28:13  Evicted pod: Underutilized   (helm-controller)
+    #             -> Helm upgrade failed ... : context canceled
+    #   17:28:48  new pod took leadership, retried, succeeded
+    #
+    # Flux retries so it self-heals, but the retry is not free: the same eviction
+    # during the pre-upgrade migration hook interrupts a running database
+    # migration rather than a resource diff, and that is the failed-release state
+    # that needs manual recovery. Already observed once as "pre-upgrade hooks
+    # failed: context canceled".
+    #
+    # Deliberately not applied to source-controller or notification-controller.
+    # Their work is short and idempotent - a re-fetch or a re-send - so eviction
+    # costs nothing there, and every annotated pod is another node consolidation
+    # cannot reclaim. helm-controller is the only one holding a long,
+    # non-idempotent operation.
+    #
+    # The value must stay a QUOTED string: Kubernetes annotation values are
+    # strings and an unquoted true is rejected at apply time.
+    helmController = {
+      create      = true
+      annotations = { "karpenter.sh/do-not-disrupt" = "true" }
+    }
+    sourceController = { create = true }
   })]
 }
 


### PR DESCRIPTION
Karpenter consolidation is evicting `helm-controller` while it holds an in-flight Helm upgrade. The eviction kills the reconciliation context, so the release fails:

```
17:25:41  helm upgrade running, "checking resources for changes: {"resources":220}"
17:28:13  Evicted pod: Underutilized   (helm-controller)
          -> Helm upgrade failed for release dozuki/dozuki with chart dozuki@2.0.4: context canceled
17:28:21  replacement container started
17:28:48  took leadership, retried, "Helm upgrade succeeded ... dozuki.v11"
```

It is not isolated. flux-system is churned continuously by consolidation:

```
17:24:25  Killing  source-controller
17:26:43  Evicted  source-controller        Underutilized
17:28:13  Evicted  helm-controller          Underutilized
17:28:13  Evicted  notification-controller  Underutilized
17:30:51  Evicted  source-controller        Underutilized
```

## Why fix it if Flux already retries

Every occurrence so far has self-healed inside three minutes, and the one above interrupted a resource diff, which is harmless.

The concern is where else the eviction can land. The same interruption during the **pre-upgrade migration hook** stops a running database migration rather than a diff, and that produces the failed-release state that needs manual recovery. That has already happened once, with the identical signature:

```
rev 14  failed  Upgrade "dozuki" failed: pre-upgrade hooks failed: context canceled
rev 15  superseded  Upgrade complete          (24 seconds later)
```

It was written off as noise at the time. It was the same defect.

## Scope

`helm-controller` only.

`source-controller` and `notification-controller` do short, idempotent work - a re-fetch, a re-send - so eviction costs them nothing. Every annotated pod is another node consolidation cannot reclaim, so the annotation goes on the one controller that holds long, non-idempotent operations and nowhere else.

## Verification

Against flux2 `2.19.0`, since a wrong values key would silently do nothing:

- `helmController.annotations` renders onto the **pod** template, not the Deployment.
- Supplying it via a values file **merges** with the chart's `prometheus.io/*` defaults rather than replacing them.
- The value must stay a quoted string - Kubernetes rejects a bare boolean annotation, and `--set` coerces it to one.

`tofu fmt` clean, `tflint` clean. `tofu validate` reports one error about the `vault` provider's required `address`; confirmed identical on `master` with the change stashed, so it predates this and is supplied by terragrunt at runtime.