### PR TITLE
fix(logical): select the on-demand nodepool by name, not by capacity-type

### DIFF
--- a/terraform/logical/flux.tf
+++ b/terraform/logical/flux.tf
@@ -242,7 +242,16 @@ locals {
   # chart they would make these pods unschedulable there. Same reason the chart's
   # dozuki.onDemand* helpers gate on aws.enabled. The `for..if` idiom (not cond?{}:{})
   # matches app_azure_values - see the type-unification note above it.
-  stateful_node_selector = { "karpenter.sh/capacity-type" = "on-demand" }
+  #
+  # Select the pool by NAME, not by capacity-type. capacity-type is an attribute the spot
+  # pool also sets: it requests capacity-type In [spot, on-demand] as an ICE fallback, so a
+  # spot-pool node running on-demand capacity carries capacity-type=on-demand and satisfies
+  # this selector. With the spot pool outweighing this one 100 to 10 it won every time, the
+  # on-demand pool never launched a node at all, and its NoSchedule taint therefore never
+  # kept anything off these nodes - opensearch shared a node with untainted workloads until
+  # the node ran out of page cache. Naming the pool is what actually engages both the taint
+  # and the pool's WhenEmpty disruption policy (2026-08-01).
+  stateful_node_selector = { "karpenter.sh/nodepool" = "on-demand" }
   stateful_tolerations = [{
     key      = "eks.amazonaws.com/capacity-type"
     operator = "Equal"


### PR DESCRIPTION
## What

The stateful workload node selector matched a capacity attribute instead of pool identity: `{ "karpenter.sh/capacity-type" = "on-demand" }`. That attribute isn't unique to the on-demand NodePool. The spot NodePool requests `capacity-type In [spot, on-demand]` as an ICE (insufficient capacity) fallback, so any spot-pool node that actually launched on on-demand capacity also carries `capacity-type=on-demand` and satisfies the selector.

With the spot pool weighted 100 against the on-demand pool's 10, the spot pool won the scheduling race every time. The consequence: the on-demand pool has never launched a node, its `NoSchedule` taint has therefore never applied to anything, and the four EBS-backed workloads this selector targets (opensearch, prometheus, alertmanager, dashboards-grafana) have been sharing spot-pool nodes with untainted workloads instead of landing on dedicated on-demand capacity.

The fix selects the pool by name (`karpenter.sh/nodepool = on-demand`) instead of by the shared capacity-type attribute. This is unambiguous and engages both the taint and the on-demand pool's `WhenEmpty` disruption policy as intended.

## Rollout risk

This is the first time the on-demand NodePool will actually launch a node in any environment. Each of the four affected workloads owns a zonal EBS volume, so when it first reschedules onto the on-demand pool it gets a detach-then-reattach of that volume in the AZ its PVC is pinned to. There is no live handoff, only pod downtime for the reschedule.

Logical stacks autodeploy on merge, so the actual gate is whichever environment next bumps `infra_version`. Recommend rolling one expendable/non-critical environment first and watching the four workloads reschedule cleanly before letting it ride into anything customer-facing.

This does not address the memory budget on 4 GiB nodes; that's tracked separately.
