### PR TITLE
chore(renovate): harden update policy

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -15,7 +15,8 @@ jobs:
       matrix:
         include:
           # The physical layer uses the rds-aurora module (master_password_wo),
-          # which requires Terraform/OpenTofu >= 1.11.1 — run it on OpenTofu 1.12.x.
+          # which requires Terraform/OpenTofu >= 1.11.1 — run it on the fleet's
+          # OpenTofu 1.11.8.
           - module: physical
             tool: tofu
           # The logical layer moved to OpenTofu: it uses provider for_each (azurerm
@@ -23,6 +24,11 @@ jobs:
           # stacks run OPEN_TOFU. Validate it with tofu, not Terraform 1.5.7.
           - module: logical
             tool: tofu
+          # Azure bundles are assembled and validated with Terraform 1.13.4.
+          # Validate the source layer on PRs too, before an azure-v* tag tries to
+          # assemble a release from it.
+          - module: physical-azure
+            tool: terraform
 
     # Use the Bash shell regardless whether the GitHub Actions runner is ubuntu-latest, macos-latest, or windows-latest
     defaults:
@@ -47,10 +53,10 @@ jobs:
       if: matrix.tool == 'terraform'
       uses: hashicorp/setup-terraform@v3
       with:
-        terraform_version: 1.5.7
+        terraform_version: 1.13.4
 
     - name: ${{ matrix.module }} Module Init
-      run: ${{ matrix.tool }} init
+      run: ${{ matrix.tool }} init -backend=false -input=false
       working-directory: ./terraform/${{ matrix.module }}
 
     # Checks that all configuration files adhere to a canonical format
@@ -58,8 +64,16 @@ jobs:
       run: ${{ matrix.tool }} fmt -check
       working-directory: ./terraform/${{ matrix.module }}
 
-    # Performs linting on the Terraform files
+    - name: Validate
+      if: matrix.module == 'physical-azure'
+      run: ${{ matrix.tool }} validate
+      working-directory: ./terraform/${{ matrix.module }}
+
+    # This action is configured with the AWS ruleset below. physical-azure has no
+    # Azure TFLint plugin/config in the repo, so init + fmt + validate are its
+    # meaningful credential-free PR gates; do not run AWS rules against it.
     - name: Terraform Linter
+      if: matrix.module != 'physical-azure'
       uses: reviewdog/action-tflint@v1
       with:
         github_token: ${{ secrets.github_token }}

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,19 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended"],
+  "extends": [
+    "config:recommended",
+    ":configMigration",
+    "docker:pinDigests",
+    "helpers:pinGitHubActionDigests"
+  ],
+  "ignorePresets": [":ignoreModulesAndTests"],
+  "ignorePaths": [
+    "**/node_modules/**",
+    "**/bower_components/**",
+    "**/vendor/**",
+    "**/examples/**",
+    "**/__fixtures__/**"
+  ],
   "description": [
     "The committed .terraform.lock.hcl stops silent provider upgrades. This file is what keeps them flowing anyway, so pinning does not turn into the thing we were actually burned by before: sitting on an ancient provider until the eventual upgrade is a big-bang change nobody wants to start.",
     "Renovate always proposes the NEWEST version that has already passed minimumReleaseAge, and marks anything newer as pending - it does not sit and wait for the newest release to age. So forward motion is guaranteed no matter how long the soak is, and a long soak costs only currency, which we do not care about. What we buy with it is a proposed version that has a real public track record by the time we see it.",
@@ -9,23 +22,42 @@
   "timezone": "America/New_York",
   "schedule": ["before 9am on monday"],
   "prConcurrentLimit": 3,
-  "labels": ["dependencies"],
   "minimumReleaseAge": "30 days",
   "internalChecksFilter": "strict",
   "dependencyDashboard": true,
 
   "lockFileMaintenance": {
-    "enabled": true,
-    "schedule": ["before 9am on monday"]
+    "enabled": false
   },
 
   "packageRules": [
+    {
+      "description": "Terraform and Helm-values changes are part of the versioned deployment artifact. Use fix so release-please publishes a patch instead of leaving the merged change unreachable until some unrelated release.",
+      "matchManagers": ["terraform", "helm-values"],
+      "commitMessagePrefix": "fix(deps):"
+    },
+    {
+      "description": "Workflow-only dependency updates must not publish a CloudPrem release.",
+      "matchManagers": ["github-actions"],
+      "commitMessagePrefix": "chore(ci):"
+    },
+    {
+      "description": "Breaking upgrades stay visible on the Dashboard but need an explicit decision before Renovate creates a PR.",
+      "matchUpdateTypes": ["major"],
+      "dependencyDashboardApproval": true
+    },
+    {
+      "description": "alpine/k8s tags encode the kubectl minor as a SemVer minor, but kubectl is supported only within one minor of kube-apiserver. EKS versions vary across the fleet, so every change needs Dashboard approval even when Renovate calls it non-major.",
+      "matchDatasources": ["docker"],
+      "matchPackageNames": ["alpine/k8s"],
+      "dependencyDashboardApproval": true
+    },
     {
       "description": "Providers are the fleet-wide blast radius: one bad release reaches every stack that inits. One PR per provider, so a bad bump reverts without dragging unrelated updates with it. 30 days because being current has no value to us and a month of public exposure has quite a lot.",
       "matchManagers": ["terraform"],
       "matchDepTypes": ["provider", "required_provider"],
       "minimumReleaseAge": "30 days",
-      "commitMessagePrefix": "chore(providers):"
+      "commitMessagePrefix": "fix(providers):"
     },
     {
       "description": "aws 6.57.0 (2026-07-29) has a request-signing regression that makes data-source reads fail across IAM/KMS/EC2/STS, so plans die during refresh - hashicorp/terraform-provider-aws#49170. This lives here rather than as '!= 6.57.0' in required_providers because Renovate's hashicorp versioning has no '!=' operator: it warns 'Unsupported hashicorp constraint' and then skips the dependency, leaving the AWS provider unmanaged forever. Delete this rule once a fixed release is out and adopted.",
@@ -45,12 +77,21 @@
       "matchFileNames": ["live/tests/**"],
       "minimumReleaseAge": "3 days",
       "commitMessagePrefix": "test(harness):"
+    },
+    {
+      "description": "The harness container also ships to nobody and release-please excludes it.",
+      "matchManagers": ["dockerfile"],
+      "matchFileNames": ["live/tests/**"],
+      "minimumReleaseAge": "3 days",
+      "commitMessagePrefix": "test(harness):"
     }
   ],
 
   "vulnerabilityAlerts": {
     "description": "Security fixes skip the soak. The reason to wait is that other people have not found the bugs yet, and that reasoning inverts once the bug is known and being exploited.",
+    "schedule": [],
     "minimumReleaseAge": null,
-    "labels": ["security"]
+    "dependencyDashboardApproval": false,
+    "commitMessagePrefix": "fix(security):"
   }
 }


