### PR TITLE
fix(logical): stop managing the vault smtp password, fall back to sendgrid

### DIFF
--- a/terraform/logical/README.md
+++ b/terraform/logical/README.md
@@ -116,7 +116,6 @@ No modules.
 | [vault_kv_secret_v2.db](https://registry.terraform.io/providers/hashicorp/vault/latest/docs/resources/kv_secret_v2) | resource |
 | [vault_kv_secret_v2.google_translate](https://registry.terraform.io/providers/hashicorp/vault/latest/docs/resources/kv_secret_v2) | resource |
 | [vault_kv_secret_v2.grafana](https://registry.terraform.io/providers/hashicorp/vault/latest/docs/resources/kv_secret_v2) | resource |
-| [vault_kv_secret_v2.smtp](https://registry.terraform.io/providers/hashicorp/vault/latest/docs/resources/kv_secret_v2) | resource |
 | [vault_kv_secret_v2.tls](https://registry.terraform.io/providers/hashicorp/vault/latest/docs/resources/kv_secret_v2) | resource |
 | [vault_policy.eso_readonly](https://registry.terraform.io/providers/hashicorp/vault/latest/docs/resources/policy) | resource |
 | [vault_policy.flux_relay_readonly](https://registry.terraform.io/providers/hashicorp/vault/latest/docs/resources/policy) | resource |
@@ -220,7 +219,7 @@ No modules.
 | <a name="input_smtp_enabled"></a> [smtp\_enabled](#input\_smtp\_enabled) | Whether to enable SMTP email sending. | `bool` | `true` | no |
 | <a name="input_smtp_from_address"></a> [smtp\_from\_address](#input\_smtp\_from\_address) | SMTP from email address. | `string` | `"noreply@dozuki.com"` | no |
 | <a name="input_smtp_host"></a> [smtp\_host](#input\_smtp\_host) | SMTP server hostname (and port if necessary). | `string` | `"smtp.sendgrid.net:587"` | no |
-| <a name="input_smtp_password"></a> [smtp\_password](#input\_smtp\_password) | SMTP authentication password. | `string` | `""` | no |
+| <a name="input_smtp_password"></a> [smtp\_password](#input\_smtp\_password) | SMTP authentication password. Feeds the Azure Key Vault path (keyvault.tf) and the plain/onprem Flux values (flux.tf) only - the AWS Vault path no longer writes this to secret/<customer>/<env>/smtp (see the `removed` block in vault.tf). That change requires the dozuki chart release carrying the ExternalSecret null-safe smtp\_password guard (dozuki/helm#221) to be live fleet-wide before any env's Vault smtp path is deleted; on older chart versions an absent path aborts the whole dozuki-infra-credentials sync. | `string` | `""` | no |
 | <a name="input_smtp_username"></a> [smtp\_username](#input\_smtp\_username) | SMTP authentication username. | `string` | `"apikey"` | no |
 | <a name="input_spacelift"></a> [spacelift](#input\_spacelift) | Set to true when running in Spacelift. Enables IAM auth for the Vault provider. | `bool` | `false` | no |
 | <a name="input_subsite_gateway_api_enabled"></a> [subsite\_gateway\_api\_enabled](#input\_subsite\_gateway\_api\_enabled) | Switches subsite routing to Gateway API HTTPRoutes: the dozuki-operator reconciles one HTTPRoute per subsite off the chart's dozuki-gateway instead of the legacy nginx Ingress, so subsites route automatically on Envoy Gateway installs (no hand-created wildcard HTTPRoutes). Off by default - it changes subsite routing behavior, so enable per-env after validating. Requires a bundled dozuki-operator >= the version that ships gatewayAPI.enabled (older pins silently ignore it). Safe on GovCloud's exact-host gateway layout (the operator no-ops there). | `bool` | `false` | no |

--- a/terraform/logical/variables.tf
+++ b/terraform/logical/variables.tf
@@ -174,7 +174,7 @@ variable "smtp_username" {
 
 #tfsec:ignore:general-secrets-no-plaintext-exposure
 variable "smtp_password" {
-  description = "SMTP authentication password."
+  description = "SMTP authentication password. Feeds the Azure Key Vault path (keyvault.tf) and the plain/onprem Flux values (flux.tf) only - the AWS Vault path no longer writes this to secret/<customer>/<env>/smtp (see the `removed` block in vault.tf). That change requires the dozuki chart release carrying the ExternalSecret null-safe smtp_password guard (dozuki/helm#221) to be live fleet-wide before any env's Vault smtp path is deleted; on older chart versions an absent path aborts the whole dozuki-infra-credentials sync."
   type        = string
   default     = ""
   sensitive   = true

--- a/terraform/logical/vault.tf
+++ b/terraform/logical/vault.tf
@@ -236,15 +236,28 @@ resource "vault_kv_secret_v2" "google_translate" {
   })
 }
 
-resource "vault_kv_secret_v2" "smtp" {
-  count               = var.cloud == "aws" ? 1 : 0
-  mount               = "secret"
-  name                = "${local.vault_env_prefix}/smtp"
-  delete_all_versions = !var.protect_resources
+# The env smtp password is no longer Terraform-managed. The dozuki chart's
+# ExternalSecret reads this Vault path with a null-safe template guard and
+# falls back to the fleet-wide SendGrid password when the path is absent, so
+# an env that wants its own password gets it hand-written to Vault (or synced
+# from 1Password later) instead of arriving through a stack variable.
+# destroy = false: forget the resource, leave whatever value is in Vault
+# today untouched. Deleting the path per env is a separate, deliberate step
+# gated on that env running the chart release with the ExternalSecret fix
+# (dozuki/helm#221) - see terraform/logical/README.md's smtp_password entry.
+#
+# Requires the chart release from dozuki/helm#221 fleet-wide FIRST: on the
+# old chart, an absent smtp path aborts the whole dozuki-infra-credentials
+# ExternalSecret sync (db/cache/sentry stop refreshing too). This `removed`
+# block only forgets Terraform state, it does not touch Vault, so it is safe
+# to merge and apply before every env is upgraded - the actual deletion of
+# each env's Vault path is a manual, per-env, post-upgrade step.
+removed {
+  from = vault_kv_secret_v2.smtp
 
-  data_json = jsonencode({
-    password = var.smtp_password
-  })
+  lifecycle {
+    destroy = false
+  }
 }
 
 # --- Dashboards (shared Grafana) --- #
@@ -326,11 +339,6 @@ moved {
 moved {
   from = vault_kv_secret_v2.google_translate
   to   = vault_kv_secret_v2.google_translate[0]
-}
-
-moved {
-  from = vault_kv_secret_v2.smtp
-  to   = vault_kv_secret_v2.smtp[0]
 }
 
 moved {


### PR DESCRIPTION
## What

Drops `vault_kv_secret_v2.smtp` from the AWS Vault path (`terraform/logical/vault.tf`). That resource existed only to give the ExternalSecret sync something to read at `secret/<env>/smtp` - most envs got a blank password written there. The dozuki chart's ExternalSecret now tolerates that path being absent and falls back to the shared SendGrid password (chart PR: `dozuki/helm#221`), so this stack no longer needs to manage it.

Uses `removed { lifecycle { destroy = false } }`, not a plain delete: it forgets the resource from Terraform state only, it does not touch Vault or delete anything there. Whatever value is currently in Vault for a given env is left alone.

`var.smtp_password` is kept - it still feeds the Azure Key Vault path (`keyvault.tf`) and the plain/onprem Flux values (`flux.tf`), neither of which has a fallback wired up. Only the AWS Vault write goes away.

## Sequencing (hard gate)

This must not be applied to an env before that env is running the chart release from `dozuki/helm#221`. On older chart versions, an absent smtp path aborts the *entire* `dozuki-infra-credentials` ExternalSecret sync (db/cache/sentry credentials stop refreshing too, not just smtp). The `removed` block itself is inert against Vault, so merging and applying this early is safe - the actual per-env Vault path deletion is a separate, manual, deliberate step taken only after that env's chart bump, and is out of scope for this PR.

Noted in the `smtp_password` variable description in `variables.tf` for anyone touching this later.

## Test plan

- [x] `tofu fmt` - clean
- [x] `tofu validate` - passes
- [x] `tflint` - passes (pre-existing unrelated warnings only)
- [x] terraform-docs regenerated (`README.md`)
- [ ] apply to a dev stack once the chart bump has landed there, confirm plan shows the resource leaving state with zero destroys