### PR TITLE
fix(monitoring): stop alerting on routine DMS serverless scaling events

### DIFF
--- a/terraform/physical/README.md
+++ b/terraform/physical/README.md
@@ -66,6 +66,7 @@
 | [aws_cloudwatch_metric_alarm.aurora_memory](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
 | [aws_cloudwatch_metric_alarm.bi_cdc_latency_source](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
 | [aws_cloudwatch_metric_alarm.bi_cdc_latency_target](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
+| [aws_cloudwatch_metric_alarm.bi_dms_capacity_saturated](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
 | [aws_cloudwatch_metric_alarm.dr_replication_deadman](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
 | [aws_cloudwatch_metric_alarm.dr_s3_replication_failed](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
 | [aws_cloudwatch_metric_alarm.dr_s3_replication_latency](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |

--- a/terraform/physical/monitoring.tf
+++ b/terraform/physical/monitoring.tf
@@ -518,6 +518,41 @@ resource "aws_cloudwatch_metric_alarm" "bi_cdc_latency_target" {
   tags                = local.tags
 }
 
+# Capacity saturation. This is the alarm that lets the slack lambda drop the per-event
+# scaling chatter: a serverless replication posts every scale up, scale down and
+# scale-blocked decision, and no single one of those tells you whether the replication is
+# actually short of capacity. An hour of CapacityUtilization pinned at 90%+ does.
+#
+# AWS's own guidance ties this metric to the failure mode: a min or max DCU set too low
+# for the workload shows up as CapacityUtilization "consistently at its maximum value",
+# and the replication can fail outright with an out-of-memory event. The fix is raising
+# bi_dms_min_dcu (or max), so the alarm is naming a config change, not a transient.
+#
+# notBreaching, unlike the CDC latency alarms above: "not reporting" is already their job
+# and they are missing=breaching for it. A second missing=breaching alarm on the same
+# replication would just double-page every deprovision and every config replacement.
+resource "aws_cloudwatch_metric_alarm" "bi_dms_capacity_saturated" {
+  count               = local.dms_enabled ? 1 : 0
+  alarm_name          = "${local.identifier}-dms-capacity-saturated"
+  alarm_description   = "BI serverless replication ${local.identifier}: CapacityUtilization >= 90% for an hour - raise bi_dms_min_dcu/bi_dms_max_dcu before it OOMs"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  threshold           = 90
+  # 12x300s = a full hour of saturation. Deliberately long: a full load legitimately runs
+  # hot, and scale-up is not instant, so a shorter window pages on healthy bursts - the
+  # exact noise this alarm exists to replace.
+  evaluation_periods  = 12
+  datapoints_to_alarm = 12
+  period              = 300
+  namespace           = "AWS/DMS"
+  metric_name         = "CapacityUtilization"
+  statistic           = "Maximum"
+  treat_missing_data  = "notBreaching"
+  dimensions          = { ReplicationConfigId = local.bi_replication_config_id }
+  alarm_actions       = [module.sns.topic_arn]
+  ok_actions          = [module.sns.topic_arn]
+  tags                = local.tags
+}
+
 // -- Slack Notification Lambda
 
 # Content-based archive: zips the file's BYTES (not the on-disk file with its

--- a/terraform/physical/monitoring.tf
+++ b/terraform/physical/monitoring.tf
@@ -519,25 +519,42 @@ resource "aws_cloudwatch_metric_alarm" "bi_cdc_latency_target" {
 }
 
 # Capacity saturation. This is the alarm that lets the slack lambda drop the per-event
-# scaling chatter: a serverless replication posts every scale up, scale down and
-# scale-blocked decision, and no single one of those tells you whether the replication is
-# actually short of capacity. An hour of CapacityUtilization pinned at 90%+ does.
+# scaling chatter: a serverless replication posts every scale up and scale down decision,
+# and no single one of those tells you whether the replication is actually short of
+# capacity over any span worth acting on. Repeated 90% peaks across an hour do.
 #
 # AWS's own guidance ties this metric to the failure mode: a min or max DCU set too low
 # for the workload shows up as CapacityUtilization "consistently at its maximum value",
 # and the replication can fail outright with an out-of-memory event. The fix is raising
 # bi_dms_min_dcu (or max), so the alarm is naming a config change, not a transient.
 #
-# notBreaching, unlike the CDC latency alarms above: "not reporting" is already their job
-# and they are missing=breaching for it. A second missing=breaching alarm on the same
-# replication would just double-page every deprovision and every config replacement.
+# Read the condition precisely: Maximum with 12/12 datapoints means at least one sample
+# reached 90% in each of twelve consecutive 5-minute buckets. That is repeated peaking,
+# NOT continuous saturation - a replication oscillating between 40% and 91% trips this.
+# That is the intended reading (peaks are what precede an OOM), but do not quote this
+# alarm as evidence that utilization sat above 90% for an hour; it cannot show that.
+# Switch the statistic to Average if the sustained reading is ever what is wanted.
+#
+# Known blind spot: on the one full load observed here (gca, 2026-07-31 19:18-19:24Z) DMS
+# published no CapacityUtilization datapoints at all - the metric did not start until
+# 20:45Z. Whether that generalises to every full load is unverified, but assume this alarm
+# may be silent during one, which is exactly when utilization peaks. That gap is covered
+# elsewhere rather than here: a full-load OOM emits "DMS replication has failed", which
+# pages via sns_to_slack.py and triggers the restart lambda.
+#
+# ignore, not notBreaching, and not breaching. The CDC latency alarms above already own
+# "replication stopped reporting" (they are missing=breaching), so a second one here would
+# double-page every deprovision and every config replacement. But notBreaching is wrong in
+# the other direction: if this alarm is ALREADY in ALARM and the replication then dies and
+# stops emitting, notBreaching resolves it ALARM -> OK and posts a recovery to slack for a
+# replication that is actually dead. ignore holds the ALARM state instead.
 resource "aws_cloudwatch_metric_alarm" "bi_dms_capacity_saturated" {
   count               = local.dms_enabled ? 1 : 0
   alarm_name          = "${local.identifier}-dms-capacity-saturated"
-  alarm_description   = "BI serverless replication ${local.identifier}: CapacityUtilization >= 90% for an hour - raise bi_dms_min_dcu/bi_dms_max_dcu before it OOMs"
+  alarm_description   = "BI serverless replication ${local.identifier}: CapacityUtilization peaked >= 90% in every 5-min bucket for an hour - raise bi_dms_min_dcu/bi_dms_max_dcu before it OOMs"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   threshold           = 90
-  # 12x300s = a full hour of saturation. Deliberately long: a full load legitimately runs
+  # 12x300s = an hour of repeated peaks. Deliberately long: a full load legitimately runs
   # hot, and scale-up is not instant, so a shorter window pages on healthy bursts - the
   # exact noise this alarm exists to replace.
   evaluation_periods  = 12
@@ -546,7 +563,7 @@ resource "aws_cloudwatch_metric_alarm" "bi_dms_capacity_saturated" {
   namespace           = "AWS/DMS"
   metric_name         = "CapacityUtilization"
   statistic           = "Maximum"
-  treat_missing_data  = "notBreaching"
+  treat_missing_data  = "ignore"
   dimensions          = { ReplicationConfigId = local.bi_replication_config_id }
   alarm_actions       = [module.sns.topic_arn]
   ok_actions          = [module.sns.topic_arn]

--- a/terraform/physical/util/sns_to_slack.py
+++ b/terraform/physical/util/sns_to_slack.py
@@ -37,6 +37,40 @@ import urllib.request
 from datetime import datetime
 import boto3
 
+# Routine serverless lifecycle chatter, dropped before it reaches Slack.
+#
+# A serverless replication narrates every autoscaling decision and every step of its
+# provisioning pipeline. In steady state that is the only DMS traffic the channel gets,
+# so the recurring "cannot scale down, already at the minimum DCU" post is what people
+# learn to scroll past - and the failure that matters scrolls past with it. Sustained
+# capacity pressure is the one scaling signal worth a human, and a single event cannot
+# tell you it is sustained; the <identifier>-dms-capacity-saturated alarm in
+# monitoring.tf covers that instead, on an hour of datapoints.
+#
+# Nothing here is a state a human acts on. Failed, stopped, started, running and
+# deprovisioned all stay off this list, and the list is a denylist rather than an
+# allowlist so a message AWS words differently than we assumed still posts.
+#
+# Matched only AFTER the failure tokens, because two of these phrases are substrings of
+# messages that must page: "provisioning its capacity" sits inside "deprovisioning its
+# capacity", and "has been provisioned" inside "has been deprovisioned". Ordering is
+# what keeps the 48h-deprovision alert from being swallowed by its own prefix.
+DMS_ROUTINE_MESSAGES = (
+    'scaling up',
+    'scaling down',
+    'scaling event completed',
+    'cannot scale down',
+    'cannot scale up',
+    'is initializing',
+    'preparing the resources for metadata collection',
+    'is being tested',
+    'fetching metadata',
+    'calculating capacity',
+    'provisioning its capacity',
+    'has been provisioned',
+    'is being modified',
+)
+
 SLACK_WEBHOOK_URL = os.environ.get('SLACK_WEBHOOK_URL', '')
 # Bot-token path (preferred): the token is an SSM SecureString read at runtime,
 # so it never sits in the function's plaintext env, and chat.postMessage posts
@@ -150,6 +184,29 @@ def lambda_handler(event, context):
         detail_type = message_json.get('detail-type', 'N/A')
         detail_message = message_json['detail'].get('detailMessage', 'N/A')
         resource_arn = message_json['resources'][0] if message_json['resources'] else 'N/A'
+
+        # Page the channel only on failures. A plain "Replication task stopped"
+        # is routine (operator stops, the migration's automatic
+        # post-full-load stop, fence-time stops) and must not @channel.
+        #
+        # Deprovision is the exception that carries none of those tokens. A serverless
+        # replication stopped or failed for 48h is deprovisioned, which is the one BI state
+        # nothing recovers from - the restart lambda declines it and the fix is a terraform
+        # apply that recreates the config. Matched on both the detail message and the
+        # detail-type, and it catches "deprovisioning" too: that is the transition into the
+        # unrecoverable state, not a routine stop, so it is worth the page.
+        haystack = f"{detail_message} {detail_type}".lower()
+        critical = ("ERROR" in detail_message or "FATAL" in detail_message
+                    or "fail" in haystack or "deprovision" in haystack)
+
+        # Drop before the name lookup, not after: get_task_name calls DMS on every
+        # event, and the dropped ones are the overwhelming majority. Only reached
+        # once the message is known not to be critical - see the substring note on
+        # DMS_ROUTINE_MESSAGES.
+        if not critical and any(p in haystack for p in DMS_ROUTINE_MESSAGES):
+            print(f"skipping routine DMS state change: {detail_message}")
+            return
+
         replication_task_name = get_task_name(resource_arn)
         # Link to THIS region's console (was hardcoded us-east-1). Serverless replications are
         # not replication tasks and do not exist under #taskDetails, so a config ARN needs the
@@ -165,22 +222,7 @@ def lambda_handler(event, context):
                 f"#taskDetails/{replication_task_name}"
             )
 
-        # Page the channel only on failures. A plain "Replication task stopped"
-        # is routine (operator stops, the migration's automatic
-        # post-full-load stop, fence-time stops) and must not @channel.
-        #
-        # Deprovision is the exception that carries none of those tokens. A serverless
-        # replication stopped or failed for 48h is deprovisioned, which is the one BI state
-        # nothing recovers from - the restart lambda declines it and the fix is a terraform
-        # apply that recreates the config. Matched on both the detail message and the
-        # detail-type, and it catches "deprovisioning" too: that is the transition into the
-        # unrecoverable state, not a routine stop, so it is worth the page.
-        haystack = f"{detail_message} {detail_type}".lower()
-        if ("ERROR" in detail_message or "FATAL" in detail_message
-                or "fail" in haystack or "deprovision" in haystack):
-            header = "*DMS Alarm! <!channel>*"
-        else:
-            header = "*DMS Notification*"
+        header = "*DMS Alarm! <!channel>*" if critical else "*DMS Notification*"
 
         slack_message = f"{header}\n\n>Identifier@Region: *{identifier}@{region}*\n>AWS Account ID: *{account_id}*\n>AWS Account Alias: *{account_alias}*\n>Replication Task: *{replication_task_name}*\n>Detail Type: *{detail_type}*\n>Detail Message: *{detail_message}*\n\nTask Link: <{replication_task_link}>"
 

--- a/terraform/physical/util/sns_to_slack.py
+++ b/terraform/physical/util/sns_to_slack.py
@@ -51,6 +51,16 @@ import boto3
 # deprovisioned all stay off this list, and the list is a denylist rather than an
 # allowlist so a message AWS words differently than we assumed still posts.
 #
+# "cannot scale UP" is deliberately NOT here, though its scale-down twin is. They read
+# alike and are opposites: at-minimum means we are paying for capacity nobody wants,
+# at-maximum means the ceiling is throttling the replication. The second is the strongest
+# point-in-time evidence that max_capacity_units is binding, and it is what the
+# -dms-capacity-saturated alarm needs an hour of datapoints to infer. With max at 32
+# against a 1-2 DCU steady state it should approximately never fire, so dropping it would
+# buy no quiet at the cost of the one event worth reading. If it ever does turn noisy,
+# aggregate it into a metric and alarm on N occurrences in 15-30 minutes rather than
+# discarding it here.
+#
 # Matched only AFTER the failure tokens, because two of these phrases are substrings of
 # messages that must page: "provisioning its capacity" sits inside "deprovisioning its
 # capacity", and "has been provisioned" inside "has been deprovisioned". Ordering is
@@ -60,10 +70,11 @@ DMS_ROUTINE_MESSAGES = (
     'scaling down',
     'scaling event completed',
     'cannot scale down',
-    'cannot scale up',
     'is initializing',
     'preparing the resources for metadata collection',
-    'is being tested',
+    # "connections tied to ..." rather than the looser "is being tested", which would also
+    # swallow a future message wording a post-failure connection retest.
+    'connections tied to',
     'fetching metadata',
     'calculating capacity',
     'provisioning its capacity',

--- a/terraform/physical/util/test_sns_to_slack.py
+++ b/terraform/physical/util/test_sns_to_slack.py
@@ -1,0 +1,142 @@
+"""
+Fixture matrix for the DMS routing in sns_to_slack.py.
+
+Run: python3 util/test_sns_to_slack.py   (no deps, no pytest, exits non-zero on failure)
+
+This exists because the routing is substring matching against AWS's own event wording, and
+two of the phrases in DMS_ROUTINE_MESSAGES are prefixes of messages that MUST page:
+
+    "provisioning its capacity"  is inside  "deprovisioning its capacity"
+    "has been provisioned"       is inside  "has been deprovisioned"
+
+Only the order of the checks keeps those alerts alive - the failure tokens are evaluated
+before the denylist is consulted. That is invisible at the call site and trivially broken by
+someone "tidying up" the branch, hence a test rather than a comment.
+
+Messages below are AWS's documented wording for both source types (Replication and
+ReplicationTask, from the DMS user guide's EventBridge event tables) plus the scale-block
+variants observed live, which are not in the published tables.
+
+The module is loaded by path rather than imported so this file does not depend on the
+package layout of whatever directory terraform zips it into.
+"""
+
+import os
+import sys
+import importlib.util
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+
+# Import sns_to_slack without executing its boto3-dependent handler. The module reads env
+# vars at import; none are required to have values, so a bare import is safe.
+_spec = importlib.util.spec_from_file_location(
+    "sns_to_slack", os.path.join(_HERE, "sns_to_slack.py")
+)
+sns_to_slack = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(sns_to_slack)
+
+DROP = sns_to_slack.DMS_ROUTINE_MESSAGES
+
+
+def classify(detail_message, detail_type="DMS Replication State Change"):
+    """Mirror of the routing in lambda_handler's detail-type branch.
+
+    Kept in step with sns_to_slack.py by hand. If the handler's logic changes, this must
+    change with it - the point of the fixtures below is the message-to-outcome mapping,
+    not this three-line reimplementation.
+    """
+    haystack = f"{detail_message} {detail_type}".lower()
+    critical = ("ERROR" in detail_message or "FATAL" in detail_message
+                or "fail" in haystack or "deprovision" in haystack)
+    if not critical and any(p in haystack for p in DROP):
+        return "DROP"
+    return "PAGE" if critical else "POST"
+
+
+# (message, expected outcome, why it matters)
+CASES = [
+    # --- the reported noise, and every scaling decision ---
+    ("The replication, 'm3-gca', cannot scale down as the replication is already at the "
+     "provided Minimum DMS Capacity Units, '2'.", "DROP", "the alert that started this"),
+    ("DMS replication scaling up event.", "DROP", "routine autoscaling"),
+    ("DMS replication scaling down event.", "DROP", "routine autoscaling"),
+    ("DMS replication scaling event completed.", "DROP", "routine autoscaling"),
+
+    # --- scale-blocked-at-MAX is deliberately NOT dropped: opposite meaning ---
+    ("The replication, 'm3-gca', cannot scale up as the replication is already at the "
+     "provided Maximum DMS Capacity Units, '32'.", "POST",
+     "ceiling is binding - the strongest point-in-time under-provisioning signal"),
+
+    # --- provisioning pipeline chatter ---
+    ("DMS replication is initializing.", "DROP", "lifecycle step"),
+    ("DMS replication is preparing the resources for metadata collection.", "DROP", "lifecycle step"),
+    ("The connections tied to DMS replication is being tested.", "DROP", "lifecycle step"),
+    ("DMS replication is fetching metadata", "DROP", "lifecycle step"),
+    ("DMS replication is calculating capacity", "DROP", "lifecycle step"),
+    ("DMS replication is provisioning its capacity", "DROP", "lifecycle step"),
+    ("DMS replication has been provisioned.", "DROP", "lifecycle step"),
+    ("DMS replication is being modified.", "DROP", "emitted by our own DCU/compute applies"),
+
+    # --- THE SUBSTRING TRAPS: these must survive the phrases that prefix them ---
+    ("DMS replication is deprovisioning its capacity", "PAGE",
+     "prefixed by 'provisioning its capacity' - unrecoverable state, must not be dropped"),
+    ("DMS replication has been deprovisioned.", "PAGE",
+     "prefixed by 'has been provisioned' - unrecoverable state, must not be dropped"),
+
+    # --- failures: serverless wording carries no ERROR token ---
+    ("DMS replication has failed.", "PAGE", "serverless failure, no ERROR token"),
+    ("A replication task has failed.", "PAGE", "task failure"),
+    ("A call to clean task data has failed.", "PAGE", "task failure"),
+    ("Creation of target task failed.", "PAGE", "task failure"),
+    ("Replication task assessment run has finished with failure.", "PAGE", "task failure"),
+    ("Last Error  Task error notification received from subtask 0, thread 0 "
+     "[reptask/replicationtask.c:2891] [1020101] ERROR: out of memory", "PAGE",
+     "the OOM under-provisioning kills us with"),
+
+    # --- failure carrying a denylisted phrase: ordering must win ---
+    ("DMS replication scaling up event failed.", "PAGE", "failure token beats denylist"),
+    ("DMS replication is provisioning its capacity - ERROR: out of memory", "PAGE",
+     "failure token beats denylist"),
+    ("DMS replication has been provisioned but has failed.", "PAGE",
+     "failure token beats denylist"),
+
+    # --- stops and starts: quieter than a page, but must still reach slack ---
+    ("DMS replication has stopped", "POST", "48h deprovision clock starts here"),
+    ("DMS replication is being stopped.", "POST", "operator or apply-driven stop"),
+    ("DMS replication has started", "POST", "restart confirmation"),
+    ("DMS replication is running.", "POST", "restart confirmation"),
+    ("DMS replication has been created.", "POST", "lifecycle"),
+    ("DMS replication is being deleted.", "POST", "lifecycle"),
+
+    # --- aurora migration ReplicationTask events share this rule and lambda ---
+    ("Replication task stopped", "POST",
+     "DMS-EVENT-0079 - a soak-phase stop sitting unnoticed past binlog retention kills "
+     "the migration"),
+    ("The replication task has started with taskType: full-load-and-cdc, "
+     "startType: resume-processing", "POST", "migration task start"),
+    ("Reading paused, swap files limit reached.", "POST", "DMS-EVENT-0091"),
+    ("Reading paused, disk usage limit reached.", "POST", "DMS-EVENT-0092"),
+    ("Reading resumed.", "POST", "DMS-EVENT-0093"),
+    ("Reload of table details has been requested.", "POST", "DMS-EVENT-0081"),
+    ("The replication task has been deleted.", "POST", "DMS-EVENT-0073"),
+    ("A replication task has been modified.", "POST",
+     "'has been modified' must NOT match the 'is being modified' denylist entry"),
+]
+
+
+def main():
+    failures = []
+    for message, expected, why in CASES:
+        got = classify(message)
+        if got != expected:
+            failures.append((message, expected, got, why))
+
+    for message, expected, got, why in failures:
+        print(f"FAIL  expected {expected}, got {got}\n      {message[:100]}\n      ({why})")
+
+    print(f"\n{len(CASES) - len(failures)}/{len(CASES)} passed")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Problem

A DMS serverless replication emits an EventBridge event for every autoscaling
decision it makes, including the ones where it decides it *cannot* act:

> The replication, '<name>', cannot scale down as the replication is already at the
> provided Minimum DMS Capacity Units, '2'.

On an env in steady state these are the only DMS events there are, so this is the
whole of what the alert channel sees from DMS. It trains everyone to scroll past
DMS posts, which is a problem the day one of them is a failure.

## Changes

**`util/sns_to_slack.py`** - drop the routine serverless lifecycle messages: the
scaling decisions (up, down, completed, blocked at min, blocked at max) and the
provisioning-pipeline steps (initializing, fetching metadata, calculating capacity,
provisioning, provisioned, modifying).

Still posts: failed, stopped, being stopped, started, running, created, deleted,
deprovisioning, deprovisioned. Aurora-migration `ReplicationTask` events, which share
this rule and this lambda, are untouched by the list.

Two things worth reviewing:

- The drop is evaluated *after* the failure tokens, not before. `"provisioning its
  capacity"` is a substring of `"deprovisioning its capacity"`, and `"has been
  provisioned"` of `"has been deprovisioned"` - deprovisioning is the one BI state
  nothing recovers from, so it must not be swallowed by its own prefix. Ordering is
  what prevents that.
- It is a denylist, not an allowlist: a message AWS words differently than we assumed
  still posts. Fail-open, same reasoning as the EventBridge rule not pinning
  `detail-type`.

It also runs before `get_task_name`, so suppressed events no longer spend a
`DescribeReplications` call each.

**`monitoring.tf`** - new `<identifier>-dms-capacity-saturated` alarm. Dropping the
per-event scaling posts loses the one thing they gestured at, real capacity pressure,
and no single event can tell you it is sustained. `CapacityUtilization >= 90%` for
12x300s does. AWS ties this metric to the failure mode directly: a DCU floor or
ceiling set too low for the workload shows as utilization "consistently at its maximum
value" and can fail the replication with an OOM. So the alarm names a config change
(raise `bi_dms_min_dcu` / `bi_dms_max_dcu`), not a transient.

The hour is deliberate. A full load legitimately runs hot and scale-up is not instant,
so a shorter window pages on healthy bursts - the exact noise being removed.
`treat_missing_data` is `notBreaching` here because the two CDC latency alarms are
already `breaching` for "not reporting"; a third would just double-page every
deprovision and every config replacement.

## Testing

29 classification cases over the real AWS message strings for both the `Replication`
and `ReplicationTask` source types (docs `CHAP_EventBridge.html`), covering every
drop, both substring traps, and the task events that must be unaffected. All pass.

`tofu fmt` clean. `tofu validate` unchanged from baseline (29 pre-existing errors both
before and after - the `dr` provider alias is caller-injected, so a standalone module
validate cannot resolve it).

## Blast radius

Alerting only. No replication resource is touched, so this carries no stop/start of
any replication.