### PR TITLE
fix(physical): CDC latency alarms for serverless BI replications

### DIFF
--- a/terraform/physical/README.md
+++ b/terraform/physical/README.md
@@ -64,6 +64,8 @@
 | [aws_cloudwatch_metric_alarm.aurora_connections](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
 | [aws_cloudwatch_metric_alarm.aurora_cpu](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
 | [aws_cloudwatch_metric_alarm.aurora_memory](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
+| [aws_cloudwatch_metric_alarm.bi_cdc_latency_source](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
+| [aws_cloudwatch_metric_alarm.bi_cdc_latency_target](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
 | [aws_cloudwatch_metric_alarm.dr_replication_deadman](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
 | [aws_cloudwatch_metric_alarm.dr_s3_replication_failed](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
 | [aws_cloudwatch_metric_alarm.dr_s3_replication_latency](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |

--- a/terraform/physical/monitoring.tf
+++ b/terraform/physical/monitoring.tf
@@ -441,6 +441,65 @@ resource "aws_cloudwatch_event_target" "dms_task_state_changed_target" {
   arn       = module.sns.topic_arn
 }
 
+# --- BI serverless CDC latency alarms --- #
+#
+# Serverless replications do NOT publish under the provisioned-task dimensions
+# (ReplicationInstanceIdentifier + ReplicationTaskIdentifier); they publish under
+# a single ReplicationConfigId dimension whose value is "<account>:<config id>".
+# The config id changes every time the replication config is replaced (endpoint
+# rename, compute change), so the dimension is derived from the config ARN here
+# and follows any replacement in the same apply. Hand-created alarms keyed to a
+# task id latch into ALARM forever the moment the task is deleted.
+#
+# missing=breaching is deliberate: a deprovisioned or stuck replication emits
+# nothing, and it must page before the source's binlog retention window makes a
+# resume impossible. The 6x300s window tolerates the ~20 minute serverless
+# provisioning ladder on restarts without paging.
+locals {
+  bi_replication_config_id = local.dms_enabled ? join(":", [
+    split(":", aws_dms_replication_config.this[0].arn)[4],
+    split(":", aws_dms_replication_config.this[0].arn)[6],
+  ]) : ""
+}
+
+resource "aws_cloudwatch_metric_alarm" "bi_cdc_latency_source" {
+  count               = local.dms_enabled ? 1 : 0
+  alarm_name          = "${local.identifier}-dms-cdc-latency-source"
+  alarm_description   = "BI serverless replication ${local.identifier}: CDCLatencySource high or not reporting (missing=breaching)"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  threshold           = 900 # seconds
+  evaluation_periods  = 6
+  datapoints_to_alarm = 6
+  period              = 300
+  namespace           = "AWS/DMS"
+  metric_name         = "CDCLatencySource"
+  statistic           = "Maximum"
+  treat_missing_data  = "breaching"
+  dimensions          = { ReplicationConfigId = local.bi_replication_config_id }
+  alarm_actions       = [module.sns.topic_arn]
+  ok_actions          = [module.sns.topic_arn]
+  tags                = local.tags
+}
+
+resource "aws_cloudwatch_metric_alarm" "bi_cdc_latency_target" {
+  count               = local.dms_enabled ? 1 : 0
+  alarm_name          = "${local.identifier}-dms-cdc-latency-target"
+  alarm_description   = "BI serverless replication ${local.identifier}: CDCLatencyTarget high or not reporting (missing=breaching)"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  threshold           = 900 # seconds
+  evaluation_periods  = 6
+  datapoints_to_alarm = 6
+  period              = 300
+  namespace           = "AWS/DMS"
+  metric_name         = "CDCLatencyTarget"
+  statistic           = "Maximum"
+  treat_missing_data  = "breaching"
+  dimensions          = { ReplicationConfigId = local.bi_replication_config_id }
+  alarm_actions       = [module.sns.topic_arn]
+  ok_actions          = [module.sns.topic_arn]
+  tags                = local.tags
+}
+
 // -- Slack Notification Lambda
 
 # Content-based archive: zips the file's BYTES (not the on-disk file with its

--- a/terraform/physical/monitoring.tf
+++ b/terraform/physical/monitoring.tf
@@ -453,8 +453,14 @@ resource "aws_cloudwatch_event_target" "dms_task_state_changed_target" {
 #
 # missing=breaching is deliberate: a deprovisioned or stuck replication emits
 # nothing, and it must page before the source's binlog retention window makes a
-# resume impossible. The 6x300s window tolerates the ~20 minute serverless
-# provisioning ladder on restarts without paging.
+# resume impossible. The 6x300s window only softens the case where an
+# ESTABLISHED metric stops (last real datapoint must age out, ~30min). A new
+# metric identity - greenfield env, or any config replacement rotating the
+# dimension value - has no datapoints, so every lookback slot counts as
+# breaching and the alarm pages at its first evaluation, staying in ALARM
+# until the logical layer starts the replication. That page is accurate (BI
+# is not replicating) and expected during those windows; do not "fix" it by
+# switching to notBreaching, which trades it for silent BI death.
 locals {
   bi_replication_config_id = local.dms_enabled ? join(":", [
     split(":", aws_dms_replication_config.this[0].arn)[4],


### PR DESCRIPTION
Serverless DMS replications publish CloudWatch metrics under a single `ReplicationConfigId` dimension (`<account>:<config id>`), not the provisioned-task `ReplicationInstanceIdentifier` + `ReplicationTaskIdentifier` pair. The CDC latency alarms that existed for BI were hand-created against task ids, so the serverless migration deleted their tasks and latched them into permanent ALARM with `missing=breaching`, blind to the replacement replications. Those hand alarms have been deleted out-of-band.

This adds the alarms to the physical module, keyed on `ReplicationConfigId` derived from the replication config ARN, so any future config replacement (endpoint rename, compute change) updates the alarm dimension in the same apply.

Design notes:
- `missing=breaching` is kept on purpose: a deprovisioned or stuck replication emits nothing, and it has to page before the source's binlog retention window makes a resume impossible.
- Missing-data semantics, stated honestly: the 6x300s window only delays the page when an established metric stops emitting (~30 min for the last datapoint to age out). A new metric identity (greenfield env, or any config replacement rotating the dimension) has no datapoints at all, so the alarm pages at its first evaluation and stays in ALARM until the logical layer starts the replication. That page is accurate (BI is not replicating during that window) and expected during swaps; switching to `notBreaching` would trade it for silent BI death.
- Alarm names match the previous hand-created ones, so any leftover stale alarm gets upserted by `PutMetricAlarm` instead of duplicated.
- Gated on `local.dms_enabled`, same as the replication config itself.