### PR TITLE
fix(dr): stop the rds snapshot guard denying aurora a CMK

### DIFF
--- a/terraform/physical/aurora.tf
+++ b/terraform/physical/aurora.tf
@@ -72,7 +72,7 @@ module "aurora" {
   create_security_group = false
 
   storage_encrypted = true
-  kms_key_id        = local.rds_kms_key_arn
+  kms_key_id        = local.aurora_kms_key_arn
 
   snapshot_identifier = var.aurora_snapshot_identifier != "" ? var.aurora_snapshot_identifier : null
 

--- a/terraform/physical/dr.tf
+++ b/terraform/physical/dr.tf
@@ -42,6 +42,29 @@ locals {
   rds_use_tf_cmk  = var.rds_adopt_dr_cmk && var.rds_kms_key_id == "alias/aws/rds" && !local.rds_snapshot_restored_instance
   rds_kms_key_arn = local.rds_use_tf_cmk ? aws_kms_key.rds_cmk[0].arn : data.aws_kms_key.rds.arn
 
+  # Aurora gets its own key selection, WITHOUT the snapshot exclusion above, and the split
+  # matters more than it looks. The exclusion is about a limitation of
+  # RestoreDBInstanceFromDBSnapshot; Aurora does not share it. But db_engine stays "rds" for
+  # the whole DMS migration by design (the app is still served by the RDS primary until the
+  # cutover apply), so a stack mid-migration satisfies rds_snapshot_restored_instance while
+  # aurora.tf is creating a brand-new EMPTY cluster that DMS will load. Feeding that cluster
+  # rds_kms_key_arn denied it a CMK for a reason that has nothing to do with it, and since the
+  # key is immutable at create the only way back is a snapshot-restore swap later.
+  #
+  # That is not hypothetical: it is why all four migrated 3M clusters sit on the AWS-managed
+  # key. Reading rds_adopt_dr_cmk = false on those envs suggested they had opted out, but this
+  # local would have overridden them to the managed key even set true.
+  #
+  # Safe for a snapshot-restored Aurora too, which is the case the exclusion was written for:
+  # RestoreDBClusterFromSnapshot accepts KmsKeyId and re-encrypts, and that asymmetry is
+  # exactly what the fleet's key-swap runbook depends on.
+  # aurora_present is in the condition so the key is created only when there is actually an
+  # Aurora cluster to encrypt. Without it, any stack with rds_adopt_dr_cmk = true but no Aurora
+  # (qa today) would mint a CMK on its next apply that nothing consumes, and it also keeps the
+  # aws_kms_key.rds_cmk[0] reference below safe when the count is zero.
+  aurora_use_tf_cmk  = var.rds_adopt_dr_cmk && var.rds_kms_key_id == "alias/aws/rds" && local.aurora_present
+  aurora_kms_key_arn = local.aurora_use_tf_cmk ? aws_kms_key.rds_cmk[0].arn : data.aws_kms_key.rds.arn
+
   # RDS automated-backup cross-region replication is only possible when the DB
   # uses a customer-managed key (either our created CMK or an operator-pinned one).
   # Aurora DR uses Global Database, not automated-backup replication.
@@ -114,7 +137,9 @@ check "dr_rds_replicable" {
 # on its own, and it is the prerequisite for RDS automated-backup cross-region replication and
 # for encrypting an Aurora global secondary in the DR region.
 resource "aws_kms_key" "rds_cmk" {
-  count = local.rds_use_tf_cmk ? 1 : 0
+  # Either path can be the one that wants it: a fresh Aurora cluster mid-migration needs the
+  # key even when the RDS snapshot exclusion is holding rds_use_tf_cmk false.
+  count = local.rds_use_tf_cmk || local.aurora_use_tf_cmk ? 1 : 0
 
   description             = "${local.identifier} database encryption (customer-managed; DR-replicable)"
   enable_key_rotation     = true


### PR DESCRIPTION
`rds_use_tf_cmk` excludes snapshot-restored databases because `RestoreDBInstanceFromDBSnapshot` has no storage-key parameter, so a CMK there never converges. Aurora has no such limitation - `RestoreDBClusterFromSnapshot` accepts `KmsKeyId` and re-encrypts, which is what the key-swap runbook relies on - but both engines read the same local, so the exclusion hit Aurora too.

That bites precisely during a DMS migration: `db_engine` stays `"rds"` until the cutover apply while `aurora.tf` creates a brand-new **empty** cluster for DMS to load. The guard denied that cluster a CMK for a reason belonging to a different database, and the key is immutable at create.

This is the actual reason all four migrated 3M clusters are on the AWS-managed key. `rds_adopt_dr_cmk = false` on those envs looked like the explanation, but this local would have overridden them regardless.

`aurora_use_tf_cmk` drops the snapshot term and gains `aurora_present`, so the CMK is created only when a cluster exists to encrypt it (otherwise qa mints an unused key, and the `[0]` reference is unsafe at count zero).

**Blast radius: none.** Evaluated against all six 3M envs - five set `rds_adopt_dr_cmk = false`, qa has no Aurora - so `aurora_use_tf_cmk` is false everywhere today and no existing cluster is touched. It activates for **usac at provision**, which is the motivation: usac is the last primary migration and create time is its only cheap shot at a CMK.

The RDS path and the two BI RDS instances are unchanged.

Follow-up: #376's `bi_aurora` cluster should read `aurora_kms_key_arn` too once it merges.