### PR TITLE
fix(physical): rotate the S3 key and tag the resources that were missing tags

### DIFF
--- a/terraform/physical-azure/.terraform.lock.hcl
+++ b/terraform/physical-azure/.terraform.lock.hcl
@@ -1,0 +1,113 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/azurerm" {
+  version     = "4.81.0"
+  constraints = "~> 4.0"
+  hashes = [
+    "h1:+SK0igaGkoHG872vP6Q8Haqfn6bb9f93bpwwtfXQYjo=",
+    "h1:/BPm6F9H7OA+0YUbYFLzo/11O9JwKyQF9xtqGysP4fM=",
+    "h1:3GpAIyIEvHp715KDMWwQXR3D5/T6y4ym9guOvnEsTRw=",
+    "h1:4+KKAPuCkQ4mMcnY8lV9117FEt0IVOFX6sb0i1V0wHQ=",
+    "h1:CQD+Nc/yArsvbnqSUsRFXSg8dEt1HY9zdzPLHVHZ17s=",
+    "h1:JfSDFlyoomcxMaesZCqmf4R1AM0x6H2EOQUHTowh2gw=",
+    "h1:VTqM+VVLaJR7fld2I6kSIecR9J46cP3lpKzZpHHMTvA=",
+    "h1:aV5LUZ6xHHowYZ9tTk0KeMzaDfwrQC4SBntjq+OQIZk=",
+    "h1:h0YZJJXvcNEaJSkbLDhK3QjZrCb/zfSpYuM78mCLZpA=",
+    "h1:hbiwWQ9tZ1ajGcbr+ami9hzLD3EqyO8nOjy5L7l9MxA=",
+    "h1:lfSfUaLWqBdpAlb6d3KScGGPMyVSKi94nPjviBkqpYU=",
+    "h1:oEUfYv79aNXEMu5FhiTgwo9lpHcvKtU1pBNY2rjOCeM=",
+    "h1:sZ4atLmq9quI2eyU4pkf68eWbg194MhgFMZe3iLa9N0=",
+    "h1:tXnzefiSTHO3DBLBVGZSZ03y7+opr2hwbDpaWnNyQcc=",
+    "h1:v+SZNctpFiplpLtyKK14QfUo+nTOx2TChVGkhMcP4EQ=",
+    "zh:00039b380b581a6a2ceb9f6caf2a9f6a963b50d0cbb63effa6faf7933b4b9324",
+    "zh:0cf3daf3aed4dfc8c3ad9a92113303799ef6977b61e23077173ada1d2355520c",
+    "zh:3244bb91bcb5b5f4bd8f18a149cbb53cee2b286fda33e3934e363bd15360b5c2",
+    "zh:3d2aaf5f8085f5c6514353525c2e60e82942d4fa5c0dca51e461b737468d47c5",
+    "zh:3f93ee9f6066ed22ff1f2fa90bfa0b2a6521bb3c38675b5bc83f217689963a0c",
+    "zh:44f67168d661504c18da6e00c2cc87cd2c57c1d171a348e4e8e5d18953a8a193",
+    "zh:5712823959db99c11f56215afa059cc6fc791ae927fce8ecebba454d9f32c240",
+    "zh:5a85351f237b72e6c2f417e4ff70b96d1f7090012d20cb7655230b60e266e4cf",
+    "zh:63529f04136918ccfa1bb3e081d33e5cbd9d217efb5376d09179f07d5392b1d3",
+    "zh:7a8c870fa01019586065094ed96409836c5e03b4e6d9b8a01623f2632173e880",
+    "zh:a510081c7da2e086cbda0261e86190e7988eb2f078ccac5b3b8d838cbac85c40",
+    "zh:a6ae0f84089f7f86f0a5db29afb35e84804b61cba1413c2fee1af45d450479f2",
+    "zh:d25410d042051ce4f3f35d9eb7127a6693d1969e165ecc12fea7b059b562f2a8",
+    "zh:faf96f32e7bd9bf4886a34635c93e80f512214228531e7548ac5b2e3b93a525d",
+    "zh:fc915f76beaf9afd0934057a5c5a460846dabfeb5a9a1f4d8b7c7f0aacbfffc8",
+  ]
+}
+
+provider "registry.opentofu.org/hashicorp/random" {
+  version     = "3.9.0"
+  constraints = "~> 3.0"
+  hashes = [
+    "h1:8EQU5KSxezcjo/phRSe69rDOI0lk4pSaggj7FsskYp8=",
+    "h1:Lw9im2VBBJQ3RyAbHPQ0rcvcmmcZWm3x+kIOpN+Tv9s=",
+    "h1:U8KXqGCoNI9/guYbTvzgdtVk3fRthoG0UXwm1JoEpIs=",
+    "h1:YXaVd4p6qXPPVaxIBaIDNXmBwT02ZqDn0qD+tYpw8sA=",
+    "h1:cOpc03fphEt/G9Rfc4jLL/fW0D7tgvlXqiDKPF4vuww=",
+    "h1:g09RR7T1xWkeGrZwWvWMT9ncJrFGr1k3CBD585UmO7w=",
+    "h1:gGDdPPibmw2EWROx+sh1RGLjR5+nPwZyrf6/N9jXfeM=",
+    "h1:haE7/nXCOhXKP4oXeEnER3t5CaVQWqujz4nBnpeTUv4=",
+    "h1:ieSVpfZS2lKuMr05ph0QsOVpCzg7uk3cgKBaXR+Ikug=",
+    "h1:ig2s1IS9IzehorRjvVAnKIsUUj8fkgyxct1L/kswcc4=",
+    "h1:j3lS+ZEERFnoab8t1ppDrScGVP/cgWbzlCrEYKTCXYw=",
+    "h1:lxezrKmOiQIySHAM+os8qLVq7hqufDr8h3Hpzvsk+78=",
+    "h1:lzRqBJAG+NETxHbEZUJ/YP3RMEjZBinTX7VmgH3lw60=",
+    "h1:tdSNWK5ApqUsgbdYieyeYLTu6nIZUV3hR1oFqUfAuGo=",
+    "h1:xedet8yH/zI2CfdxsGlK0nlFWc/Bp61yrWsEa3fHB8g=",
+    "zh:03f1114cc20b8913523735ab76e0f0a2b16ce13c92923a53304bf85f07fc0dbc",
+    "zh:105b678ee72322a3067f105d7e05e940f6143238f377f6e87ff4ec909246ac2a",
+    "zh:55f3bbf13ea18cbace61a706566a80f25f33fe2b1780b6f3d7b582af2a05b6d2",
+    "zh:63adf996db48f082f7a6351eb485e219cd88795fc71e6ec60a837263ab0d2cb1",
+    "zh:7e99550738a4e3cc68b8a467714b0d69371025fe95e3326d5323d026d55653e9",
+    "zh:8342b54af3a18a37e075eeae61be57f4de2ba71b35d95c5075d402dd2c1f289d",
+    "zh:83ee18e32ac9dd5fc91298554b7c4cfa4c3a1db50f4c797945637cc93c0844ae",
+    "zh:993ecc0adbf6bd535a59fbc9b735d8c33950e6f6eb5e621d750da9b71d65d80a",
+    "zh:ad722bc59d4edbf1415e827fc007c0efe6e0e9462d5568bae20b34be1058a261",
+    "zh:ae9448e1f87b2f9a6c5197a0e9862162ec6b137cb3a3835e11522995d8939e7c",
+    "zh:bc9cdd3aac784f759125c6627f6f6416e8726a1c184eb9cf3e55b9edbc94c627",
+    "zh:c8e35b89572ba1c40a9b20022e033a3395fb8d42e7604d50c900f193ba10382e",
+    "zh:e2deaa8a9975ef81d9f62baed12c41286918b0a10908e0e031f13f69a3b730a1",
+    "zh:ee39707557210a0ab1098aa357d2cdfe502e5a312d0dbdffb09d08facc4d3fc5",
+    "zh:f81afe4eb63e8aa9e0ea71be6c990f0dc69cb360e7191c0742a991f4a5081b64",
+  ]
+}
+
+provider "registry.opentofu.org/hashicorp/time" {
+  version     = "0.14.0"
+  constraints = "~> 0.13"
+  hashes = [
+    "h1:7NpGFIxlybShI7Rp75FYsN1y634ERY8k2tWecAd+7E4=",
+    "h1:8BLHeBjRS/J2SB2jX/APsNqaCoW957ItWwYHB2tDJxQ=",
+    "h1:AjF6WvzpGqqqBL9GvRTnoNaBhb3gATNr7BQGKJZTgLg=",
+    "h1:Bxx62jDcZK0am+afGk6Ykai3xAJ+kywRBXKSFYurYVg=",
+    "h1:CQIlkT9lxTbVH4cxqXCx82pZKQEzOkLpT46RsxD/HYk=",
+    "h1:MZahRDJtGnhvg0wxOHDuaondAXVW2nXX5qpQyzP3VjM=",
+    "h1:R2VyKXqik22JkOOwhF9TRnizaP/xgbqa+1uWFlOF9Qk=",
+    "h1:TgathXtnDVLJSkETVDP6c9txmSsq5SJsud6O/28ptZg=",
+    "h1:UGqbICb3O/mPHa7dxJGYMdXEYfqFaWOBAlVwP+EkXsw=",
+    "h1:VVWIHk02wVfQjW0LZWebQcgPeEeiN9Vy2GNdHq5FExk=",
+    "h1:nXb/PVTFSacCYD6BQnTsgKPEUOGIVOgociSAE2iWN/c=",
+    "h1:sHruA5X0bMk1a9152XBk0E6F1TMsOwXcqMEIDm4dk4Y=",
+    "h1:sR5ZgoL7xEw1WrX2CMzwCShqojJpgDgoD5b7XR0rwyo=",
+    "h1:te8wkusyzI1LT1Aa08bB5oU5xgb1xp8oXMEZeLdFmg0=",
+    "h1:zlqgl4B3cEk+wNKcHTGuF1VrQTTmeWBSr1TqwnLuWLA=",
+    "zh:155688768de4c53bc6523c5fed46aa4a74c8fc8cab25ea808ce2ff24e2f5ae83",
+    "zh:1af6716fa8e7c4fd8be408ff2ff6ee12759171bb128d162f9926ad32cb0ffa49",
+    "zh:1be2795c86651fd1d87fffba6013086d56890ce6db1f541ae2ba9404db24d4a6",
+    "zh:2fb4a1dfaf37d452ce5981925215dd0e0f6c89733a3c97c8f78307a05765939a",
+    "zh:5986f66d98602017953257ef51bb6396d2bc648ebcaf8feb9c088b3585ff2195",
+    "zh:6047a3daafe8ce495aef249a128ba4002aca334b811bafddea521ebca03b11dc",
+    "zh:6e0be9e14223fe21bf38ba723026d2eee2dc1e5dfab6f7fc4d31bfa8c19a7543",
+    "zh:7d391e37de3043bc4aad2a51146154ac9a63022527524136880807cf8addc719",
+    "zh:7d9726369f062243ffc474068f56cb315911250f73e03fa3d63833293e092d1a",
+    "zh:905790b553654aa66db59d5efda57ae207f72ade11677983c0849a83f4f7969b",
+    "zh:a24165685313941779a0be04c36ddbc33836f26b8a5a9198eb01dbb1e339dda8",
+    "zh:a4228f0edd34868696077710200409936963ae93f3cf108bce3ec6b936e458b6",
+    "zh:b82a35e7b7ef55bc329a6dc084d19d034ff9cc9372d904f4134c6ec9cc3a1ca3",
+    "zh:c00432d129e4ddfa5e986aa872d442e918496c118a04b3b259b167ca40257575",
+    "zh:f804b662a4c82dfa241ae9ddc9cb35b7c197e7e97a578cef4dc425a4002eadf1",
+  ]
+}

