### PR TITLE
fix(logical): grafana-db-init hook image follows the env registry

### DIFF
--- a/terraform/logical/flux.tf
+++ b/terraform/logical/flux.tf
@@ -288,6 +288,14 @@ locals {
       host          = local.db_master_host
       adminUsername = local.db_master_username
       adminPassword = local.db_master_password
+      # The chart's default repository is the commercial dozukicloud ECR, which gov
+      # cannot reach (found live on sharedgov 2026-08-03: the first hook run sat in
+      # ImagePullBackOff and wedged the 2.7.1 upgrade in a fail/rollback loop). Derive
+      # the host from the env's own registry instead: identical to the default on
+      # commercial, the haul-mirrored copy on gov. Tag stays the chart default.
+      image = {
+        repository = "${split("/", var.image_repository)[0]}/mysql-client"
+      }
     }
 
     googleTranslate = { token = var.google_translate_api_token } # (was set_sensitive)


### PR DESCRIPTION
The db-init hook (chart >= 2.6.0) defaults its image to the commercial dozukicloud ECR. Gov cannot reach that registry, so sharedgov's first upgrade carrying the hook sat in ImagePullBackOff, failed pre-upgrade hooks, and cycled fail/rollback. The rollback target (2.5.0) references the TF-managed grafana-db-credentials secret this release removes, so the env's dashboards Grafana stayed down through the loop.

Fix derives the image host from the env's own image_repository: byte-identical to the chart default on commercial (069174876992...), the haul-mirrored mysql-client on gov (446787640263...). Verified live on sharedgov by patching the rendered values with exactly this value and forcing the reconcile.