### PR TITLE
feat(logical): harden external-secrets webhook, pin upgrade/rollback force=false

### DIFF
--- a/terraform/logical/flux.tf
+++ b/terraform/logical/flux.tf
@@ -547,9 +547,16 @@ resource "kubectl_manifest" "dozuki_helmrelease" {
       # upgrade retries=2: with retries=0 ONE failed upgrade (an eviction, a
       # not-yet-mirrored image, a transient webhook) stalls the release until a
       # human does the requestedAt+forceAt dance (seen live 2026-07-30). Two
-      # retries let it self-heal once the cause clears; remediateLastFailure
-      # stays false so a failure never auto-rolls-back over a completed
-      # migration. Install keeps retries=0: install remediation uninstalls
+      # retries let it self-heal once the cause clears. What that costs:
+      # remediation (strategy defaults to rollback) runs BETWEEN each attempt,
+      # so retries=2 means up to 2 rollbacks per failed upgrade, and the counter
+      # resets on a chart version change, so it bounds one cycle and not the
+      # loop (dev-min 2026-08-01). remediateLastFailure=false is load-bearing,
+      # not redundant: Flux defaults it to TRUE whenever retries > 0. It governs
+      # only the failure after retries are spent, parking the release on the new
+      # revision instead of rolling back - a human sees a failed release rather
+      # than a chart silently older than the schema already in the database.
+      # Install keeps retries=0: install remediation uninstalls
       # first, which is not a loop we want running unattended.
       upgrade = { disableWait = false, timeout = "4h30m", crds = "CreateReplace", remediation = { retries = 2, remediateLastFailure = false } }
       # rollback.force=false pinned explicitly (it is the Helm default, but this is the one

--- a/terraform/logical/flux.tf
+++ b/terraform/logical/flux.tf
@@ -553,20 +553,23 @@ resource "kubectl_manifest" "dozuki_helmrelease" {
       # resets on a chart version change, so it bounds one cycle and not the
       # loop (dev-min 2026-08-01). remediateLastFailure=false is load-bearing,
       # not redundant: Flux defaults it to TRUE whenever retries > 0. It governs
-      # only the failure after retries are spent, parking the release on the new
-      # revision instead of rolling back - a human sees a failed release rather
-      # than a chart silently older than the schema already in the database.
+      # only the failure after retries are spent: Flux performs no rollback, so the
+      # release stays failed and live state may be left partially applied, pending
+      # operator recovery. A human sees a failed release rather than a chart
+      # silently older than the schema already in the database.
       # Install keeps retries=0: install remediation uninstalls
       # first, which is not a loop we want running unattended.
       upgrade = { disableWait = false, timeout = "4h30m", crds = "CreateReplace", remediation = { retries = 2, remediateLastFailure = false } }
       # rollback.force=false pinned explicitly (it is the Helm default, but this is the one
       # knob here that can destroy data, so it gets written down rather than inherited).
-      # Remediation re-renders the previous revision over the live objects, and force=true
-      # resolves any conflict by deleting and recreating the object. The db-migrations Job is
-      # the object most likely to conflict (spec.template and spec.selector are immutable), so
-      # force would delete a completed migration and re-run it unattended, mid-incident, on a
-      # database that is already one schema version ahead. A rollback that fails loudly and
-      # parks the release is the better outcome.
+      # Under client-side apply force does not wait for a conflict: it selects the replace
+      # strategy and recreates every same-named object it visits, so a completed db-migrations
+      # Job would be deleted and re-run unattended, mid-incident, on a database already one
+      # schema version ahead. Under server-side apply Flux documents force as ignored, and the
+      # flux_chart_version pinned here is on the SSA line, so today this is defense-in-depth
+      # for client-side or adopted releases rather than an active guard. It does not govern
+      # the ordinary create/prune cycle that happens when the Job name changes. A rollback
+      # that fails loudly and parks the release is the better outcome.
       rollback = { force = false }
       # driftDetection=enabled corrects cluster drift back to the chart's desired state. Promoted from warn after a fleet
       # sweep (2026-07-30) found drift on exactly one env, and it was stale old-chart state helm's 3-way merge could never

--- a/terraform/logical/flux.tf
+++ b/terraform/logical/flux.tf
@@ -559,7 +559,14 @@ resource "kubectl_manifest" "dozuki_helmrelease" {
       # silently older than the schema already in the database.
       # Install keeps retries=0: install remediation uninstalls
       # first, which is not a loop we want running unattended.
-      upgrade = { disableWait = false, timeout = "4h30m", crds = "CreateReplace", remediation = { retries = 2, remediateLastFailure = false } }
+      # upgrade.force pinned false for the same reason as rollback.force below, and it
+      # carries more weight here: every reconcile that produces a change goes through
+      # upgrade, while rollback only runs on remediation. force=true selects Helm's
+      # replace strategy, so an upgrade that leaves the migration Job name unchanged
+      # would delete the completed Job and re-run migrations. It is also the knob
+      # reached for to punch through immutable-field errors, which is the exact class
+      # of failure the chart's manualSelector change fixes at the source.
+      upgrade = { disableWait = false, timeout = "4h30m", crds = "CreateReplace", force = false, remediation = { retries = 2, remediateLastFailure = false } }
       # rollback.force=false pinned explicitly (it is the Helm default, but this is the one
       # knob here that can destroy data, so it gets written down rather than inherited).
       # Under client-side apply force does not wait for a conflict: it selects the replace

--- a/terraform/logical/flux.tf
+++ b/terraform/logical/flux.tf
@@ -552,6 +552,15 @@ resource "kubectl_manifest" "dozuki_helmrelease" {
       # migration. Install keeps retries=0: install remediation uninstalls
       # first, which is not a loop we want running unattended.
       upgrade = { disableWait = false, timeout = "4h30m", crds = "CreateReplace", remediation = { retries = 2, remediateLastFailure = false } }
+      # rollback.force=false pinned explicitly (it is the Helm default, but this is the one
+      # knob here that can destroy data, so it gets written down rather than inherited).
+      # Remediation re-renders the previous revision over the live objects, and force=true
+      # resolves any conflict by deleting and recreating the object. The db-migrations Job is
+      # the object most likely to conflict (spec.template and spec.selector are immutable), so
+      # force would delete a completed migration and re-run it unattended, mid-incident, on a
+      # database that is already one schema version ahead. A rollback that fails loudly and
+      # parks the release is the better outcome.
+      rollback = { force = false }
       # driftDetection=enabled corrects cluster drift back to the chart's desired state. Promoted from warn after a fleet
       # sweep (2026-07-30) found drift on exactly one env, and it was stale old-chart state helm's 3-way merge could never
       # fix: failed upgrade attempts record the new manifest without fully applying it, so the next successful upgrade sees

--- a/terraform/logical/flux.tf
+++ b/terraform/logical/flux.tf
@@ -561,22 +561,26 @@ resource "kubectl_manifest" "dozuki_helmrelease" {
       # first, which is not a loop we want running unattended.
       # upgrade.force pinned false for the same reason as rollback.force below, and it
       # carries more weight here: every reconcile that produces a change goes through
-      # upgrade, while rollback only runs on remediation. force=true selects Helm's
-      # replace strategy, so an upgrade that leaves the migration Job name unchanged
-      # would delete the completed Job and re-run migrations. It is also the knob
-      # reached for to punch through immutable-field errors, which is the exact class
-      # of failure the chart's manualSelector change fixes at the source.
+      # upgrade, while rollback only runs on remediation. It is also the knob reached
+      # for to punch through immutable-field errors, where it makes things worse, not
+      # better (see below).
       upgrade = { disableWait = false, timeout = "4h30m", crds = "CreateReplace", force = false, remediation = { retries = 2, remediateLastFailure = false } }
-      # rollback.force=false pinned explicitly (it is the Helm default, but this is the one
-      # knob here that can destroy data, so it gets written down rather than inherited).
-      # Under client-side apply force does not wait for a conflict: it selects the replace
-      # strategy and recreates every same-named object it visits, so a completed db-migrations
-      # Job would be deleted and re-run unattended, mid-incident, on a database already one
-      # schema version ahead. Under server-side apply Flux documents force as ignored, and the
-      # flux_chart_version pinned here is on the SSA line, so today this is defense-in-depth
-      # for client-side or adopted releases rather than an active guard. It does not govern
-      # the ordinary create/prune cycle that happens when the Job name changes. A rollback
-      # that fails loudly and parks the release is the better outcome.
+      # Both force knobs pinned false explicitly. That is already the Helm default, but the
+      # semantics are widely misread, so they get written down rather than inherited.
+      # What force actually does, checked against source (helm v3.19.0 pkg/kube/client.go
+      # updateResource, v4.0.0 replaceResource): it swaps the patch for helper.Replace, a
+      # whole-object PUT. It does NOT delete and recreate, so it will not re-run a completed
+      # db-migrations Job. The reason to keep it off is the opposite of the usual pitch. A
+      # PUT sends only what the chart renders, so any field the server populated and the
+      # chart does not carry is dropped or makes the PUT fail outright, and an immutable
+      # field whose live value was server-defaulted (exactly the auto-stamped Job selector
+      # this chart change removes) turns a survivable patch into a hard failure. It is an
+      # all-or-nothing write with no upside on this release.
+      # Scope: helm v4 refuses force-replace together with server-side apply, and the
+      # HelmRelease CRD documents force as ignored under SSA. The flux_chart_version pinned
+      # here is on the SSA line, so today both pins are defense-in-depth for client-side or
+      # adopted releases rather than an active guard. Neither governs the ordinary
+      # create/prune cycle that happens when the Job name changes.
       rollback = { force = false }
       # driftDetection=enabled corrects cluster drift back to the chart's desired state. Promoted from warn after a fleet
       # sweep (2026-07-30) found drift on exactly one env, and it was stale old-chart state helm's 3-way merge could never

--- a/terraform/logical/kubernetes.tf
+++ b/terraform/logical/kubernetes.tf
@@ -516,13 +516,18 @@ resource "helm_release" "external_secrets" {
       value = "64Mi"
     },
     {
-      # Without a priority class an evicted replica just sits Pending until
-      # Karpenter provisions a node, and the PDB stays blocked that whole time
-      # (it counts healthy pods, not scheduled ones). system-cluster-critical
-      # lets the replacement preempt instead of wait, which is correct for a
-      # fail-closed admission webhook: every ExternalSecret and SecretStore in
-      # the cluster is stuck behind it. It is a built-in class, works outside
-      # kube-system, and is already in use on dev-min (dozuki, istio-system,
+      # A Pending replica keeps the PDB blocked: disruptionsAllowed counts
+      # healthy pods, not scheduled ones, so one unschedulable replica stalls
+      # every drain behind it. Priority shortens that window, it does not remove
+      # it. Preemption only fires when evicting lower-priority pods on some node
+      # actually makes this pod fit, and at a 10m/64Mi request it usually fits
+      # somewhere without preempting anything; on a genuinely full cluster it
+      # still waits on Karpenter. What the class buys unconditionally is the
+      # rest: head of the scheduling queue, nothing else can preempt it, and the
+      # kubelet ranks it last for node-pressure eviction. Worth it for a
+      # fail-closed admission webhook, where every ExternalSecret and SecretStore
+      # in the cluster is stuck behind it. Built-in class, works outside
+      # kube-system, already in use on dev-min (dozuki, istio-system,
       # amazon-cloudwatch).
       name  = "webhook.priorityClassName"
       value = "system-cluster-critical"

--- a/terraform/logical/kubernetes.tf
+++ b/terraform/logical/kubernetes.tf
@@ -497,15 +497,17 @@ resource "helm_release" "external_secrets" {
       value = "1"
     },
     {
-      # Chart ships no requests at all, which makes the pod free in Karpenter's
-      # bin-packing and lets the topology spread below be silently ignored (a
-      # zero-request pod always "fits", so the scheduler has nothing to skew).
-      # Small real requests give the spread something to bite on. Requests only,
-      # no limits: an under-set memory limit OOMKills the webhook, which is the
+      # Chart ships no requests at all. Two consequences: the pod is free in
+      # Karpenter's bin-packing, so it can be packed onto a node with no real
+      # headroom left, and it lands in BestEffort QoS, which is what the kubelet
+      # evicts first under node pressure. Small real requests fix both. They do
+      # NOT affect the topology spread below - PodTopologySpread scoring counts
+      # matching pods per domain and never looks at requests. Requests only, no
+      # limits: an under-set memory limit OOMKills the webhook, which is the
       # exact fail-closed outage this block exists to prevent. Measured on
       # dev-min 2026-08-02: 1m CPU / 32Mi. Memory is requested at 64Mi rather
-      # than at the observed 32Mi so the pod is not first in line for eviction
-      # the moment a node comes under memory pressure.
+      # than the observed 32Mi to leave headroom and keep the pod out of the
+      # front of the eviction queue.
       name  = "webhook.resources.requests.cpu"
       value = "10m"
     },
@@ -534,10 +536,10 @@ resource "helm_release" "external_secrets" {
   # Pending forever on genuinely single-node clusters (the smallest
   # CloudPrem tiers). Soft means it is a preference, not a guarantee: on a
   # cluster with one schedulable node both replicas still land together, and
-  # we can lose the pair. The requests set above are what make the preference
-  # worth anything at all (a zero-request pod always fits, so the scheduler
-  # never sees a skew to correct). No labelSelector needed - the chart
-  # auto-fills it from the webhook's own selector labels when omitted.
+  # we can lose the pair. topologyKey is hostname, so this is node-loss
+  # protection only and buys nothing against a zone failure. No labelSelector
+  # needed - the chart auto-fills it from the webhook's own selector labels
+  # when omitted.
   values = [
     yamlencode({
       webhook = {

--- a/terraform/logical/kubernetes.tf
+++ b/terraform/logical/kubernetes.tf
@@ -471,6 +471,85 @@ resource "helm_release" "external_secrets" {
       name  = "crds.createClusterSecretStore"
       value = "true"
     },
+    {
+      # Chart default is 1. A single webhook replica is a single point of
+      # failure for every ExternalSecret/SecretStore admission in the
+      # cluster (fail-closed) - the dev-min rollback loop on 2026-08-01 was
+      # made worse by exactly this: the sole webhook pod rescheduling took
+      # down 6 ExternalSecrets + the SecretStore at once.
+      name  = "webhook.replicaCount"
+      value = "2"
+    },
+    {
+      # Chart default is false. Without one, nothing stops Karpenter from
+      # draining a node and taking every webhook replica on it at once,
+      # which is the fail-closed admission outage we are fixing.
+      name  = "webhook.podDisruptionBudget.enabled"
+      value = "true"
+    },
+    {
+      # maxUnavailable, not minAvailable: the chart's own PDB template
+      # prefers maxUnavailable over minAvailable once both keys are present,
+      # and minAvailable=2 on a 2-replica deployment would forbid every
+      # eviction outright, permanently blocking Karpenter consolidation of
+      # any node hosting a webhook replica.
+      name  = "webhook.podDisruptionBudget.maxUnavailable"
+      value = "1"
+    },
+    {
+      # Chart ships no requests at all, which makes the pod free in Karpenter's
+      # bin-packing and lets the topology spread below be silently ignored (a
+      # zero-request pod always "fits", so the scheduler has nothing to skew).
+      # Small real requests give the spread something to bite on. Requests only,
+      # no limits: an under-set memory limit OOMKills the webhook, which is the
+      # exact fail-closed outage this block exists to prevent. Measured on
+      # dev-min 2026-08-02: 1m CPU / 32Mi. Memory is requested at 64Mi rather
+      # than at the observed 32Mi so the pod is not first in line for eviction
+      # the moment a node comes under memory pressure.
+      name  = "webhook.resources.requests.cpu"
+      value = "10m"
+    },
+    {
+      name  = "webhook.resources.requests.memory"
+      value = "64Mi"
+    },
+    {
+      # Without a priority class an evicted replica just sits Pending until
+      # Karpenter provisions a node, and the PDB stays blocked that whole time
+      # (it counts healthy pods, not scheduled ones). system-cluster-critical
+      # lets the replacement preempt instead of wait, which is correct for a
+      # fail-closed admission webhook: every ExternalSecret and SecretStore in
+      # the cluster is stuck behind it. It is a built-in class, works outside
+      # kube-system, and is already in use on dev-min (dozuki, istio-system,
+      # amazon-cloudwatch).
+      name  = "webhook.priorityClassName"
+      value = "system-cluster-critical"
+    },
+  ]
+
+  # List-of-objects value, safer as a values block than a dotted/indexed
+  # `set` entry. Biases the 2 webhook replicas onto separate nodes so a
+  # single node loss is less likely to take out both. Soft (ScheduleAnyway),
+  # not DoNotSchedule: a hard constraint would strand the 2nd replica
+  # Pending forever on genuinely single-node clusters (the smallest
+  # CloudPrem tiers). Soft means it is a preference, not a guarantee: on a
+  # cluster with one schedulable node both replicas still land together, and
+  # we can lose the pair. The requests set above are what make the preference
+  # worth anything at all (a zero-request pod always fits, so the scheduler
+  # never sees a skew to correct). No labelSelector needed - the chart
+  # auto-fills it from the webhook's own selector labels when omitted.
+  values = [
+    yamlencode({
+      webhook = {
+        topologySpreadConstraints = [
+          {
+            maxSkew           = 1
+            topologyKey       = "kubernetes.io/hostname"
+            whenUnsatisfiable = "ScheduleAnyway"
+          }
+        ]
+      }
+    })
   ]
 }
 


### PR DESCRIPTION
Two independent commits, both fallout from the dev-min incident on 2026-08-01.

## 1. external-secrets webhook HA

The webhook runs 1 replica with no PDB, no spread and no resource requests (all chart defaults). Its ValidatingWebhookConfiguration is fail-closed, so a single pod reschedule fails admission for every ExternalSecret and SecretStore in the namespace. On dev-min that took down 6 ExternalSecrets plus the SecretStore at once and made the rollback loop materially worse.

- `replicaCount: 2`
- PDB with `maxUnavailable: 1`. Not `minAvailable: 2`, which on a 2-replica deployment forbids every eviction and permanently blocks Karpenter consolidation of any node hosting a replica. At 2 replicas `maxUnavailable: 1` and `minAvailable: 1` are arithmetically identical anyway.
- Soft (`ScheduleAnyway`) topologySpreadConstraint by hostname. Not `DoNotSchedule`, which would strand the 2nd replica Pending forever on genuinely single-node clusters. Soft means preference, not guarantee: on a one-node cluster both replicas still land together. `topologyKey` is hostname, so this is node-loss protection only and buys nothing against a zone failure.
- Requests `10m` / `64Mi`. Measured live on dev-min at 1m / 32Mi; memory is requested above observed to leave headroom.
- `priorityClassName: system-cluster-critical`.

No limits, on purpose. An under-set memory limit OOMKills the webhook, which is the outage this is meant to prevent.

### What the requests and the priority class actually do

An earlier revision of this PR (and of the code comments) claimed the requests are what make the topology spread meaningful, and that the priority class lets an evicted replica preempt instead of waiting. Both overstated the mechanism. Corrected:

**Requests** do not affect the spread at all. `PodTopologySpread` scoring counts matching pods per topology domain and never looks at resource requests. What real requests buy is separate and still worth having: a zero-request pod lands in BestEffort QoS, which is the first thing the kubelet evicts under node pressure, and Karpenter treats it as free in bin-packing, so it can be packed onto a node with no real headroom left.

**The priority class** shortens the Pending window but does not remove it. A Pending replica keeps the PDB blocked, since `disruptionsAllowed` counts healthy pods and not scheduled ones, so one unschedulable replica stalls every drain behind it. Preemption only fires when evicting lower-priority pods on some node actually makes this pod fit, and at a 10m/64Mi request it usually fits somewhere without preempting anything. On a genuinely full cluster it still waits on Karpenter. What the class buys unconditionally is the rest: head of the scheduling queue, nothing else can preempt it, and the kubelet ranks it last for node-pressure eviction. That is a fair trade for a fail-closed admission webhook, where every ExternalSecret and SecretStore in the cluster is stuck behind it.

## 2. `upgrade.force` and `rollback.force` pinned false on the dozuki HelmRelease

Both are Helm's default. They are written down anyway because the semantics are widely misread, including by two earlier revisions of this PR.

**What `force` actually does.** Checked against source, not docs: helm v3.19.0 `pkg/kube/client.go` `updateResource` and v4.0.0 `replaceResource` both take the same branch, `helper.Replace`, which is a whole-object PUT. It does **not** delete and recreate. Earlier revisions of this description and of the code comments claimed a completed `db-migrations` Job would be deleted and re-run against a database one schema version ahead. That is wrong, and the corrected reason to keep force off is close to the opposite:

A PUT sends only what the chart renders. Any field the server populated and the chart does not carry is dropped or makes the write fail outright, and an immutable field whose live value was server-defaulted turns a survivable patch into a hard failure. The auto-stamped `batch.kubernetes.io/controller-uid` Job selector is exactly that case, which is why reaching for `force` to punch through an immutable-field error makes it worse rather than better. It is an all-or-nothing write with no upside on this release.

Neither pin governs the ordinary create/prune cycle that happens when the Job name changes.

**Scope, honestly stated.** helm v4 refuses force-replace together with server-side apply, and the HelmRelease CRD documents `force` as ignored under SSA. The `flux_chart_version` pinned here is on the SSA line, so today both pins are defense-in-depth for client-side or adopted releases rather than an active guard.

`upgrade.force` is the one that was missing, and it is the more exposed of the two: every reconcile that produces a change goes through upgrade, while rollback only runs on remediation.

## Verification

- Rendered ESO 2.8.0 with the exact `set` list. Webhook Deployment comes out with `replicas: 2`, the requests, `priorityClassName: system-cluster-critical`, and the topologySpreadConstraint with `labelSelector` auto-filled from the chart. PDB renders `maxUnavailable: 1`. All five keys confirmed present under `webhook:` in the chart's values.
- `kubectl explain helmrelease.spec.upgrade.force` against live dev-min confirms the field exists on the `helm.toolkit.fluxcd.io/v2` HelmRelease and confirms the SSA caveat above.
- `tofu fmt -check -recursive` clean.

## Blast radius

Logical layer, so every AWS/Azure logical stack on the next `infra_version` bump. Airgapped onprem installs are unaffected: they don't get external-secrets from this layer.

## Ordering

The `force` pins are independent of the companion chart change and can land first. Nothing here depends on that chart change, and nothing in it depends on this.
