### PR TITLE
test(harness): vault token renewal, logging-guard paging, and toolchain leftovers

### DIFF
--- a/.github/workflows/provider-lock.yml
+++ b/.github/workflows/provider-lock.yml
@@ -88,7 +88,10 @@ jobs:
       - name: Setup OpenTofu
         uses: opentofu/setup-opentofu@v1
         with:
-          tofu_version: 1.11.8
+          # Track the engine the fleet runs. This job regenerates the lock and fails on
+          # any diff, so if it runs a different OpenTofu than the stacks do, it is
+          # asserting something about a file the stacks will read differently.
+          tofu_version: 1.12.5
 
       - name: Complete the lock and assert nothing was missing
         working-directory: terraform/${{ matrix.module }}

--- a/live/Dockerfile
+++ b/live/Dockerfile
@@ -1,15 +1,24 @@
-FROM devopsinfra/docker-terragrunt:aws-tf-1.5.2-tg-0.48.1
+# OpenTofu, not Terraform: physical requires >= 1.11.1 and logical needs OpenTofu's
+# provider for_each, so the old tf-1.5.2 image could not init either layer. Terragrunt
+# 1.1.1 matches what the Spacelift fleet pins; OpenTofu is 1.12.4 rather than the fleet's
+# 1.12.5 only because the base image has no 1.12.5 build yet.
+#
+# This image is Alpine (the old tf-1.5.2 tag was Debian), so package installs are apk.
+FROM devopsinfra/docker-terragrunt:aws-ot-1.12.4-tg-1.1.1
 
 ENV KUBE_VERSION="v1.32.0"
 
-# kubectl isn't in the base image; the isolated_run.sh harness needs it.
+# kubectl isn't in the base image; the isolated_run.sh harness needs it. TARGETARCH comes
+# from BuildKit, so an arm64 build gets an arm64 kubectl - the arch used to be hardcoded
+# to amd64, which silently produced an unrunnable binary when built on an Apple Silicon
+# machine. -f so a bad URL fails the build instead of installing an error page as the
+# binary, and a --client call so a broken download fails HERE rather than mid-run.
+ARG TARGETARCH
 RUN set -ex \
-    && apt-get update \
-    && apt-get install -y --no-install-recommends ca-certificates curl \
-    && curl -LO https://dl.k8s.io/release/${KUBE_VERSION}/bin/linux/amd64/kubectl \
+    && apk add --no-cache ca-certificates curl \
+    && curl -fsSLO "https://dl.k8s.io/release/${KUBE_VERSION}/bin/linux/${TARGETARCH:-amd64}/kubectl" \
     && chmod +x kubectl \
     && mv kubectl /usr/local/bin/ \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
+    && kubectl version --client
 
 CMD ["bash"]

--- a/live/tests/harness/run.go
+++ b/live/tests/harness/run.go
@@ -103,6 +103,13 @@ func RunUpgrade(p RunParams) (err error) {
 	}
 	deleteAfter := startTime.Add(time.Duration(ttl) * time.Hour).UTC().Format(time.RFC3339)
 
+	// Registered before the teardown defers so it stops LAST: the logical destroy reads
+	// Vault too, and this run applies logical twice, so the second one lands near the
+	// token's 1h TTL. See vault.go.
+	renewCtx, stopRenew := context.WithCancel(context.Background())
+	defer stopRenew()
+	StartVaultTokenRenewer(renewCtx)
+
 	// Teardown always runs (defer); the signal handler runs it on SIGINT/SIGTERM too.
 	// Do NOT discard the teardown error. Swallowing it hid a silent no-op teardown:
 	// the stack stayed up, diagnostics were never captured, and the run reported only
@@ -156,6 +163,12 @@ func RunFresh(p RunParams) (err error) {
 		ttl = 24
 	}
 	deleteAfter := startTime.Add(time.Duration(ttl) * time.Hour).UTC().Format(time.RFC3339)
+
+	// Registered before the teardown defers so it stops LAST (the logical destroy reads
+	// Vault too). See vault.go.
+	renewCtx, stopRenew := context.WithCancel(context.Background())
+	defer stopRenew()
+	StartVaultTokenRenewer(renewCtx)
 
 	// Do NOT discard the teardown error. Swallowing it hid a silent no-op teardown:
 	// the stack stayed up, diagnostics were never captured, and the run reported only
