### PR TITLE
docs(logical): name standalone interaction handler

### DIFF
--- a/terraform/logical/flux.tf
+++ b/terraform/logical/flux.tf
@@ -164,7 +164,7 @@ locals {
           # POST the exact silence API route; the Alertmanager UI retains the
           # per-environment ops login.
           # Keep the action off until Terraform has distributed the shared
-          # password to both Resource Reaper and this environment's Vault path.
+          # password to both the standalone handler and this environment's Vault path.
           interactivity = {
             enabled = var.cloud == "aws" && var.alertmanager_slack_silence_password != ""
           }


### PR DESCRIPTION
Correct the logical Helm-values comment so password distribution points to the standalone Alertmanager Slack handler rather than Resource Reaper.

Validation:
- VAULT_ADDR=http://dummy tofu -chdir=terraform/logical validate