### PR TITLE
fix(physical): grant the DMS service principal on the BI key for serverless compute

### DIFF
--- a/terraform/physical/README.md
+++ b/terraform/physical/README.md
@@ -196,6 +196,7 @@
 | [aws_availability_zones.available](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/availability_zones) | data source |
 | [aws_availability_zones.dr](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/availability_zones) | data source |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_iam_policy_document.bi_kms](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.cluster_access](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.dr_guide_buckets_ssl_only](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.dr_s3_replication](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |

--- a/terraform/physical/bi.tf
+++ b/terraform/physical/bi.tf
@@ -72,10 +72,11 @@ resource "aws_kms_key" "bi" {
 
 # The serverless replication encrypts its compute resources with this key
 # (compute_config.kms_key_id below) and accesses it as the dms.amazonaws.com
-# service principal directly, unlike the old provisioned instance which went
-# through its instance role and was covered by the root statement alone. On the
-# default key policy the replication fails at preparing_metadata_resources with
-# "No permission to access Key". Caught by the qa canary.
+# service principal directly, unlike the old provisioned instance whose role
+# got access through IAM policies under the root statement's delegation. A
+# service principal cannot: it needs its own key policy statement. On the
+# default key policy the replication fails at preparing_metadata_resources
+# with "No permission to access Key". Caught by the qa canary.
 data "aws_iam_policy_document" "bi_kms" {
   count = var.enable_bi ? 1 : 0
 

--- a/terraform/physical/bi.tf
+++ b/terraform/physical/bi.tf
@@ -65,8 +65,51 @@ resource "aws_kms_key" "bi" {
   description             = "BI KMS key for replication credentials"
   enable_key_rotation     = true
   deletion_window_in_days = var.protect_resources ? 30 : 7
+  policy                  = data.aws_iam_policy_document.bi_kms[0].json
 
   tags = local.tags
+}
+
+# The serverless replication encrypts its compute resources with this key
+# (compute_config.kms_key_id below) and accesses it as the dms.amazonaws.com
+# service principal directly, unlike the old provisioned instance which went
+# through its instance role and was covered by the root statement alone. On the
+# default key policy the replication fails at preparing_metadata_resources with
+# "No permission to access Key". Caught by the qa canary.
+data "aws_iam_policy_document" "bi_kms" {
+  count = var.enable_bi ? 1 : 0
+
+  statement {
+    sid = "Enable IAM User Permissions"
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:root"]
+    }
+    actions   = ["kms:*"]
+    resources = ["*"]
+  }
+
+  statement {
+    sid = "AllowDMSServerlessCompute"
+    principals {
+      type        = "Service"
+      identifiers = ["dms.amazonaws.com"]
+    }
+    actions = [
+      "kms:Decrypt",
+      "kms:DescribeKey",
+      "kms:Encrypt",
+      "kms:GenerateDataKey*",
+      "kms:ReEncrypt*",
+      "kms:CreateGrant",
+    ]
+    resources = ["*"]
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceAccount"
+      values   = [data.aws_caller_identity.current.account_id]
+    }
+  }
 }
 
 # The provisioned replication instance that used to live here is gone; the serverless


### PR DESCRIPTION
The qa BI canary (v8.4.0) caught this: the serverless replication failed at
preparing_metadata_resources with "No permission to access Key" on the BI KMS key.

compute_config.kms_key_id points at aws_kms_key.bi, which had no policy argument, so it
ran on the AWS default key policy (account root only). The old provisioned replication
instance accessed the key through its instance role and was covered by that root
statement. DMS Serverless accesses the compute key as the dms.amazonaws.com service
principal directly, which the default policy does not allow.

Fix: give the key an explicit policy that keeps the root statement and adds the DMS
service principal (Decrypt, DescribeKey, Encrypt, GenerateDataKey*, ReEncrypt*,
CreateGrant), conditioned on aws:SourceAccount. Applies in place on existing keys, no
replacement.

qa was unblocked with the same policy applied by hand; this makes it code before the
remaining BI migrations pick up the version.