--- a/terraform/physical-azure/main.tf
+++ b/terraform/physical-azure/main.tf
@@ -42,11 +42,10 @@ locals {
   identifier_compact = replace(local.identifier, "-", "")
 
   tags = {
-    Terraform   = "true"
-    Project     = "mpc"
+    Terraform = "true"
+    # Project held the same value as Service, and Identifier duplicated Customer; both dropped.
     Service     = "mpc"
     Customer    = coalesce(var.customer, "dozuki")
-    Identifier  = local.identifier
     Environment = var.environment
   }
 

--- a/terraform/physical/bi.tf
+++ b/terraform/physical/bi.tf
@@ -65,6 +65,8 @@ resource "aws_kms_key" "bi" {
   description             = "BI KMS key for replication credentials"
   enable_key_rotation     = true
   deletion_window_in_days = var.protect_resources ? 30 : 7
+
+  tags = local.tags
 }
 
 resource "aws_dms_replication_instance" "this" {

--- a/terraform/physical/eks.tf
+++ b/terraform/physical/eks.tf
@@ -186,6 +186,8 @@ resource "aws_kms_key" "eks" {
   description             = "EKS Secret Encryption Key"
   enable_key_rotation     = true
   deletion_window_in_days = var.protect_resources ? 30 : 7
+
+  tags = local.tags
 }
 
 resource "aws_iam_policy" "assume_cross_account_role" {

--- a/terraform/physical/main.tf
+++ b/terraform/physical/main.tf
@@ -68,12 +68,20 @@ locals {
   // If you add a tag, it must never be blank.
   tags = merge(
     {
-      Terraform   = "true"
-      Project     = "Dozuki"
+      Terraform = "true"
+      # Service names the WORKLOAD, and this module is the managed private cloud product.
+      # Not "cloudprem" - that term is deprecated. Not "<customer>-<env>" either: Customer and
+      # Environment already carry that, and StackPath pins the exact unit, so a composite here
+      # would be pure duplication. What Service uniquely buys is separating the MPC fleet from
+      # shared infrastructure (vault) and from internal tooling (resource-reaper, airgap-hauler,
+      # spacelift-private-worker, ...), which have no customer or environment at all.
       Service     = "mpc"
       Customer    = coalesce(var.customer, "dozuki")
-      Identifier  = coalesce(var.customer, "Dozuki")
       Environment = var.environment
+      # Project and Identifier removed. Project was the constant "Dozuki" on every resource in
+      # every account, so it grouped nothing; Identifier was a verbatim duplicate of Customer.
+      # The tagging policy always had Project collapsing into Service. The keys stay ACTIVE as
+      # cost allocation tags org-wide (other accounts may group on them), we just stop emitting.
     },
     var.delete_after != "" ? { deleteAfter = var.delete_after } : {},
   )

--- a/terraform/physical/modules/acm/main.tf
+++ b/terraform/physical/modules/acm/main.tf
@@ -16,9 +16,10 @@ locals {
 
   # Tags for all resources. If you add a tag, it must never be blank.
   tags = {
-    Terraform   = "true"
-    Project     = "Dozuki"
-    Identifier  = coalesce(var.identifier, "Dozuki")
+    Terraform = "true"
+    # Matches the physical root: Service names the workload; Project (constant) and Identifier
+    # (duplicate of Customer) are dropped.
+    Service     = "mpc"
     Environment = var.environment
   }
 }

--- a/terraform/physical/modules/vpn/main.tf
+++ b/terraform/physical/modules/vpn/main.tf
@@ -13,9 +13,10 @@ locals {
 
   # Tags for all resources. If you add a tag, it must never be blank.
   tags = {
-    Terraform   = "true"
-    Project     = "Dozuki"
-    Identifier  = coalesce(var.identifier, "Dozuki")
+    Terraform = "true"
+    # Matches the physical root: Service names the workload; Project (constant) and Identifier
+    # (duplicate of Customer) are dropped.
+    Service     = "mpc"
     Environment = var.environment
   }
 }

--- a/terraform/physical/monitoring.tf
+++ b/terraform/physical/monitoring.tf
@@ -31,6 +31,8 @@ resource "aws_iam_policy" "lambda_permissions" {
 
   name   = "${local.identifier}-${data.aws_region.current.region}-lambda-alias"
   policy = data.aws_iam_policy_document.lambda_permissions[0].json
+
+  tags = local.tags
 }
 
 resource "aws_iam_role" "lambda_execution" {
@@ -38,6 +40,8 @@ resource "aws_iam_role" "lambda_execution" {
 
   name               = "${local.identifier}-${data.aws_region.current.region}-lambda-execution"
   assume_role_policy = data.aws_iam_policy_document.lambda_execution[0].json
+
+  tags = local.tags
 }
 resource "aws_iam_role_policy_attachment" "lambda_basic_execution" {
   count = var.slack_webhook_url != "" || local.dms_enabled ? 1 : 0
@@ -299,6 +303,8 @@ resource "aws_cloudwatch_metric_alarm" "rds_storage_space_alarm" {
       }
     }
   }
+
+  tags = local.tags
 }
 
 module "rds_connections_alarm" {
@@ -409,6 +415,8 @@ resource "aws_cloudwatch_event_rule" "dms_task_state_changed_rule" {
       local.aurora_migration_dms ? [aws_dms_replication_task.aurora_migration[0].replication_task_arn] : []
     ))
   })
+
+  tags = local.tags
 }
 
 resource "aws_cloudwatch_event_target" "dms_task_state_changed_target" {
@@ -456,6 +464,8 @@ resource "aws_lambda_function" "sns_to_slack" {
       AWS_ACCOUNT_ID    = data.aws_caller_identity.current.account_id
     }
   }
