### PR TITLE
fix(physical): set final_snapshot_identifier on both aurora clusters

### DIFF
--- a/terraform/physical/README.md
+++ b/terraform/physical/README.md
@@ -198,6 +198,7 @@
 | [null_resource.create_dms_cloudwatch_role](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [null_resource.create_dms_vpc_role](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [null_resource.s3_replication_job_init](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
+| [random_id.aurora_final_snapshot](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
 | [random_password.aurora](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
 | [random_password.bi_aurora](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
 | [terraform_data.aurora_migration_phase](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/resources/data) | resource |

--- a/terraform/physical/aurora.tf
+++ b/terraform/physical/aurora.tf
@@ -16,6 +16,20 @@ resource "random_password" "aurora" {
   special = false
 }
 
+# Suffix for the Aurora final-snapshot names (this file and bi.tf). The rds-aurora
+# module has no final_snapshot_identifier_PREFIX variable the way the rds module
+# does, only the literal identifier, so the uniqueness the rds path gets for free
+# has to be built here. Same shape as what terraform-aws-modules/rds appends.
+#
+# A destroy does not consume the value, so a stack that is destroyed, recreated
+# and destroyed again reuses this hex and the second delete fails
+# DBSnapshotAlreadyExists. That matches the existing rds and BI paths rather than
+# regressing them; rename or drop the stale snapshot when it happens.
+resource "random_id" "aurora_final_snapshot" {
+  count       = local.aurora_present || local.bi_uses_aurora ? 1 : 0
+  byte_length = 4
+}
+
 module "aurora" {
   source  = "terraform-aws-modules/rds-aurora/aws"
   version = "10.2.0"
@@ -135,9 +149,18 @@ module "aurora" {
     ]
   }
 
-  apply_immediately            = local.db_apply_immediately
-  deletion_protection          = var.protect_resources
-  skip_final_snapshot          = !var.protect_resources
+  apply_immediately   = local.db_apply_immediately
+  deletion_protection = var.protect_resources
+  skip_final_snapshot = !var.protect_resources
+  # Required whenever skip_final_snapshot is false. Without it the provider
+  # refuses the delete outright ("FinalSnapshotIdentifier is required when a
+  # final snapshot is required"), which made the aurora_migration_state = "off"
+  # abort path impossible to run through terraform. Clearing deletion protection
+  # out of band gets past the first gate only to hit this one, and
+  # skip_final_snapshot is a terraform-only attribute with no RDS API equivalent,
+  # so there is nothing to override by hand. The cluster then has to be
+  # snapshotted and deleted manually, which is how this was found.
+  final_snapshot_identifier    = "${local.identifier}-final-${random_id.aurora_final_snapshot[0].hex}"
   copy_tags_to_snapshot        = true
   backup_retention_period      = var.rds_backup_retention_period
   preferred_backup_window      = "17:00-19:00"

--- a/terraform/physical/bi.tf
+++ b/terraform/physical/bi.tf
@@ -511,9 +511,12 @@ module "bi_aurora" {
     ]
   }
 
-  apply_immediately            = local.db_apply_immediately
-  deletion_protection          = var.protect_resources
-  skip_final_snapshot          = !var.protect_resources
+  apply_immediately   = local.db_apply_immediately
+  deletion_protection = var.protect_resources
+  skip_final_snapshot = !var.protect_resources
+  # Same requirement as the primary cluster in aurora.tf; see the comment there
+  # for why its absence makes a cluster undestroyable through terraform.
+  final_snapshot_identifier    = "${local.identifier}-bi-final-${random_id.aurora_final_snapshot[0].hex}"
   copy_tags_to_snapshot        = true
   backup_retention_period      = var.rds_backup_retention_period
   preferred_backup_window      = "17:00-19:00"


### PR DESCRIPTION
Found while aborting an Aurora migration: with `protect_resources = true`, neither
Aurora cluster can be destroyed through terraform at all.

## The bug

`module.aurora` (aurora.tf) and `module.bi_aurora` (bi.tf) both set:

```hcl
deletion_protection = var.protect_resources
skip_final_snapshot = !var.protect_resources
```

but neither sets `final_snapshot_identifier`, and rds-aurora v10.2.0 defaults it to
`null`. The provider hard-errors on delete when a final snapshot is required and no
name was given.

The rds and provisioned-BI paths already avoid this with
`final_snapshot_identifier_prefix` (rds.tf:208, bi.tf:575), which the rds module
suffixes with a `random_id`. rds-aurora exposes no prefix variable, only the literal
identifier, so the suffix is built here from one shared `random_id` covering both
clusters.

## Why it matters

It breaks the `aurora_migration_state = "off"` abort path specifically. Deletion
protection is only the first gate, and it can be cleared out of band. The missing
snapshot name is the second, and it cannot: `skip_final_snapshot` is a terraform-only
attribute with no RDS API equivalent, so there is nothing to flip with the CLI. The
cluster has to be snapshotted and deleted by hand, then dropped from state by refresh.

That is the documented reversal for a migration that gets provisioned and then
abandoned, so it should work.

## Scope and blast radius

Adding `final_snapshot_identifier` shows as an in-place update on existing clusters
and issues no API call, since the attribute is only read at destroy time. Both new
`random_id` and the attribute are gated so they exist exactly when their cluster does:

```hcl
count = local.aurora_present || local.bi_uses_aurora ? 1 : 0
```

`local.aurora_present` covers `module.aurora`, `local.bi_uses_aurora` covers
`module.bi_aurora`, so the `[0]` index always resolves.

Note `aws_rds_cluster` is in auto-gate's `sensitive_types`, so envs picking this up
will gate for a manual confirm rather than autodeploying. That is the intended
behaviour for a DB-touching diff.

## Known limitation

A destroy does not consume the `random_id`, so a stack destroyed, recreated and
destroyed again reuses the hex and the second delete fails `DBSnapshotAlreadyExists`.
That is the same behaviour as the existing rds and BI paths rather than a regression;
rename or drop the stale snapshot when it happens.

## Verification

`tofu fmt` and the pre-commit `tflint` pass. `tofu validate` fails on this module
both with and without the change, identically, because it expects the caller to
configure the `aws.dr` provider alias that terragrunt generates. Confirmed by
validating pristine `master` in a separate worktree.