### PR TITLE
fix(eks): tag the iam policies and pod identity associations

### DIFF
--- a/terraform/physical/eks.tf
+++ b/terraform/physical/eks.tf
@@ -48,6 +48,8 @@ data "aws_iam_policy_document" "cluster_access" {
 resource "aws_iam_policy" "cluster_access" {
   name   = "${local.identifier}-${data.aws_region.current.region}-cluster-access"
   policy = data.aws_iam_policy_document.cluster_access.json
+
+  tags = local.tags
 }
 
 data "aws_iam_policy_document" "eks_worker_kms" {
@@ -204,6 +206,8 @@ resource "aws_iam_policy" "assume_cross_account_role" {
       }
     ]
   })
+
+  tags = local.tags
 }
 
 #tfsec:ignore:aws-vpc-no-public-egress-sgr
@@ -339,6 +343,8 @@ resource "aws_eks_pod_identity_association" "app_default" {
   namespace       = "dozuki"
   service_account = "default"
   role_arn        = aws_iam_role.app_pod_identity.arn
+
+  tags = local.tags
 }
 
 # App deployments use the migration-wait SA (for kubectl RBAC in init
@@ -348,6 +354,8 @@ resource "aws_eks_pod_identity_association" "app_migration_wait" {
   namespace       = "dozuki"
   service_account = "dozuki-migration-wait"
   role_arn        = aws_iam_role.app_pod_identity.arn
+
+  tags = local.tags
 }
 
 # Pod Identity: cert-manager cross-account Route53
@@ -383,6 +391,8 @@ resource "aws_eks_pod_identity_association" "cert_manager" {
   namespace       = "cert-manager"
   service_account = "cert-manager"
   role_arn        = aws_iam_role.cert_manager_pod_identity.arn
+
+  tags = local.tags
 }
 
 # Container Insights: CloudWatch agent (amazon-cloudwatch-observability addon).


### PR DESCRIPTION
Infracost's tagging policy fails on five resources in `eks.tf` that carry no tags: `aws_iam_policy.assume_cross_account_role`, `aws_iam_policy.cluster_access`, and the `app_default` / `app_migration_wait` / `cert_manager` pod identity associations. Each now gets `local.tags`.

infra-live #164's `default_tags` floor covers these too once merged, but only for stacks driven by that repo - consumers using this module directly have no such floor, so the tags belong at source as well. Same reasoning as the monitoring.tf resources in #379.

In-place; tags never force replacement.

A wider sweep suggests other resources may also be missing tags (some IAM policies/roles, secrets, parameter groups, the global cluster). Deliberately not included here - that needs a careful pass to separate genuinely taggable resources from ones that do not support tags at all.