### PR TITLE
fix(monitoring): skip the INSUFFICIENT_DATA to OK transition in slack alerts

### DIFF
--- a/terraform/physical/util/sns_to_slack.py
+++ b/terraform/physical/util/sns_to_slack.py
@@ -32,9 +32,32 @@ post messages to the designated Slack channel."""
 import json
 import os
 import urllib.request
+from datetime import datetime
 import boto3
 
 SLACK_WEBHOOK_URL = os.environ['SLACK_WEBHOOK_URL']
+
+# How close a state change must be to the alarm's last config create/update to count
+# as alarm settling rather than a real recovery. Wide on purpose: some metrics (DR
+# replication, agent-fed ContainerInsights) take hours after an apply to emit their
+# first datapoint, and the cost of a too-wide window is one suppressed healthy-state
+# post shortly after someone edited that same alarm.
+SETTLE_WINDOW_SECONDS = 24 * 3600
+
+
+def alarm_recently_configured(message_json):
+    """True when the state change happened within the settle window of the alarm's
+    config being created or updated. Any missing or unparseable timestamp returns
+    False so the caller posts the message - never classify on bad data.
+    """
+    fmt = "%Y-%m-%dT%H:%M:%S.%f%z"
+    try:
+        state_change = datetime.strptime(message_json["StateChangeTime"], fmt)
+        configured = datetime.strptime(
+            message_json["AlarmConfigurationUpdatedTimestamp"], fmt)
+    except (KeyError, TypeError, ValueError):
+        return False
+    return abs((state_change - configured).total_seconds()) <= SETTLE_WINDOW_SECONDS
 
 
 def get_account_alias():
@@ -95,11 +118,16 @@ def lambda_handler(event, context):
         # A freshly created alarm goes INSUFFICIENT_DATA -> OK as its first datapoints
         # arrive. That is alarm birth, not a recovery: an apply that adds a batch of
         # alarms floods the channel with healthy-state posts that read like an incident.
-        # Only this exact transition is dropped - ALARM -> OK still closes real incidents,
-        # INSUFFICIENT_DATA -> ALARM still pages (missing=breaching alarms enter that
-        # way), and a payload without OldStateValue posts as before.
-        if old_state_value == "INSUFFICIENT_DATA" and new_state_value == "OK":
-            print(f"skipping INSUFFICIENT_DATA -> OK for {alarm_name}")
+        # The transition alone is not enough to drop, though - an established alarm in
+        # ALARM whose metric stops arriving also exits via INSUFFICIENT_DATA -> OK, and
+        # that post is the only closure the channel gets. The config-updated timestamp
+        # separates the two: only suppress when the alarm was created or edited within
+        # the settle window. ALARM -> OK still closes real incidents, anything entering
+        # ALARM still pages (missing=breaching alarms arrive via INSUFFICIENT_DATA ->
+        # ALARM), and a payload missing OldStateValue or timestamps posts as before.
+        if (old_state_value == "INSUFFICIENT_DATA" and new_state_value == "OK"
+                and alarm_recently_configured(message_json)):
+            print(f"skipping INSUFFICIENT_DATA -> OK for {alarm_name} (alarm settling)")
             return
 
         if new_state_value == "ALARM":

--- a/terraform/physical/util/sns_to_slack.py
+++ b/terraform/physical/util/sns_to_slack.py
@@ -88,8 +88,19 @@ def lambda_handler(event, context):
         # Process CloudWatch Alarm message
         alarm_name = message_json.get('AlarmName', 'N/A')
         alarm_description = message_json.get('AlarmDescription', 'N/A')
+        old_state_value = message_json.get('OldStateValue')
         new_state_value = message_json.get('NewStateValue', 'N/A')
         new_state_reason = message_json.get('NewStateReason', 'N/A')
+
+        # A freshly created alarm goes INSUFFICIENT_DATA -> OK as its first datapoints
+        # arrive. That is alarm birth, not a recovery: an apply that adds a batch of
+        # alarms floods the channel with healthy-state posts that read like an incident.
+        # Only this exact transition is dropped - ALARM -> OK still closes real incidents,
+        # INSUFFICIENT_DATA -> ALARM still pages (missing=breaching alarms enter that
+        # way), and a payload without OldStateValue posts as before.
+        if old_state_value == "INSUFFICIENT_DATA" and new_state_value == "OK":
+            print(f"skipping INSUFFICIENT_DATA -> OK for {alarm_name}")
+            return
 
         if new_state_value == "ALARM":
             header = "*CloudWatch Alarm! <!channel>*"


### PR DESCRIPTION
When an apply creates new CloudWatch alarms (for example the aurora alarms that appear when an env moves to Aurora), each alarm transitions INSUFFICIENT_DATA to OK as its first datapoints arrive, and the sns_to_slack lambda posts every one. The posts carry alarming names and descriptions over healthy State: OK bodies, so a batch of new alarms reads like a real CPU/memory incident in the alerts channel.

The transition alone is not a safe filter: an established alarm in ALARM whose metric stops arriving also exits via INSUFFICIENT_DATA to OK, and that post is the only closure the channel gets. So the suppression is gated on the alarm settling after a config change. The handler drops the post only when OldStateValue is INSUFFICIENT_DATA, NewStateValue is OK, and StateChangeTime is within 24 hours of AlarmConfigurationUpdatedTimestamp. The window is wide on purpose, some metrics (DR replication, agent-fed ContainerInsights) take hours after an apply to emit their first datapoint. Everything else is unchanged:

- ALARM to OK recovery posts still go out.
- INSUFFICIENT_DATA to OK on an established alarm (metric gap during an incident) still posts.
- Anything entering ALARM still posts and pages, including INSUFFICIENT_DATA to ALARM (the missing=breaching alarms enter ALARM that way).
- A payload missing OldStateValue or either timestamp posts as before (fail open, never drop a message we can't classify).
- Non-CloudWatch messages (DMS notifications) are untouched.

## Verification

`python3 -m py_compile terraform/physical/util/sns_to_slack.py` passes. Exercised the handler locally with boto3 and the webhook stubbed, one synthetic SNS event per scenario:

| Scenario | Result |
| --- | --- |
| INSUFFICIENT_DATA to OK, alarm configured 10 min ago | suppressed (no Slack post, skip logged) |
| INSUFFICIENT_DATA to OK, alarm configured 30 days ago | posted |
| INSUFFICIENT_DATA to OK, timestamps missing from payload | posted |
| ALARM to OK | posted |
| OK to ALARM | posted, paged `<!channel>` |
| INSUFFICIENT_DATA to ALARM | posted, paged `<!channel>` |
| no OldStateValue, NewStateValue OK | posted |
| DMS deprovision event | posted, paged `<!channel>` |

Only the lambda source changes, no Terraform resources. Nothing happens in any env until it bumps to the release that carries this.