### PR TITLE
fix(ci): make TFLint configuration errors fatal

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -62,9 +62,10 @@ jobs:
       run: ${{ matrix.tool }} validate
       working-directory: ./terraform/${{ matrix.module }}
 
-    # This action is configured with the AWS ruleset below. physical-azure has no
-    # Azure TFLint plugin/config in the repo, so init + fmt + validate are its
-    # meaningful credential-free PR gates; do not run AWS rules against it.
+    # The AWS-backed layers have local configs that pin and enable the AWS
+    # ruleset. physical-azure has no Azure TFLint plugin/config in the repo, so
+    # init + fmt + validate are its meaningful credential-free PR gates; do not
+    # run AWS rules against it.
     - name: Terraform Linter
       if: matrix.module != 'physical-azure'
       uses: reviewdog/action-tflint@54a5e5aed57dcfbb4662ec548de876df33d6288d # v1
@@ -72,9 +73,11 @@ jobs:
         github_token: ${{ secrets.github_token }}
         working_directory: "./terraform/${{ matrix.module }}"
         reporter: github-pr-review
-        fail_on_error: "false"
+        # Keep warnings as review comments, but fail for configuration/runtime
+        # errors instead of allowing a broken lint invocation to pass CI.
+        fail_level: "error"
         filter_mode: "nofilter"
-        tflint_rulesets: "aws"
+        tflint_init: "true"
 
     # tfsec removed — deprecated in favor of Trivy. The reviewdog/action-tfsec
     # action crashes on tfsec v1.28.0 output parsing. Migrate to Trivy in a

--- a/.tflint.hcl
+++ b/.tflint.hcl
@@ -1,0 +1,8 @@
+# pre-commit-terraform runs `tflint --init` once from the repository root
+# before linting individual module directories. Declare the pinned plugin here
+# so that initialization installs the plugin used by the module-local configs.
+plugin "aws" {
+  enabled = true
+  version = "0.48.0"
+  source  = "github.com/terraform-linters/tflint-ruleset-aws"
+}

--- a/terraform/logical/.tflint.hcl
+++ b/terraform/logical/.tflint.hcl
@@ -4,6 +4,12 @@
 # terraform_required_providers rule aborts with "Invalid expression" on that construct. Disable
 # just that rule here; every other rule still runs. Re-enable if tflint gains OpenTofu
 # provider-for_each support.
+plugin "aws" {
+  enabled = true
+  version = "0.48.0"
+  source  = "github.com/terraform-linters/tflint-ruleset-aws"
+}
+
 rule "terraform_required_providers" {
   enabled = false
 }

--- a/terraform/physical/.tflint.hcl
+++ b/terraform/physical/.tflint.hcl
@@ -1,0 +1,8 @@
+# reviewdog/action-tflint always invokes TFLint with an explicit config path.
+# Keep the file local to this module so its AWS rules run without inheriting
+# the logical layer's OpenTofu-specific rule exception.
+plugin "aws" {
+  enabled = true
+  version = "0.48.0"
+  source  = "github.com/terraform-linters/tflint-ruleset-aws"
+}


### PR DESCRIPTION
## Summary

- add explicit TFLint configs for the physical and logical AWS-backed layers
- pin and enable tflint-ruleset-aws 0.48.0, with a root config for pre-commit plugin initialization
- replace deprecated fail_on_error with fail_level: error so warnings remain review comments while configuration and runtime errors fail CI

## Why

The physical Terraform matrix leg always passed -c .tflint.hcl from terraform/physical even though that file did not exist. Reviewdog reported the load error but returned success, so reruns could be green without running physical lint. The AWS plugin was also downloaded but not enabled by either module config.

## Validation

- pre-commit run terraform_tflint --all-files
- TFLint 0.64.0 loaded AWS ruleset 0.48.0 for physical and logical
- both module lint runs completed with only the existing unused-declaration warnings
- workflow YAML parsed successfully
- git diff --check