@@ -232,6 +245,14 @@ func RunRecovery(p RunParams, recoverConfigName string) (err error) {
 		ttl = 24
 	}
 	deleteAfter := startTime.Add(time.Duration(ttl) * time.Hour).UTC().Format(time.RFC3339)
+
+	// Registered before the teardown defers so it stops LAST. This scenario is the one
+	// that made the renewer necessary: source stack, drill, snapshot and rebuild run in
+	// sequence, so the rebuild's logical apply ALWAYS lands past the token's 1h TTL.
+	// See vault.go.
+	renewCtx, stopRenew := context.WithCancel(context.Background())
+	defer stopRenew()
+	StartVaultTokenRenewer(renewCtx)
 
 	// Source-stack teardown: registered FIRST so it runs LAST (the recovery stack
 	// adopts the source's DR buckets; destroying them first would strand it).

--- a/live/tests/harness/terragrunt.go
+++ b/live/tests/harness/terragrunt.go
@@ -35,6 +35,17 @@ var kubeAuthRaceRE = regexp.MustCompile(`credentials configured in the provider 
 // still fail the run.
 var transientNetRE = regexp.MustCompile(`(?i)no such host|connection reset by peer|i/o timeout|TLS handshake timeout|request send failed|EOF$`)
 
+// vaultTokenExpiredRE matches the vault provider failing to validate its OWN token
+// (a 403 on auth/token/lookup-self). The renewer in vault.go is what should keep this
+// from ever happening; this is the second net, because the cost of being wrong is an
+// entire run - cycle 45 lost ~80 minutes of correct work to exactly this, with the
+// rebuild apply already in flight.
+//
+// Narrow on purpose. It matches only the provider's own token lookup, not "permission
+// denied" generally, so a genuine Vault POLICY problem still fails immediately instead
+// of being retried into a confusing timeout.
+var vaultTokenExpiredRE = regexp.MustCompile(`(?i)failed to lookup token`)
+
 type TGOptions struct {
 	WorkingDir   string
 	AccountID    string
@@ -102,6 +113,17 @@ func (o TGOptions) Apply() error {
 			time.Sleep(wait)
 			continue
 		}
+		// No backoff: a re-login either produced a usable token or it did not, and
+		// waiting does not change that. Only retry if the refresh actually succeeded,
+		// so a dead AWS session fails on this attempt instead of three more.
+		if attempt < maxAttempts && vaultTokenExpiredRE.MatchString(out) {
+			if refreshVaultToken() {
+				fmt.Fprintf(os.Stderr, "\n>> harness: Vault token had expired; re-logged in and retrying apply (attempt %d/%d)\n\n", attempt+1, maxAttempts)
+				continue
+			}
+			fmt.Fprintf(os.Stderr, "\n>> harness: Vault token expired and re-login failed — not retrying\n\n")
+			return err
+		}
 		if attempt < maxAttempts && transientNetRE.MatchString(out) {
 			wait := time.Duration(attempt*30) * time.Second
 			fmt.Fprintf(os.Stderr, "\n>> harness: transient network failure (request never reached AWS); retrying apply in %s (attempt %d/%d)\n\n", wait, attempt+1, maxAttempts)
@@ -140,19 +162,22 @@ func (o TGOptions) Destroy() error {
 	return o.destroyModule("physical")
 }
 
-// refreshVaultToken best-effort re-logs-in to Vault before the teardown and updates
-// VAULT_TOKEN in the process env. A long run can outlast the AWS-auth token's TTL,
-// so the token run.sh logged in with is stale by teardown — the logical destroy then
-// 403s on every vault data source (lookup-self against VAULT_ADDR). run.sh's
-// port-forward is still up, so we re-login the same way it did. Best-effort: if the
-// vault/aws CLIs or VAULT_ADDR are absent, keep the inherited token — the logical
-// destroy is best-effort anyway and the cleanup-orphans backstop re-auths too.
-func refreshVaultToken() {
+// refreshVaultToken best-effort re-logs-in to Vault and updates VAULT_TOKEN in the
+// process env, returning whether it actually got a token. A long run can outlast the
+// AWS-auth token's 1h TTL, and everything that reads Vault then 403s on lookup-self
+// against VAULT_ADDR. run.sh's port-forward is still up, so we re-login the same way it
+// did. Best-effort: if the vault/aws CLIs or VAULT_ADDR are absent, keep the inherited
+// token — the cleanup-orphans backstop re-auths too.
+//
+// Note this mints a DIFFERENT token, so it only helps processes started afterwards.
+// Steady-state renewal (vault.go) keeps the existing token alive instead; this is the
+// recovery path for when it is already too late for that.
+func refreshVaultToken() bool {
 	if os.Getenv("VAULT_ADDR") == "" {
-		return // no Vault tunnel in this run (e.g. azure / SKIP_VAULT_TUNNEL)
+		return false // no Vault tunnel in this run (e.g. azure / SKIP_VAULT_TUNNEL)
 	}
 	if _, err := exec.LookPath("vault"); err != nil {
-		return
+		return false
 	}
 	profile := os.Getenv("VAULT_AWS_PROFILE")
 	if profile == "" {
@@ -169,7 +194,7 @@ func refreshVaultToken() {
 		"export-credentials", "--format", "env-no-export").Output()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, ">> teardown: Vault re-login skipped (aws creds for %q: %v) — using inherited token\n", profile, err)
-		return
+		return false
 	}
 	loginEnv := os.Environ()
 	for _, line := range strings.Split(strings.TrimSpace(string(credsOut)), "\n") {
@@ -182,7 +207,7 @@ func refreshVaultToken() {
 	out, err := login.Output()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, ">> teardown: Vault re-login skipped (%v) — using inherited token; backstop re-auths if needed\n", err)
-		return
+		return false
 	}
 	var resp struct {
 		Auth struct {
@@ -190,10 +215,11 @@ func refreshVaultToken() {
 		} `json:"auth"`
 	}
 	if json.Unmarshal(out, &resp) != nil || resp.Auth.ClientToken == "" {
-		return
+		return false
 	}
 	_ = os.Setenv("VAULT_TOKEN", resp.Auth.ClientToken)
-	fmt.Fprintf(os.Stderr, ">> teardown: refreshed Vault token (re-login via aws role=%s) so the logical destroy uses a live token\n", role)
+	fmt.Fprintf(os.Stderr, ">> vault: refreshed token (re-login via aws role=%s)\n", role)
+	return true
 }
 
 // clearNLBProtection disables deletion protection on the stack's NLB before the

--- a/live/tests/harness/vault.go
+++ b/live/tests/harness/vault.go
@@ -1,0 +1,69 @@
+package harness
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// The Vault AWS-auth token run.sh logs in with has a 1 hour TTL. Any run longer than
+// that loses Vault the moment the next logical apply touches it: every vault data source
+// and resource fails with `failed to lookup token ... 403 permission denied` on
+// auth/token/lookup-self. A dead PORT-FORWARD looks different (connection refused), so
+// the 403 is specifically an expired token.
+//
+// This is not a rare edge. The recovery scenario cannot avoid it: the source stack, the
+// drill, the snapshot and the rebuild run in sequence, so the rebuild's logical layer
+// always lands past the hour mark. Cycle 45 died exactly there, ~81 minutes in, having
+// already done every expensive thing correctly. The upgrade scenario is exposed too - it
+// applies logical twice - it just tended to fail earlier for other reasons.
+//
+// Renewal rather than re-login on purpose: the token is renewable with no explicit max
+// TTL, so `vault token renew` resets the lease WITHOUT changing the token value. That
+// matters because VAULT_TOKEN has already been copied into the environment of any child
+// process; re-login mints a different token and only helps processes started afterwards.
+// Re-login stays as the fallback for when the token is already dead.
+const vaultRenewInterval = 20 * time.Minute
+
+// StartVaultTokenRenewer keeps the run's Vault token alive until ctx is cancelled.
+// Best-effort by design: no Vault tunnel (azure / SKIP_VAULT_TUNNEL) or no vault CLI
+// means there is nothing to renew, and a failed renewal is reported rather than fatal -
+// the apply that needs the token will fail loudly on its own if this cannot recover.
+//
+// Pass a context that outlives teardown; the logical destroy reads Vault too.
+func StartVaultTokenRenewer(ctx context.Context) {
+	if os.Getenv("VAULT_ADDR") == "" {
+		return
+	}
+	if _, err := exec.LookPath("vault"); err != nil {
+		return
+	}
+	go func() {
+		t := time.NewTicker(vaultRenewInterval)
+		defer t.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-t.C:
+				renewVaultToken()
+			}
+		}
+	}()
+}
+
+// renewVaultToken extends the current token's lease, falling back to a full re-login if
+// the token is too far gone to renew.
+func renewVaultToken() {
+	out, err := exec.Command("vault", "token", "renew", "-format=json").CombinedOutput()
+	if err == nil {
+		fmt.Fprintf(os.Stderr, ">> vault: token lease renewed (next in %s)\n", vaultRenewInterval)
+		return
+	}
+	fmt.Fprintf(os.Stderr, ">> vault: token renew failed (%v: %s) — re-logging in\n",
+		err, truncate(strings.TrimSpace(string(out)), 200))
+	refreshVaultToken()
+}

--- a/live/tests/harness/vault_test.go
+++ b/live/tests/harness/vault_test.go
@@ -1,0 +1,82 @@
+package harness
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// The renewer only helps if it fires comfortably inside the token's life. The Vault
+// AWS-auth role issues a 1h token (measured, not assumed: creation_ttl=3600,
+// explicit_max_ttl=0, renewable). Renewing resets the lease to a fresh hour, so the
+// interval just has to leave room for a renewal to FAIL and still be retried before the
+// token dies - otherwise a single transient Vault blip puts the run back exactly where
+// cycle 45 was, ~80 minutes in with a dead token and an apply in flight.
+func TestVaultRenewIntervalLeavesRoomForAMissedRenewal(t *testing.T) {
+	const tokenTTL = time.Hour
+
+	if vaultRenewInterval >= tokenTTL {
+		t.Fatalf("renew interval %s is not inside the %s token TTL - the token dies before it is ever renewed",
+			vaultRenewInterval, tokenTTL)
+	}
+	if 2*vaultRenewInterval >= tokenTTL {
+		t.Fatalf("renew interval %s leaves no margin: one failed renewal and the %s token expires before the next attempt",
+			vaultRenewInterval, tokenTTL)
+	}
+}
+
+// The retry must fire on an expired token and NOT on a real authorization failure.
+// Retrying a policy problem just turns an instant, readable error into three more
+// re-logins and a confusing timeout.
+func TestVaultTokenExpiredREMatchesOnlyTheProvidersOwnTokenLookup(t *testing.T) {
+	// Verbatim from cycle 45's rebuild apply.
+	expired := `Error: failed to lookup token, err=Error making API request.
+
+URL: GET http://127.0.0.1:8200/v1/auth/token/lookup-self
+Code: 403. Errors:
+
+* permission denied`
+
+	if !vaultTokenExpiredRE.MatchString(expired) {
+		t.Fatal("expired-token error not matched; the retry would never fire and a run dies at the 1h mark")
+	}
+
+	// A live token that simply is not allowed to do this. Must fail immediately.
+	for name, out := range map[string]string{
+		"policy denial on a kv write": `Error: error writing to Vault: Error making API request.
+
+URL: PUT http://127.0.0.1:8200/v1/secret/data/dozuki/smoke
+Code: 403. Errors:
+
+* 1 error occurred:
+	* permission denied`,
+		"bare permission denied": "Error: permission denied",
+		"sealed vault":           "Error: Vault is sealed",
+	} {
+		if vaultTokenExpiredRE.MatchString(out) {
+			t.Errorf("%s: matched the expired-token retry, but re-logging in cannot fix it", name)
+		}
+	}
+}
+
+// No Vault tunnel means there is nothing to renew. This must return rather than spawn a
+// goroutine that shells out to a missing binary every 20 minutes for the life of an
+// azure or SKIP_VAULT_TUNNEL run.
+func TestStartVaultTokenRenewerIsANoopWithoutVaultAddr(t *testing.T) {
+	t.Setenv("VAULT_ADDR", "")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() {
+		StartVaultTokenRenewer(ctx)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("StartVaultTokenRenewer blocked with no VAULT_ADDR; it must return immediately")
+	}
+}

--- a/live/tests/validation/logging.go
+++ b/live/tests/validation/logging.go
@@ -78,19 +78,71 @@ func AssertControlPlaneLogging(ctx context.Context, region, clusterName string) 
 		return fmt.Errorf("log group retention = %v, want 90", r)
 	}
 
-	// Audit events flowing in the last 30 min.
+	return assertAuditEventsFlowing(ctx, cw, logGroup)
+}
+
+// auditWaitBudget bounds how long we wait for the first audit events to reach
+// CloudWatch. A fresh EKS control plane does not deliver instantly, and this check runs
+// only ~15 minutes after the cluster exists.
+const auditWaitBudget = 5 * time.Minute
+
+// assertAuditEventsFlowing checks that kube-apiserver-audit events landed in the last 30
+// minutes.
+//
+// Two things make the obvious one-shot version wrong, and cycle 46 lost a 53-minute run
+// to them:
+//
+//   - An empty PAGE is not an empty RESULT. FilterLogEvents scans a bounded amount per
+//     call across every matching stream, so it can legitimately return zero events
+//     together with a nextToken. The previous code passed Limit=1, took the first page,
+//     and reported "no audit events" whenever that page happened to come back empty.
+//     Paging is not optional here - it is the difference between "none exist" and "none
+//     in the slice I looked at".
+//   - Delivery lag. The events show up a few minutes after the control plane starts, so
+//     a hard failure on the first look tests AWS's delivery latency, not the deploy.
+//
+// So: page to exhaustion, and if genuinely nothing is there yet, retry within a budget.
+func assertAuditEventsFlowing(ctx context.Context, cw *cloudwatchlogs.Client, logGroup string) error {
+	deadline := time.Now().Add(auditWaitBudget)
+	for attempt := 1; ; attempt++ {
+		found, err := anyAuditEvent(ctx, cw, logGroup)
+		if err != nil {
+			return err
+		}
+		if found {
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("no kube-apiserver-audit events in last 30m for %s (waited %s across %d attempts)",
+				logGroup, auditWaitBudget, attempt)
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(30 * time.Second):
+		}
+	}
+}
+
+// anyAuditEvent pages FilterLogEvents to exhaustion, returning true at the first event.
+func anyAuditEvent(ctx context.Context, cw *cloudwatchlogs.Client, logGroup string) (bool, error) {
 	start := time.Now().Add(-30 * time.Minute).UnixMilli()
-	fl, err := cw.FilterLogEvents(ctx, &cloudwatchlogs.FilterLogEventsInput{
+	in := &cloudwatchlogs.FilterLogEventsInput{
 		LogGroupName:        &logGroup,
 		LogStreamNamePrefix: aws.String("kube-apiserver-audit"),
 		StartTime:           &start,
-		Limit:               aws.Int32(1),
-	})
-	if err != nil {
-		return err
 	}
-	if len(fl.Events) == 0 {
-		return fmt.Errorf("no kube-apiserver-audit events in last 30m for %s", logGroup)
+	for {
+		fl, err := cw.FilterLogEvents(ctx, in)
+		if err != nil {
+			return false, err
+		}
+		if len(fl.Events) > 0 {
+			return true, nil
+		}
+		if fl.NextToken == nil || *fl.NextToken == "" {
+			return false, nil
+		}
+		in.NextToken = fl.NextToken
 	}
-	return nil
 }

--- a/terraform/logical/.terraform.lock.hcl
+++ b/terraform/logical/.terraform.lock.hcl
@@ -36,7 +36,7 @@ provider "registry.opentofu.org/alekc/kubectl" {
 
 provider "registry.opentofu.org/hashicorp/aws" {
   version     = "6.56.0"
-  constraints = "~> 6.0, != 6.57.0"
+  constraints = "~> 6.0"
   hashes = [
     "h1:+NMCqCUCfCyaqO3+gUNIOG5BuEwRruMEkq9YWBB/TCc=",
     "h1:0kvfRRcQe7537L4ZAb799OMUVJadelfrgi+DPzFHHgM=",

--- a/terraform/logical/README.md
+++ b/terraform/logical/README.md
@@ -3,7 +3,7 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.7.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 6.0 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | ~> 4.0 |
 | <a name="requirement_external"></a> [external](#requirement\_external) | ~> 2.0 |

--- a/terraform/logical/main.tf
+++ b/terraform/logical/main.tf
@@ -1,5 +1,15 @@
 terraform {
-  required_version = ">= 1.7.0"
+  # OpenTofu >= 1.9, where provider for_each landed. This layer depends on it: the
+  # in-module azurerm provider is instantiated with ZERO instances on AWS deploys, which
+  # is the only thing stopping azurerm v4 from authenticating eagerly on workers that have
+  # no Azure CLI (count=0 on the resources does NOT prevent that). The old >= 1.7.0 floor
+  # predated that and would let an engine through that cannot init this module at all.
+  #
+  # required_version cannot say "OpenTofu specifically" - Terraform 1.9 also satisfies
+  # this and would then fail later on the for_each itself. The floor is here to reject
+  # clearly-too-old engines early, not to pick the engine; that is the stack's tool
+  # setting (OPEN_TOFU in infra-live).
+  required_version = ">= 1.9.0"
 
   required_providers {
     aws = {

--- a/terraform/physical/.terraform.lock.hcl
+++ b/terraform/physical/.terraform.lock.hcl
@@ -40,7 +40,7 @@ provider "registry.opentofu.org/hashicorp/archive" {
 
 provider "registry.opentofu.org/hashicorp/aws" {
   version     = "6.56.0"
-  constraints = ">= 3.29.0, >= 4.45.0, >= 5.81.0, >= 6.0.0, ~> 6.0, >= 6.28.0, >= 6.33.0, >= 6.52.0, != 6.57.0"
+  constraints = ">= 3.29.0, >= 4.45.0, >= 5.81.0, >= 6.0.0, ~> 6.0, >= 6.28.0, >= 6.33.0, >= 6.52.0"
   hashes = [
     "h1:+NMCqCUCfCyaqO3+gUNIOG5BuEwRruMEkq9YWBB/TCc=",
     "h1:0kvfRRcQe7537L4ZAb799OMUVJadelfrgi+DPzFHHgM=",


### PR DESCRIPTION
338 lines across 9 files, so this is a PR rather than a direct push. Four independent fixes, all found by running the DR harness on the new toolchain today.

## `test(harness)`: keep the Vault token alive for the whole run

The AWS-auth token `run.sh` logs in with lives **one hour** (measured: `creation_ttl=3600`, `explicit_max_ttl=0`, renewable). Anything reading Vault after that fails with `failed to lookup token ... 403` on `auth/token/lookup-self`. Re-login at teardown was the only place that handled it.

The recovery scenario **cannot avoid this**: source stack, drill, snapshot and rebuild run in sequence, so the rebuild's logical apply always lands past the hour. A cycle died there ~81 minutes in with everything before it correct — provision green, promotion clean, 6/6 heartbeats, snapshot taken, rebuild in flight.

Renews rather than re-logs-in: the token is renewable with no max TTL, so `vault token renew` resets the lease **without changing the token value**. That matters because `VAULT_TOKEN` is already in the environment of running child processes, which a re-login would never reach. Re-login stays as the fallback for when it is already too late.

Confirmed working on the next run (`vault: token lease renewed` fired on schedule, and the run died 80+ minutes in on something unrelated instead of a dead token).

## `test(harness)`: stop the logging guard failing on an empty first page

Cost a 53-minute run with `no kube-apiserver-audit events in last 30m` on a cluster whose logging was fine. Two bugs in one call:

- **An empty page is not an empty result.** `FilterLogEvents` scans a bounded amount per call across every matching stream, so it can return zero events *together with* a `nextToken`. The check passed `Limit=1`, read the first page, and concluded no audit events existed. Now pages to exhaustion.
- **Delivery lag.** The guard runs ~15 minutes after the cluster exists; audit events reach CloudWatch a few minutes behind the control plane. A hard failure on the first look was testing AWS delivery latency, not the deploy. Retries within a 5-minute budget.

The previous cycle passed this same guard on the same code and config, which is what makes it flaky rather than a regression.

## `chore(toolchain)`: make the live container and the logical floor match reality

`live/Dockerfile` was on `tf-1.5.2 / tg-0.48.1` — an image that could not `init` either layer (physical needs >= 1.11.1, logical needs provider `for_each`), and after #365 switched `isolated_run.sh` to `--non-interactive` it could not even parse the command line. Moved to the OpenTofu base at tg 1.1.1, matching the fleet.

Two things that only showed up by actually building it: the new base is **Alpine** where the old was Debian, so the kubectl layer had to become `apk`; and the kubectl arch was hardcoded `amd64` while `isolated_run.sh` builds natively, so on Apple Silicon it produced an image whose kubectl could not run. Now takes `TARGETARCH` from BuildKit. Verified by building and running terragrunt, tofu, kubectl and aws in it.

`terraform/logical` declared `>= 1.7.0` while depending on provider `for_each` (1.9+). Raised to 1.9.0. `required_version` cannot express "OpenTofu", so this only rejects clearly-too-old engines.

## `ci(providers)`: run the lock check on the engine the fleet runs

The platform-coverage job regenerates `.terraform.lock.hcl` and fails on any diff, so pinning it to tofu 1.11.8 meant it asserted something about a file the stacks would read on a different engine. Now tracks the fleet.

## Verification

- `go build ./...`, `go vet`, and all three test packages pass
- Both layers `init` clean on tofu 1.12.5 against the committed lock files with `-lockfile=readonly`
- New tests cover the renew interval leaving room for one failed renewal, and the expired-token retry matching the provider's own token lookup while **not** matching a genuine policy denial