### PR DESCRIPTION
## Summary

- use free Renovate config-migration and digest-pinning features for Docker images and GitHub Actions
- restore dependency extraction for `live/tests` while continuing to ignore vendored/example trees
- disable generic lock-file maintenance so 30-day soak and one-provider-per-PR controls cannot be bypassed
- require Dashboard approval for majors and every `alpine/k8s` change, while letting vulnerability fixes bypass the schedule and soak
- align commit prefixes with release-please: runtime/provider/security changes release a patch; workflow and harness changes stay release-neutral
- add credential-free PR validation for the previously untested `terraform/physical-azure` source module

## Why

`config:recommended` includes `:ignoreModulesAndTests`, so the existing `live/tests` Go package rule never matched anything. Generic lock-file maintenance also upgrades every lock entry to the newest constraint-compatible version, bypassing Renovate package selection controls such as `minimumReleaseAge` and the temporary AWS 6.57.0 exclusion.

The CloudPrem Dashboard currently contains several breaking image, action, and provider upgrades. This keeps those visible but makes an explicit approval the prerequisite for opening a PR. `alpine/k8s` is gated for every update because its SemVer minor is the kubectl/Kubernetes minor and the supported client/server skew is only one minor.

The Community Cloud tier provides the presets and managers used here at no charge. Paid Merge Confidence workflows are intentionally not assumed.

## Validation

- `renovate-config-validator renovate.json` with Renovate 44.5.3
- full local Renovate 44.5.3 dry-run under supported Node 24, including authenticated GitHub datasource lookups: 39 files / 175 dependencies extracted
- confirmed `live/tests/go.mod` and `live/tests/Dockerfile` are extracted; vendored/example trees and coupled harness tool ARG pins remain excluded
- confirmed package-specific `renovate/aws-6.x-lockfile` remains and no generic lock-maintenance branch is generated
- `go test ./...` in `live/tests`
- Terraform 1.13.4 `init -backend=false -input=false`, `fmt -check`, and `validate` for `terraform/physical-azure` in a clean container, without cloud credentials
- workflow YAML parse and `git diff --check`

Existing `terraform/physical` cannot pass a standalone `tofu validate` because several resources intentionally reference aliased `aws.dr` / `aws.dns` provider configurations supplied by callers. This PR leaves the existing physical/logical init, fmt, and TFLint semantics intact and applies the new validate gate only to `physical-azure`.