### PR TITLE
fix(logical): floor the on-demand nodepool at >4GiB of instance memory

### DIFF
--- a/terraform/logical/kubernetes.tf
+++ b/terraform/logical/kubernetes.tf
@@ -380,18 +380,34 @@ resource "kubernetes_manifest" "nodepool_on_demand" {
                 operator = "Gt"
                 values   = ["4"]
               },
-              # Memory floor, on top of the category/generation one. Everything
-              # pinned here (the app tier, and via app_stateful_scheduling in
-              # flux.tf: opensearch, prometheus, alertmanager, grafana) wants a
-              # node bigger than 4GiB, but nothing was enforcing it. A 4GiB shape
-              # leaves ~3106Mi allocatable and opensearch requests 3Gi (3072Mi),
-              # so it FITS - it stayed off c5a.large only because the AWS
-              # DaemonSets (cloudwatch-agent 128Mi + fluent-bit 25Mi) ate the
-              # difference, leaving a 119Mi accident that any addon-request
-              # change in another repo could erase. Land there and opensearch
-              # gets 800 baseline EBS IOPS and no page cache to speak of.
+              # Memory floor, on top of the category/generation one. This exists
+              # for the workloads whose requests can never express what they
+              # need, NOT to top up an under-request.
+              #
+              # Requests are the right tool when a pod simply asks for too
+              # little, and opensearch is that case - it is sized in the chart
+              # and lands where its request says. Prometheus is the case
+              # requests cannot solve. It requests 1536Mi and backs a 50Gi TSDB,
+              # so it fits a 4GiB shape honestly, by the numbers, and Karpenter
+              # will keep bin-packing it there forever. What it actually needs is
+              # the ~1.4GiB of headroom that is left over for page cache after
+              # the request, plus the EBS baseline that comes with a larger
+              # shape; neither is something a request can ask for. Raising its
+              # request to reserve page cache would be lying about the working
+              # set to get an instance size, which is how you end up with a
+              # request nobody can explain two years from now.
+              #
+              # Alertmanager (200Mi) and grafana (nothing at all until the chart
+              # fix) are the same shape of problem, smaller: correctly sized or
+              # not, they get stacked onto whatever 4GiB node has nominal room.
+              #
               # Units are mebibytes and Gt takes exactly one value, so >4096
               # drops c*.large and makes m*.large (8GiB) the smallest node.
+              #
+              # Inert until the selector fix lands. Anything pinned by
+              # capacity-type rather than by nodepool name never reaches this
+              # pool, so this requirement had nothing to apply to; ship the two
+              # together.
               {
                 key      = "eks.amazonaws.com/instance-memory"
                 operator = "Gt"

--- a/terraform/logical/kubernetes.tf
+++ b/terraform/logical/kubernetes.tf
@@ -379,6 +379,23 @@ resource "kubernetes_manifest" "nodepool_on_demand" {
                 key      = "eks.amazonaws.com/instance-generation"
                 operator = "Gt"
                 values   = ["4"]
+              },
+              # Memory floor, on top of the category/generation one. Everything
+              # pinned here (the app tier, and via app_stateful_scheduling in
+              # flux.tf: opensearch, prometheus, alertmanager, grafana) wants a
+              # node bigger than 4GiB, but nothing was enforcing it. A 4GiB shape
+              # leaves ~3106Mi allocatable and opensearch requests 3Gi (3072Mi),
+              # so it FITS - it stayed off c5a.large only because the AWS
+              # DaemonSets (cloudwatch-agent 128Mi + fluent-bit 25Mi) ate the
+              # difference, leaving a 119Mi accident that any addon-request
+              # change in another repo could erase. Land there and opensearch
+              # gets 800 baseline EBS IOPS and no page cache to speak of.
+              # Units are mebibytes and Gt takes exactly one value, so >4096
+              # drops c*.large and makes m*.large (8GiB) the smallest node.
+              {
+                key      = "eks.amazonaws.com/instance-memory"
+                operator = "Gt"
+                values   = ["4096"]
               }
             ]
             taints = [


### PR DESCRIPTION
## What

Adds an `eks.amazonaws.com/instance-memory` `Gt: ["4096"]` requirement to the `on-demand` NodePool, alongside the existing category/generation floor.

## Why

This is for the workloads whose requests can never express what they need. It is not a way to top up an under-request.

Requests are the right tool when a pod simply asks for too little, and opensearch is that case: it is sized in the chart and lands where its request says. **Prometheus is the case requests cannot solve.** It requests 1536Mi and backs a 50Gi TSDB, so it fits a 4GiB shape honestly, by the numbers, and Karpenter will keep bin-packing it there indefinitely. What it actually needs is the ~1.4GiB of headroom left over for page cache after the request, plus the EBS baseline that comes with a larger shape. Neither is something a request can ask for, and raising the request to reserve page cache would be lying about the working set to get an instance size.

Alertmanager (200Mi) and grafana (no requests at all until the chart fix) are the same problem, smaller: correctly sized or not, they get stacked onto whatever 4GiB node has nominal room.

Measured on a live c5a.large: allocatable 3180964Ki = 3106Mi, less the AWS DaemonSets (cloudwatch-agent 128Mi + fluent-bit 25Mi) = ~2953Mi schedulable. Room for all three of the above at once, on a node with 800 baseline EBS IOPS.

## Sequencing

**Inert on its own.** Everything targeting this pool selects it by `capacity-type`, which the spot pool also satisfies, so nothing has ever reached the on-demand pool for this requirement to apply to. #407 fixes that selector. Ship both in the same `infra_version` bump: #407 alone puts real workloads on the pool with no floor, this alone changes nothing.

## Notes

- Units are mebibytes, and Karpenter's `Gt` takes exactly one value. `> 4096` drops `c*.large` and makes `m*.large` (8GiB) the smallest shape the pool can buy.
- Scoped to the on-demand pool only. The spot pool keeps its 4GiB-capable shapes for the general small workloads (operator, cert-manager, ESO, external-dns, gateway).
- Instance selection only, no replacement of running nodes. Existing nodes are unaffected until they expire or drift.