+
+  tags = local.tags
 }
 
 resource "aws_sns_topic_subscription" "sns_to_slack_subscription" {
@@ -517,6 +527,8 @@ resource "aws_lambda_function" "dms_restart" {
       RESTARTABLE_TASK_ARNS = join(",", [for t in aws_dms_replication_task.this : t.replication_task_arn])
     }
   }
+
+  tags = local.tags
 }
 
 resource "aws_sns_topic_subscription" "dms_restart_subscription" {
@@ -562,6 +574,8 @@ resource "aws_cloudwatch_metric_alarm" "dr_s3_replication_latency" {
 
   alarm_actions = [module.sns.topic_arn]
   ok_actions    = [module.sns.topic_arn]
+
+  tags = local.tags
 }
 
 resource "aws_cloudwatch_metric_alarm" "dr_s3_replication_failed" {
@@ -586,6 +600,8 @@ resource "aws_cloudwatch_metric_alarm" "dr_s3_replication_failed" {
 
   alarm_actions = [module.sns.topic_arn]
   ok_actions    = [module.sns.topic_arn]
+
+  tags = local.tags
 }
 
 # --- Aurora CloudWatch alarms (count-gated on aurora engine) --- #

--- a/terraform/physical/s3.tf
+++ b/terraform/physical/s3.tf
@@ -101,13 +101,21 @@ data "aws_iam_policy_document" "s3_kms_key_policy" {
   }
 }
 
-#tfsec:ignore:aws-kms-auto-rotate-keys
 resource "aws_kms_key" "s3" {
   count = local.use_provided_s3_kms ? 0 : 1
 
-  description             = "KMS key to encrypt S3 bucket contents"
+  description = "KMS key to encrypt S3 bucket contents"
+  # Rotation was suppressed with #tfsec:ignore:aws-kms-auto-rotate-keys rather than reasoned
+  # about, and this was the only KMS key in the module without it. Enabling it is safe on an
+  # existing key: AWS KMS retains ALL previous key material for the life of the key, and on
+  # decrypt it automatically selects the version that encrypted the ciphertext. Nothing is
+  # re-encrypted, the key id and ARN do not change, and AWS documents the rotation as
+  # transparent to server-side encryption in AWS services. Default period is 365 days,
+  # counted from when rotation is enabled. (Security Hub KMS.4.)
+  enable_key_rotation     = true
   deletion_window_in_days = var.protect_resources ? 30 : 7
   policy                  = data.aws_iam_policy_document.s3_kms_key_policy.json
+  tags                    = local.tags
 }
 resource "aws_kms_alias" "s3" {
   count = local.use_provided_s3_kms ? 0 : 1


### PR DESCRIPTION
Two Infracost findings from infra-live #163, both real.

## KMS.4 — `aws_kms_key.s3` had no rotation

It was the **only** KMS key in the module without `enable_key_rotation`, and it is the key encrypting customer guide content. All seven now have it:

```
bi  rds_cmk  dr_rds  dr_s3  dr_aurora  eks  s3   ->  rotation=True tags=True
```

It carried `#tfsec:ignore:aws-kms-auto-rotate-keys`, added in a generic release-prep commit (#108) rather than as a reasoned exception.

**Enabling rotation on an existing key is safe**, which is worth stating because it is the part that looks risky and is not:

- AWS KMS *retains all previous key material for the life of the key* and, on decrypt, automatically selects the version that encrypted the ciphertext. No existing object becomes unreadable.
- **Nothing is re-encrypted.** Only new encrypt operations use the new material.
- The key id and ARN do not change, so no configuration anywhere needs updating.
- AWS documents the annual rotation as *"transparent and compatible with AWS services"* for server-side encryption, and as causing *"no interruption or delay in cryptographic operations"*.
- Default period is 365 days, counted from when rotation is enabled.

## Missing `Service` tag

The provider `default_tags` (infra-live `root.hcl`) carry `Environment`, `Customer`, `ManagedBy`, `StackPath`, `Repo` — but **not** `Service`, which lives in CPI's `local.tags`. Resources that never set `tags` therefore lacked it.

This was inconsistency, not intent: in `monitoring.tf` the four Aurora alarms pass `local.tags` while sixteen older resources do not — including `aws_cloudwatch_metric_alarm.rds_storage_space_alarm`, the same resource type, right beside them.

Tagged the eight taggable ones plus the three untagged KMS keys. The remaining eight are types with **no** `tags` argument (`aws_iam_role_policy_attachment`, `aws_cloudwatch_event_target`, `aws_sns_topic_subscription`, `aws_lambda_permission`) and are left alone.

**Fixed in CPI rather than by adding `Service` to `default_tags`:** `Service` is hardcoded `"mpc"` in the physical module, so hoisting it into `root.hcl` would stamp `mpc` onto every infra-live stack including the vault and global ones, which are not MPC.

## Expect tag-only plan churn

Every stack will show in-place tag updates on these resources on its next apply. No replacements — `tags` is not ForceNew on any of them, and the KMS rotation flag is an in-place modify.