### PR TITLE
fix(dr): stop telling operators aurora DR needs a CMK

### DIFF
--- a/terraform/physical/dr.tf
+++ b/terraform/physical/dr.tf
@@ -98,7 +98,7 @@ check "dr_rds_replicable" {
   assert {
     condition = !var.enable_dr || local.dr_rds_enabled || local.aurora_dr_enabled
     error_message = local.db_uses_aurora && !local.db_is_aurora ? (
-      "DR is enabled and S3 content replicates cross-region, but the database does NOT while an Aurora migration is in flight: the live database is the Aurora cluster, and Aurora DR (Global Database) only attaches once the env finishes the migration with db_engine = \"aurora\". Expected during a migration. It also requires the Aurora cluster to be CMK-encrypted, which is set at create — see the database CMK remediation plan before assuming the retirement apply will produce a working global cluster."
+      "DR is enabled and S3 content replicates cross-region, but the database does NOT while an Aurora migration is in flight: the live database is the Aurora cluster, and Aurora DR (Global Database) only attaches once the env finishes the migration with db_engine = \"aurora\". Expected during a migration."
       ) : local.db_uses_aurora ? (
       "DR is enabled and S3 content replicates cross-region. The Aurora database replicates only when the global-database secondary is configured — ensure enable_dr is true and the admin layer injected a same-partition dr_region. (On GovCloud, confirm the engine version supports Global Database.)"
       ) : (


### PR DESCRIPTION
The `dr_database_replicable` check told operators that Aurora Global Database requires a CMK-encrypted cluster set at create time. It does not - that constraint belongs to the RDS path, where cross-region automated backup replication genuinely refuses the AWS-managed key.

Verified directly: `create-global-cluster` and an encrypted cross-region secondary both succeed against an AWS-managed-key primary.

This matters because all four 3M Aurora clusters (gca, apac, latam, emea) are on the AWS-managed key. The message was sending each of them toward a key swap as a prerequisite for DR, when the only thing actually gating `aurora_dr_enabled` is `db_engine = "aurora"`.

Message text only, no resource changes.