### PR TITLE
feat(harness): pull the real error out of the failed pod log for the mpc-alerts card

### DIFF
--- a/live/tests/argo/20-matrix.yaml
+++ b/live/tests/argo/20-matrix.yaml
@@ -216,7 +216,10 @@ spec:
             # nothing.
             WF_JSON=$(kubectl -n argo get workflows -l 'harness/parent={{workflow.name}}' -o json 2>/dev/null)
             CHILD_JSON=$(printf '%s' "$WF_JSON" | timeout 60 harness evidence --region us-east-1 2>/dev/null)
-            if [ -z "$CHILD_JSON" ] || [ "$CHILD_JSON" = "null" ]; then
+            # Fall back to the plain jq summary on anything that isn't usable JSON -
+            # empty output, a literal "null", or a truncated/malformed body (a killed
+            # `harness evidence` process can leave a partial write behind).
+            if [ -z "$CHILD_JSON" ] || [ "$CHILD_JSON" = "null" ] || ! printf '%s' "$CHILD_JSON" | jq -e . >/dev/null 2>&1; then
               CHILD_JSON=$(printf '%s' "$WF_JSON" | jq '[.items[] | {
                     name: .metadata.name,
                     config: (.metadata.labels["harness/config"] // "-"),
@@ -291,7 +294,7 @@ spec:
                 duration_seconds: $dur, trigger: $trigger, pr_url: $prurl,
                 children: (map({config: .config, phase: .phase,
                                 detail: (if .detail != "" then .detail else .msg end | .[0:400]),
-                                log_excerpt: (.log_excerpt // "" | .[0:400])}))
+                                log_excerpt: (.log_excerpt // "" | .[0:460])}))
               }')
             if [ -n "$RELAY_URL" ] && [ -n "$RELAY_TOKEN" ] && \
                printf '%s' "$RELAY_PAYLOAD" | curl -sf -X POST \

--- a/live/tests/argo/20-matrix.yaml
+++ b/live/tests/argo/20-matrix.yaml
@@ -186,6 +186,7 @@ spec:
           - |
             set -uo pipefail
             export VAULT_ADDR='{{workflow.parameters.vault-addr}}'
+            export AWS_REGION=us-east-1
             vault login -method=aws role=deployer region=us-east-1 >/dev/null || { echo "vault login failed"; exit 0; }
             GH_TOKEN="$(vault kv get -field=github_token secret/dozuki/global/harness-notify 2>/dev/null)"
             SLACK_TOKEN="$(vault kv get -field=botToken secret/dozuki/global/slack 2>/dev/null)"
@@ -205,17 +206,26 @@ spec:
             DESC="harness {{workflow.name}}: ${STATUS} (configs {{workflow.parameters.configs}}, to-ref {{workflow.parameters.to-ref}})"
 
             # Child detail, gathered once and shared by the PR comment and the Slack
-            # post. For each child: config, phase, and its deepest failure message,
-            # which is where the actually useful line lives (the child's own message
-            # is just "child ... failed").
-            CHILD_JSON=$(kubectl -n argo get workflows -l 'harness/parent={{workflow.name}}' -o json 2>/dev/null               | jq '[.items[] | {
-                  name: .metadata.name,
-                  config: (.metadata.labels["harness/config"] // "-"),
-                  phase: (.status.phase // "-"),
-                  msg: (.status.message // ""),
-                  detail: ([.status.nodes // {} | .[] | select(.phase == "Failed" or .phase == "Error")
-                            | select(.type == "Pod") | "\(.displayName): \(.message // "")"] | join("; "))
-                }]' 2>/dev/null) || CHILD_JSON='[]'
+            # post. For each child: config, phase, the plain Argo node summary
+            # (detail), and - when `harness evidence` is present in the image and a
+            # log fetch succeeds - the actual proximate tofu/terragrunt/helm error
+            # pulled from that node's archived container log (log_excerpt). The
+            # renderer prefers log_excerpt and falls back to detail, so a stale image
+            # (missing the evidence subcommand) or an S3 hiccup just means the card
+            # reads today's node summary instead of the extracted error - never
+            # nothing.
+            WF_JSON=$(kubectl -n argo get workflows -l 'harness/parent={{workflow.name}}' -o json 2>/dev/null)
+            CHILD_JSON=$(printf '%s' "$WF_JSON" | timeout 60 harness evidence --region us-east-1 2>/dev/null)
+            if [ -z "$CHILD_JSON" ] || [ "$CHILD_JSON" = "null" ]; then
+              CHILD_JSON=$(printf '%s' "$WF_JSON" | jq '[.items[] | {
+                    name: .metadata.name,
+                    config: (.metadata.labels["harness/config"] // "-"),
+                    phase: (.status.phase // "-"),
+                    msg: (.status.message // ""),
+                    detail: ([.status.nodes // {} | .[] | select(.phase == "Failed" or .phase == "Error")
+                              | select(.type == "Pod") | "\(.displayName): \(.message // "")"] | join("; "))
+                  }]' 2>/dev/null) || CHILD_JSON='[]'
+            fi
             [ -z "$CHILD_JSON" ] && CHILD_JSON='[]'
 
             if [ -n '{{workflow.parameters.pr-sha}}' ] && [ -n "$GH_TOKEN" ]; then
@@ -235,7 +245,7 @@ spec:
                 "https://api.github.com/repos/{{workflow.parameters.pr-repo}}/commits/{{workflow.parameters.pr-sha}}/pulls" \
                 | jq -r '.[0].number // empty') || PR_NUM=""
               if [ -n "$PR_NUM" ]; then
-                CHILDREN=$(printf '%s' "$CHILD_JSON" | jq -r '.[] | "| `\(.name)` | \(.config) | \(.phase) | \(if .detail != "" then .detail else .msg end) |"')
+                CHILDREN=$(printf '%s' "$CHILD_JSON" | jq -r '.[] | "| `\(.name)` | \(.config) | \(.phase) | \((.log_excerpt // "") | if . != "" then . else (if .detail != "" then .detail else .msg end) end) |"')
                 [ -z "$CHILDREN" ] && CHILDREN='| _no child workflows_ |  |  |  |'
                 BODY=$(printf '### Upgrade harness: %s %s\n\nWorkflow `%s` finished in %s.\n\n- configs `%s`, scenario `%s`\n- from `%s` to `%s`\n\n| child workflow | config | phase | detail |\n|---|---|---|---|\n%s\n' \
                   "$EMOJI" "$STATUS" '{{workflow.name}}' "$DUR_H" \
@@ -280,7 +290,8 @@ spec:
                 from_ref: $fromref, to_ref: ($toref | .[0:64]),
                 duration_seconds: $dur, trigger: $trigger, pr_url: $prurl,
                 children: (map({config: .config, phase: .phase,
-                                detail: (if .detail != "" then .detail else .msg end | .[0:400])}))
+                                detail: (if .detail != "" then .detail else .msg end | .[0:400]),
+                                log_excerpt: (.log_excerpt // "" | .[0:400])}))
               }')
             if [ -n "$RELAY_URL" ] && [ -n "$RELAY_TOKEN" ] && \
                printf '%s' "$RELAY_PAYLOAD" | curl -sf -X POST \

--- a/live/tests/cmd/harness/main.go
+++ b/live/tests/cmd/harness/main.go
@@ -1,11 +1,14 @@
 package main
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"flag"
 	"fmt"
 	"io"
 	"os"
+	"time"
 
 	"github.com/Dozuki/CloudPrem-Infra/live/tests/harness"
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -13,19 +16,28 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 )
 
-const usage = `usage: harness <provision|upgrade|validate|teardown> [flags]
+const usage = `usage: harness <provision|upgrade|validate|teardown|evidence> [flags]
   common: --run-id --config --repo-dir --account-id --profile --region --matrix --state-bucket [--mem-store]
   provision: --scenario <upgrade|fresh> --from-ref --to-ref --namespace
-  teardown:  --keep-on-failure --failed`
+  teardown:  --keep-on-failure --failed
+  evidence:  --region --max-nodes --timeout (reads a WorkflowList json on stdin,
+             writes the CHILD_JSON array on stdout; needs neither --run-id nor --config)`
 
-func main() { os.Exit(dispatch(os.Args[1:], os.Stderr)) }
+func main() { os.Exit(dispatch(os.Args[1:], os.Stdin, os.Stdout, os.Stderr)) }
 
-func dispatch(args []string, stderr io.Writer) int {
+func dispatch(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	if len(args) == 0 {
 		fmt.Fprintln(stderr, usage)
 		return 2
 	}
 	sub, rest := args[0], args[1:]
+
+	// evidence has its own flags (no --run-id/--config) and no matrix, so it
+	// branches out before the shared flagset below demands either.
+	if sub == "evidence" {
+		return runEvidence(rest, stdin, stdout, stderr)
+	}
+
 	fs := flag.NewFlagSet(sub, flag.ContinueOnError)
 	fs.SetOutput(stderr)
 	var (
@@ -120,4 +132,68 @@ func loadAWS(ctx context.Context, profile, region string) (aws.Config, error) {
 		opts = append(opts, config.WithSharedConfigProfile(profile))
 	}
 	return config.LoadDefaultConfig(ctx, opts...)
+}
+
+// runEvidence reads a `kubectl get workflows -o json` WorkflowList from stdin and
+// writes the CHILD_JSON array (the existing name/config/phase/msg/detail fields
+// plus the new log_excerpt) to stdout.
+//
+// This can never silence the failure card: 20-matrix.yaml's post-status step falls
+// back to its own jq expression on anything but a clean exit 0 with non-empty
+// output, so any failure here just means the card reads today's node summary
+// instead of the extracted error - never nothing.
+func runEvidence(rest []string, stdin io.Reader, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("evidence", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	region := fs.String("region", "us-east-1", "AWS region for the S3 log fetch")
+	maxNodes := fs.Int("max-nodes", 3, "max failed Pod nodes fetched per child")
+	timeout := fs.Duration("timeout", 45*time.Second, "overall S3 fetch budget")
+	if err := fs.Parse(rest); err != nil {
+		return 2
+	}
+
+	body, err := io.ReadAll(stdin)
+	if err != nil {
+		fmt.Fprintf(stderr, "evidence: read stdin: %v\n", err)
+		return 1
+	}
+
+	var list harness.WorkflowList
+	if trimmed := bytes.TrimSpace(body); len(trimmed) > 0 {
+		if err := json.Unmarshal(trimmed, &list); err != nil {
+			fmt.Fprintf(stderr, "evidence: parse workflows json: %v\n", err)
+			return 1
+		}
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), *timeout+10*time.Second)
+	defer cancel()
+
+	// Skip AWS entirely when there is nothing to fetch (no children, e.g. the
+	// query raced the children existing yet) - keeps the common no-op case fast
+	// and avoids depending on AWS creds being reachable at all.
+	var fetcher harness.LogTail
+	if len(list.Items) > 0 {
+		awsCfg, err := loadAWS(ctx, "", *region)
+		if err != nil {
+			fmt.Fprintf(stderr, "evidence: aws config: %v\n", err)
+			return 1
+		}
+		fetcher = harness.NewS3LogTail(s3.NewFromConfig(awsCfg))
+	} else {
+		fetcher = harness.NewS3LogTail(nil)
+	}
+
+	children := harness.Build(ctx, list, fetcher, harness.BuildOptions{
+		MaxNodesPerChild: *maxNodes,
+		OverallBudget:    *timeout,
+	})
+
+	out, err := json.Marshal(children)
+	if err != nil {
+		fmt.Fprintf(stderr, "evidence: marshal output: %v\n", err)
+		return 1
+	}
+	fmt.Fprintln(stdout, string(out))
+	return 0
 }

--- a/live/tests/cmd/harness/main_test.go
+++ b/live/tests/cmd/harness/main_test.go
@@ -2,13 +2,14 @@ package main
 
 import (
 	"bytes"
+	"io"
 	"strings"
 	"testing"
 )
 
 func TestDispatchUnknownSubcommand(t *testing.T) {
 	var b bytes.Buffer
-	if code := dispatch([]string{"frobnicate"}, &b); code == 0 {
+	if code := dispatch([]string{"frobnicate"}, strings.NewReader(""), io.Discard, &b); code == 0 {
 		t.Fatalf("unknown subcommand should be non-zero")
 	}
 	if !strings.Contains(b.String(), "usage") {
@@ -19,7 +20,26 @@ func TestDispatchUnknownSubcommand(t *testing.T) {
 func TestDispatchProvisionRequiresFlags(t *testing.T) {
 	var b bytes.Buffer
 	// missing --run-id/--config → non-zero with a clear message
-	if code := dispatch([]string{"provision", "--scenario", "fresh"}, &b); code == 0 {
+	if code := dispatch([]string{"provision", "--scenario", "fresh"}, strings.NewReader(""), io.Discard, &b); code == 0 {
 		t.Fatalf("missing required flags should fail")
+	}
+}
+
+func TestDispatchEvidenceDoesNotRequireRunFlags(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := dispatch([]string{"evidence"}, strings.NewReader(""), &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("evidence with empty stdin: code = %d, stderr = %s", code, stderr.String())
+	}
+	if got := strings.TrimSpace(stdout.String()); got != "[]" {
+		t.Fatalf("stdout = %q, want []", got)
+	}
+}
+
+func TestDispatchEvidenceRejectsMalformedInput(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := dispatch([]string{"evidence"}, strings.NewReader("not json"), &stdout, &stderr)
+	if code == 0 {
+		t.Fatalf("malformed stdin should be non-zero (so the caller's jq fallback triggers)")
 	}
 }

--- a/live/tests/harness/evidence.go
+++ b/live/tests/harness/evidence.go
@@ -1,0 +1,534 @@
+package harness
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"regexp"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+	"unicode/utf8"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+)
+
+// This file turns Argo's generic per-node "main: Error (exit code 1)" into the
+// actual proximate error (a tofu/terragrunt error, a helm timeout, ...) for the
+// harness failure Slack card. The source is already on the child Workflow CR: every
+// failed Pod node carries the exact S3 key of its own archived container log
+// (outputs.artifacts["main-logs"].s3.key), and the CR carries the bucket
+// (status.artifactRepositoryRef.artifactRepository.s3.bucket). No kubectl logs, no
+// new RBAC: post-status already runs as a ServiceAccount whose Pod Identity role
+// holds s3:GetObject on that bucket.
+
+// ---- minimal decode shapes for `kubectl get workflows -o json` ----
+
+// WorkflowList is the shape of `kubectl -n argo get workflows -l ... -o json`.
+type WorkflowList struct {
+	Items []Workflow `json:"items"`
+}
+
+type Workflow struct {
+	Metadata WorkflowMetadata `json:"metadata"`
+	Status   WorkflowStatus   `json:"status"`
+}
+
+type WorkflowMetadata struct {
+	Name   string            `json:"name"`
+	Labels map[string]string `json:"labels"`
+}
+
+type WorkflowStatus struct {
+	Phase                 string                `json:"phase"`
+	Message               string                `json:"message"`
+	ArtifactRepositoryRef ArtifactRepositoryRef `json:"artifactRepositoryRef"`
+	Nodes                 map[string]Node       `json:"nodes"`
+}
+
+type ArtifactRepositoryRef struct {
+	ArtifactRepository ArtifactRepository `json:"artifactRepository"`
+}
+
+type ArtifactRepository struct {
+	S3 S3RepoRef `json:"s3"`
+}
+
+type S3RepoRef struct {
+	Bucket string `json:"bucket"`
+}
+
+type Node struct {
+	ID          string      `json:"id"`
+	Type        string      `json:"type"`
+	Phase       string      `json:"phase"`
+	DisplayName string      `json:"displayName"`
+	Message     string      `json:"message"`
+	FinishedAt  string      `json:"finishedAt"`
+	Outputs     NodeOutputs `json:"outputs"`
+}
+
+type NodeOutputs struct {
+	Artifacts []NodeArtifact `json:"artifacts"`
+}
+
+type NodeArtifact struct {
+	Name string          `json:"name"`
+	S3   *NodeArtifactS3 `json:"s3,omitempty"`
+}
+
+type NodeArtifactS3 struct {
+	Key string `json:"key"`
+}
+
+// artifactKey returns the S3 key of a node's archived container log, or "" if the
+// node has none (e.g. it never started, or the archive step never ran).
+func artifactKey(n Node) string {
+	for _, a := range n.Outputs.Artifacts {
+		if a.Name == "main-logs" && a.S3 != nil {
+			return a.S3.Key
+		}
+	}
+	return ""
+}
+
+// failedPodNodes returns a child's failed Pod nodes, sorted by FinishedAt then
+// DisplayName for determinism, optionally capped at maxNodes (0 = unlimited).
+//
+// Filtering on Type == "Pod" is what excludes the duplicate Retry node Argo also
+// marks Failed for the same phase - Retry nodes carry no artifact of their own, and
+// including them would double every bullet. Steps/StepGroup nodes are excluded the
+// same way.
+func failedPodNodes(wf Workflow, maxNodes int) []Node {
+	var nodes []Node
+	for _, n := range wf.Status.Nodes {
+		if n.Type != "Pod" {
+			continue
+		}
+		if n.Phase != "Failed" && n.Phase != "Error" {
+			continue
+		}
+		nodes = append(nodes, n)
+	}
+	sort.Slice(nodes, func(i, j int) bool {
+		if nodes[i].FinishedAt != nodes[j].FinishedAt {
+			return nodes[i].FinishedAt < nodes[j].FinishedAt
+		}
+		return nodes[i].DisplayName < nodes[j].DisplayName
+	})
+	if maxNodes > 0 && len(nodes) > maxNodes {
+		nodes = nodes[:maxNodes]
+	}
+	return nodes
+}
+
+// ---- fetching the log tail ----
+
+// LogTail fetches the tail of an archived container log. An interface so Build is
+// testable without S3.
+type LogTail interface {
+	Tail(ctx context.Context, bucket, key string) (string, error)
+}
+
+// S3GetObjectAPI is the minimal S3 surface the tail fetch needs.
+type S3GetObjectAPI interface {
+	GetObject(context.Context, *s3.GetObjectInput, ...func(*s3.Options)) (*s3.GetObjectOutput, error)
+}
+
+// tailRangeBytes bounds the fetch cost regardless of log size: the pr440 teardown
+// log is 2.2MB / 14,822 lines, the two upgrade logs are under 1.5KB. Either way we
+// only ever pull the last 256KiB.
+const tailRangeBytes = 256 * 1024
+
+// S3LogTail fetches log tails from the Argo artifact bucket via a suffix byte range.
+type S3LogTail struct {
+	Client S3GetObjectAPI
+}
+
+func NewS3LogTail(client S3GetObjectAPI) *S3LogTail { return &S3LogTail{Client: client} }
+
+func (t *S3LogTail) Tail(ctx context.Context, bucket, key string) (string, error) {
+	out, err := t.Client.GetObject(ctx, &s3.GetObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String(key),
+		Range:  aws.String(fmt.Sprintf("bytes=-%d", tailRangeBytes)),
+	})
+	if err != nil {
+		return "", err
+	}
+	defer out.Body.Close()
+	b, err := io.ReadAll(out.Body)
+	if err != nil {
+		return "", err
+	}
+	s := string(b)
+	// A suffix range starts mid-file, so the first line is possibly a partial
+	// line cut in half. Drop it rather than risk it reading like a truncated
+	// error.
+	if idx := strings.IndexByte(s, '\n'); idx >= 0 {
+		return s[idx+1:], nil
+	}
+	return "", nil
+}
+
+// ---- error extraction ----
+
+const errWindowLines = 400
+
+var (
+	ansiRE     = regexp.MustCompile(`\x1b\[[0-9;]*[a-zA-Z]`)
+	tsPrefixRE = regexp.MustCompile(`^\d{2}:\d{2}:\d{2}\.\d{3}\s+(STDOUT|STDERR|ERROR|WARN|INFO)\s*`)
+
+	verdictRE       = regexp.MustCompile(`^(provision|upgrade|validate|teardown) failed: `)
+	verdictPrefixRE = regexp.MustCompile(`^(?:provision|upgrade|validate|teardown) failed: `)
+	thinVerdictRE   = regexp.MustCompile(`^([\w./-]+: )?exit (status|code) \d+$`)
+
+	// errLineRE deliberately does NOT get its leading "* " stripped by
+	// normalizeLine (see there) - stripping it would make this pattern
+	// unmatchable against terragrunt's own "* Failed to execute ..." banner.
+	errLineRE = regexp.MustCompile(`^(Error:|ERROR\b|fatal:|panic:|\* Failed to execute\b)`)
+
+	noiseRE = regexp.MustCompile(`Still (destroying|creating|modifying)|Destruction complete|Creation complete|^error occurred:$|^exit status \d+$`)
+)
+
+// normalizeLine strips ANSI color codes, terragrunt's "HH:MM:SS.mmm LEVEL"
+// timestamp prefix and repeated "tofu: " markers, and leading box-drawing
+// decoration, then trims whitespace.
+//
+// The leading-decoration strip intentionally leaves a bare "*" alone: that is the
+// bullet on terragrunt's own "* Failed to execute ..." error banner, which errLineRE
+// matches on. Only the box-drawing run/error markers (│ ╷ ╵) are decoration here.
+func normalizeLine(line string) string {
+	line = strings.TrimRight(line, "\r")
+	line = ansiRE.ReplaceAllString(line, "")
+	line = tsPrefixRE.ReplaceAllString(line, "")
+	line = strings.ReplaceAll(line, "tofu: ", "")
+	line = strings.TrimLeft(line, "│╷╵ \t")
+	return strings.TrimSpace(line)
+}
+
+// normalizeAndWindow normalizes every line of log, then keeps only the last
+// errWindowLines of them - the heuristic's contract is that anything further back
+// is not inspected. (This is also why terragrunt.go wraps its own error at the
+// source: a tofu failure that scrolls past this window would otherwise degrade to
+// a bare exit code.)
+func normalizeAndWindow(log string) []string {
+	raw := strings.Split(log, "\n")
+	lines := make([]string, len(raw))
+	for i, l := range raw {
+		lines[i] = normalizeLine(l)
+	}
+	if len(lines) > errWindowLines {
+		lines = lines[len(lines)-errWindowLines:]
+	}
+	return lines
+}
+
+// findErrLine scans lines bottom-up for the last line that looks like a real error,
+// skipping blanks, polling noise, and the exclude line (the verdict, so it is never
+// picked as its own explanation).
+//
+// Bottom-up on purpose: a superseded, non-fatal error the harness deliberately
+// continued past (e.g. "logical destroy failed (continuing to physical so infra
+// isn't stranded)") can sit thousands of lines above the real failure. First-match
+// would report the wrong error.
+func findErrLine(lines []string, exclude string) string {
+	for i := len(lines) - 1; i >= 0; i-- {
+		l := lines[i]
+		if l == "" || l == exclude {
+			continue
+		}
+		if noiseRE.MatchString(l) {
+			continue
+		}
+		if errLineRE.MatchString(l) {
+			return l
+		}
+	}
+	return ""
+}
+
+// ExtractError picks the single most useful line out of a (possibly truncated) log
+// tail, or "" if nothing in the window looks like a real error - callers fall back
+// to the Argo node message in that case.
+//
+// verdict is the last line matching "<phase> failed: ..." - the one choke point
+// every phase failure in cmd/harness/main.go funnels through. It is usually the most
+// specific thing available (e.g. "upgrade failed: worktree add <sha>: exit status
+// 128"). But when the wrapped error is itself just a bare exit code ("teardown
+// failed: destroy: exit status 1" - a "thin" verdict), the real explanation is the
+// tofu/terragrunt error underneath, so errLine wins instead.
+func ExtractError(log string) string {
+	lines := normalizeAndWindow(log)
+
+	verdict := ""
+	for _, l := range lines {
+		if verdictRE.MatchString(l) {
+			verdict = l
+		}
+	}
+
+	errLine := findErrLine(lines, verdict)
+
+	if verdict != "" {
+		rest := verdictPrefixRE.ReplaceAllString(verdict, "")
+		if thinVerdictRE.MatchString(rest) && errLine != "" {
+			return errLine
+		}
+		return verdict
+	}
+	return errLine
+}
+
+// lastErrorLine is ExtractError's errLine step alone, capped to 400 runes. It exists
+// for terragrunt.go, which wraps Apply/destroyModule's captured output into the
+// returned error before cmd/harness/main.go ever writes a "<phase> failed: ..."
+// verdict line - so there is no verdict to prefer yet, just the tofu/terragrunt
+// output itself.
+func lastErrorLine(out string) string {
+	lines := normalizeAndWindow(out)
+	return truncateRunes(findErrLine(lines, ""), 400)
+}
+
+// truncateRunes cuts s to at most n runes on a rune boundary, appending "…" (which
+// counts toward n) when it truncates.
+func truncateRunes(s string, n int) string {
+	if n <= 0 || s == "" {
+		return ""
+	}
+	if utf8.RuneCountInString(s) <= n {
+		return s
+	}
+	r := []rune(s)
+	if n == 1 {
+		return "…"
+	}
+	return string(r[:n-1]) + "…"
+}
+
+// ---- secret scrubbing ----
+
+var privateKeyLineRE = regexp.MustCompile(`-----BEGIN [A-Z ]+ PRIVATE KEY-----`)
+
+// scrubRule applies re, replacing matches with repl (which may reference capture
+// groups, e.g. "$1$2[redacted]").
+type scrubRule struct {
+	re   *regexp.Regexp
+	repl string
+}
+
+// scrubRules runs in order: specific token shapes first (so a Vault/AWS/Slack/
+// GitHub/JWT token is labeled precisely), then the generic password/token keyword
+// rule, then the generic base64-blob catch-all last (so it never eats a shorter,
+// already-labeled replacement).
+//
+// The blob threshold is 60, not 40: a 40-hex git SHA must survive scrubbing (in the
+// bad-ref specimen, the SHA IS the diagnostic). AWS account ids and ARNs are not
+// scrubbed at all - they are already all over the existing cards and PR comments.
+var scrubRules = []scrubRule{
+	{regexp.MustCompile(`hvs\.[A-Za-z0-9_-]{20,}`), "[redacted-vault-token]"},
+	{regexp.MustCompile(`hvb\.[A-Za-z0-9_-]{20,}`), "[redacted-vault-token]"},
+	{regexp.MustCompile(`\bs\.[A-Za-z0-9]{24,}\b`), "[redacted-vault-token]"},
+	{regexp.MustCompile(`\b(?:AKIA|ASIA)[0-9A-Z]{16}\b`), "[redacted-akid]"},
+	{regexp.MustCompile(`xox[abprs]-[A-Za-z0-9-]{10,}`), "[redacted-slack-token]"},
+	{regexp.MustCompile(`gh[pousr]_[A-Za-z0-9]{20,}`), "[redacted-github-token]"},
+	{regexp.MustCompile(`github_pat_[A-Za-z0-9_]{20,}`), "[redacted-github-token]"},
+	{regexp.MustCompile(`eyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}`), "[redacted-jwt]"},
+	{regexp.MustCompile(`(?i)(password|passwd|secret|token|api[_-]?key|session[_-]?token)(["']?\s*[:=]\s*["']?)[^\s"',]{6,}`), "$1$2[redacted]"},
+	{regexp.MustCompile(`[A-Za-z0-9+/]{60,}={0,2}`), "[redacted-blob]"},
+}
+
+// Scrub redacts secret-shaped substrings from s and drops any line that carries a
+// PEM private key header entirely. Runs both in CPI (before the text leaves the
+// cluster) and again in the Slack relay module (defence in depth).
+func Scrub(s string) string {
+	if strings.Contains(s, "PRIVATE KEY-----") {
+		var kept []string
+		for _, l := range strings.Split(s, "\n") {
+			if privateKeyLineRE.MatchString(l) {
+				continue
+			}
+			kept = append(kept, l)
+		}
+		s = strings.Join(kept, "\n")
+	}
+	for _, r := range scrubRules {
+		s = r.re.ReplaceAllString(s, r.repl)
+	}
+	return s
+}
+
+// ---- assembling the per-child evidence payload ----
+
+const (
+	maxLineExcerptRunes     = 220 // per extracted line, before the "; " join
+	maxChildExcerptRunes    = 400 // per child, after the join - matches the relay's existing per-child slice
+	defaultMaxNodesPerChild = 3
+	defaultWorkers          = 4
+	defaultPerObjectTimeout = 5 * time.Second
+	defaultOverallBudget    = 45 * time.Second
+)
+
+// ChildEvidence is one child workflow's row in the CHILD_JSON array post-status
+// builds. Field order/tags match the existing jq output (name, config, phase, msg,
+// detail) plus the new log_excerpt key.
+type ChildEvidence struct {
+	Name       string `json:"name"`
+	Config     string `json:"config"`
+	Phase      string `json:"phase"`
+	Msg        string `json:"msg"`
+	Detail     string `json:"detail"`
+	LogExcerpt string `json:"log_excerpt"`
+}
+
+// BuildOptions bounds Build's S3 fan-out. Zero values take the defaults below.
+type BuildOptions struct {
+	MaxNodesPerChild int
+	Workers          int
+	PerObjectTimeout time.Duration
+	OverallBudget    time.Duration
+}
+
+func (o BuildOptions) withDefaults() BuildOptions {
+	if o.MaxNodesPerChild <= 0 {
+		o.MaxNodesPerChild = defaultMaxNodesPerChild
+	}
+	if o.Workers <= 0 {
+		o.Workers = defaultWorkers
+	}
+	if o.PerObjectTimeout <= 0 {
+		o.PerObjectTimeout = defaultPerObjectTimeout
+	}
+	if o.OverallBudget <= 0 {
+		o.OverallBudget = defaultOverallBudget
+	}
+	return o
+}
+
+// childBase builds a child's {name, config, phase, msg, detail} exactly as the jq
+// expression it replaces did - detail is unchanged in meaning and in how it is
+// computed, uncapped, so an un-bumped renderer sees identical text.
+func childBase(wf Workflow) ChildEvidence {
+	config := wf.Metadata.Labels["harness/config"]
+	if config == "" {
+		config = "-"
+	}
+	phase := wf.Status.Phase
+	if phase == "" {
+		phase = "-"
+	}
+	var parts []string
+	for _, n := range failedPodNodes(wf, 0) {
+		parts = append(parts, fmt.Sprintf("%s: %s", n.DisplayName, n.Message))
+	}
+	return ChildEvidence{
+		Name:   wf.Metadata.Name,
+		Config: config,
+		Phase:  phase,
+		Msg:    wf.Status.Message,
+		Detail: strings.Join(parts, "; "),
+	}
+}
+
+// Build assembles CHILD_JSON for every child in list, fetching each failed Pod
+// node's archived log tail through fetcher and extracting the proximate error.
+// Any fetch or extraction miss (timeout, missing artifact, empty log, no
+// recognizable error line) leaves that child's LogExcerpt at "" - callers then fall
+// back to Detail, which is exactly today's card text. This function can never make
+// a child's evidence worse, only better.
+func Build(ctx context.Context, list WorkflowList, fetcher LogTail, opts BuildOptions) []ChildEvidence {
+	opts = opts.withDefaults()
+
+	ctx, cancel := context.WithTimeout(ctx, opts.OverallBudget)
+	defer cancel()
+
+	children := make([]ChildEvidence, len(list.Items))
+	perChildNodes := make([][]Node, len(list.Items))
+	for i, wf := range list.Items {
+		children[i] = childBase(wf)
+		perChildNodes[i] = failedPodNodes(wf, opts.MaxNodesPerChild)
+	}
+
+	type job struct {
+		childIdx, nodeIdx    int
+		bucket, key, display string
+	}
+	var jobs []job
+	for i, wf := range list.Items {
+		bucket := wf.Status.ArtifactRepositoryRef.ArtifactRepository.S3.Bucket
+		for ni, n := range perChildNodes[i] {
+			key := artifactKey(n)
+			if bucket == "" || key == "" {
+				continue
+			}
+			jobs = append(jobs, job{childIdx: i, nodeIdx: ni, bucket: bucket, key: key, display: n.DisplayName})
+		}
+	}
+
+	// results[childIdx][nodeIdx] holds "displayName: excerpt", or "" on a miss.
+	// Each job owns a disjoint slot, so workers write without a lock, and the
+	// final join walks nodeIdx order - deterministic regardless of which worker
+	// finishes first.
+	results := make([][]string, len(list.Items))
+	for i := range results {
+		results[i] = make([]string, len(perChildNodes[i]))
+	}
+
+	workers := opts.Workers
+	if len(jobs) > 0 && workers > len(jobs) {
+		workers = len(jobs)
+	}
+	if workers <= 0 {
+		workers = 1
+	}
+
+	jobCh := make(chan job)
+	var wg sync.WaitGroup
+	for w := 0; w < workers; w++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := range jobCh {
+				octx, cancel := context.WithTimeout(ctx, opts.PerObjectTimeout)
+				tail, err := fetcher.Tail(octx, j.bucket, j.key)
+				cancel()
+				if err != nil {
+					continue
+				}
+				errText := ExtractError(tail)
+				if errText == "" {
+					continue
+				}
+				excerpt := truncateRunes(Scrub(errText), maxLineExcerptRunes)
+				results[j.childIdx][j.nodeIdx] = j.display + ": " + excerpt
+			}
+		}()
+	}
+	go func() {
+		defer close(jobCh)
+		for _, j := range jobs {
+			select {
+			case jobCh <- j:
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+	wg.Wait()
+
+	for i, parts := range results {
+		var nonEmpty []string
+		for _, p := range parts {
+			if p != "" {
+				nonEmpty = append(nonEmpty, p)
+			}
+		}
+		if len(nonEmpty) == 0 {
+			continue
+		}
+		children[i].LogExcerpt = truncateRunes(strings.Join(nonEmpty, "; "), maxChildExcerptRunes)
+	}
+	return children
+}

--- a/live/tests/harness/evidence.go
+++ b/live/tests/harness/evidence.go
@@ -95,7 +95,10 @@ func artifactKey(n Node) string {
 }
 
 // failedPodNodes returns a child's failed Pod nodes, sorted by FinishedAt then
-// DisplayName for determinism, optionally capped at maxNodes (0 = unlimited).
+// DisplayName for determinism. When capped at maxNodes (0 = unlimited), it keeps the
+// LATEST maxNodes by FinishedAt, not the earliest - the most recent failures are the
+// ones relevant to why the run is currently red; an early failure that later ones
+// piled on top of is the least useful one to spend the node budget on.
 //
 // Filtering on Type == "Pod" is what excludes the duplicate Retry node Argo also
 // marks Failed for the same phase - Retry nodes carry no artifact of their own, and
@@ -119,7 +122,7 @@ func failedPodNodes(wf Workflow, maxNodes int) []Node {
 		return nodes[i].DisplayName < nodes[j].DisplayName
 	})
 	if maxNodes > 0 && len(nodes) > maxNodes {
-		nodes = nodes[:maxNodes]
+		nodes = nodes[len(nodes)-maxNodes:]
 	}
 	return nodes
 }
@@ -164,13 +167,36 @@ func (t *S3LogTail) Tail(ctx context.Context, bucket, key string) (string, error
 		return "", err
 	}
 	s := string(b)
-	// A suffix range starts mid-file, so the first line is possibly a partial
-	// line cut in half. Drop it rather than risk it reading like a truncated
-	// error.
-	if idx := strings.IndexByte(s, '\n'); idx >= 0 {
-		return s[idx+1:], nil
+	// A suffix range that lands mid-file starts partway through a line, so line 1 is
+	// possibly cut in half - drop it rather than risk it reading like a truncated
+	// error. But when the object is smaller than tailRangeBytes, S3 answers the
+	// suffix request with the WHOLE object (still 206 Partial Content, but
+	// Content-Range's start offset is 0): line 1 is then intact, and dropping it
+	// would wrongly discard a short log's only content - including turning a
+	// single-line log with no trailing newline into "" instead of its real text.
+	if s3PartialStart(out.ContentRange) {
+		if idx := strings.IndexByte(s, '\n'); idx >= 0 {
+			return s[idx+1:], nil
+		}
+		return "", nil
 	}
-	return "", nil
+	return s, nil
+}
+
+// s3PartialStart reports whether an S3 Content-Range response header ("bytes
+// start-end/total") indicates the returned bytes begin after offset 0 - i.e. this is
+// a genuine partial read and its first line may be a fragment. A missing or
+// unparsable header is treated as a whole-object read (the safer default: it keeps
+// content rather than risking silently dropping line 1 of a short log).
+func s3PartialStart(contentRange *string) bool {
+	if contentRange == nil {
+		return false
+	}
+	var start int64
+	if _, err := fmt.Sscanf(*contentRange, "bytes %d-", &start); err != nil {
+		return false
+	}
+	return start > 0
 }
 
 // ---- error extraction ----
@@ -185,6 +211,15 @@ var (
 	verdictPrefixRE = regexp.MustCompile(`^(?:provision|upgrade|validate|teardown) failed: `)
 	thinVerdictRE   = regexp.MustCompile(`^([\w./-]+: )?exit (status|code) \d+$`)
 
+	// awsSDKBoilerplateRE matches the aws-sdk-go-v2 error wrapper that every service
+	// error carries ("operation error <Service>: <Operation>, https response error
+	// StatusCode: <NNN>, RequestID: <uuid>, ") ahead of the actual diagnostic (e.g.
+	// "InvalidResourceStateFault: ... cannot be stopped."). It is pure noise - the
+	// service/operation/status code/request id never explain the failure - and at
+	// ~150 runes it is often the difference between the real diagnostic surviving
+	// the per-line excerpt cap or being truncated away before it appears.
+	awsSDKBoilerplateRE = regexp.MustCompile(`operation error [^,]+, https response error StatusCode: \d+, RequestID: [0-9a-fA-F-]+, `)
+
 	// errLineRE deliberately does NOT get its leading "* " stripped by
 	// normalizeLine (see there) - stripping it would make this pattern
 	// unmatchable against terragrunt's own "* Failed to execute ..." banner.
@@ -194,8 +229,8 @@ var (
 )
 
 // normalizeLine strips ANSI color codes, terragrunt's "HH:MM:SS.mmm LEVEL"
-// timestamp prefix and repeated "tofu: " markers, and leading box-drawing
-// decoration, then trims whitespace.
+// timestamp prefix, a repeated leading "tofu: " marker, the aws-sdk-go-v2 error
+// wrapper boilerplate, and leading box-drawing decoration, then trims whitespace.
 //
 // The leading-decoration strip intentionally leaves a bare "*" alone: that is the
 // bullet on terragrunt's own "* Failed to execute ..." error banner, which errLineRE
@@ -204,7 +239,14 @@ func normalizeLine(line string) string {
 	line = strings.TrimRight(line, "\r")
 	line = ansiRE.ReplaceAllString(line, "")
 	line = tsPrefixRE.ReplaceAllString(line, "")
-	line = strings.ReplaceAll(line, "tofu: ", "")
+	// Prefix-anchored only: "tofu: " can legitimately appear mid-line (e.g. an error
+	// message that itself mentions running tofu), and stripping it wherever it
+	// occurs would silently mangle that text. terragrunt can repeat the marker
+	// ("tofu: tofu: ..."), so trim it off the front in a loop.
+	for strings.HasPrefix(line, "tofu: ") {
+		line = strings.TrimPrefix(line, "tofu: ")
+	}
+	line = awsSDKBoilerplateRE.ReplaceAllString(line, "")
 	line = strings.TrimLeft(line, "│╷╵ \t")
 	return strings.TrimSpace(line)
 }
@@ -310,7 +352,10 @@ func truncateRunes(s string, n int) string {
 
 // ---- secret scrubbing ----
 
-var privateKeyLineRE = regexp.MustCompile(`-----BEGIN [A-Z ]+ PRIVATE KEY-----`)
+// privateKeyLineRE matches both the classic PKCS#1-style headers ("-----BEGIN RSA
+// PRIVATE KEY-----") and the algorithm-less PKCS#8 header ("-----BEGIN PRIVATE
+// KEY-----").
+var privateKeyLineRE = regexp.MustCompile(`-----BEGIN [A-Z ]*PRIVATE KEY-----`)
 
 // scrubRule applies re, replacing matches with repl (which may reference capture
 // groups, e.g. "$1$2[redacted]").
@@ -336,7 +381,22 @@ var scrubRules = []scrubRule{
 	{regexp.MustCompile(`gh[pousr]_[A-Za-z0-9]{20,}`), "[redacted-github-token]"},
 	{regexp.MustCompile(`github_pat_[A-Za-z0-9_]{20,}`), "[redacted-github-token]"},
 	{regexp.MustCompile(`eyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}`), "[redacted-jwt]"},
-	{regexp.MustCompile(`(?i)(password|passwd|secret|token|api[_-]?key|session[_-]?token)(["']?\s*[:=]\s*["']?)[^\s"',]{6,}`), "$1$2[redacted]"},
+	// Embedded keyword rule: the keyword can sit anywhere inside a longer
+	// identifier (AWS_SECRET_ACCESS_KEY, DB_PASSWORD, ...), not just stand alone -
+	// the old alternation (password|passwd|secret|token|api[_-]?key|session[_-]?key)
+	// required the keyword to butt directly against the separator, so
+	// "AWS_SECRET_ACCESS_KEY=..." never matched (the "_ACCESS_KEY" in between broke
+	// it). Only the value is replaced, so the variable name stays for context.
+	//
+	// The value must not start with "[" - several labels above ("[redacted-vault-
+	// token]", "[redacted-slack-token]", "[redacted-github-token]") contain the word
+	// "token", and without this guard this rule would run over its own output and
+	// flatten those specific labels down to a bare "[redacted]".
+	{regexp.MustCompile(`(?i)([A-Za-z_]*(?:secret|password|passwd|token|key)[A-Za-z_]*\s*[:=]\s*)[^\s\[]\S*`), "$1[redacted]"},
+	// URL-embedded credentials: scheme://user:password@host - the password never
+	// matches the keyword rule above (nothing there looks like "secret"/"token"/
+	// etc), so it needs its own rule. The username is left visible for context.
+	{regexp.MustCompile(`([A-Za-z][A-Za-z0-9+.-]*://[^\s:/@]+:)[^\s@]+(@)`), "$1[redacted]$2"},
 	{regexp.MustCompile(`[A-Za-z0-9+/]{60,}={0,2}`), "[redacted-blob]"},
 }
 
@@ -363,8 +423,17 @@ func Scrub(s string) string {
 // ---- assembling the per-child evidence payload ----
 
 const (
-	maxLineExcerptRunes     = 220 // per extracted line, before the "; " join
-	maxChildExcerptRunes    = 400 // per child, after the join - matches the relay's existing per-child slice
+	// maxLineExcerptRunes and maxChildExcerptRunes both got bumped (220->300,
+	// 400->460) alongside the aws-sdk-go-v2 boilerplate strip above: a real DMS
+	// specimen's diagnostic ("Error: stopping DMS Serverless Replication (arn:...):
+	// InvalidResourceStateFault: ... cannot be stopped.") is still ~270 runes once
+	// the boilerplate is gone, and a two-node child joining an upgrade + a destroy
+	// failure runs ~425 runes total - both would still get truncated away under the
+	// old caps. 20-matrix.yaml's jq slice on log_excerpt must stay in sync with
+	// maxChildExcerptRunes (the "relay's existing per-child slice" this comment
+	// refers to).
+	maxLineExcerptRunes     = 300 // per extracted line, before the "; " join
+	maxChildExcerptRunes    = 460 // per child, after the join - matches the relay's existing per-child slice
 	defaultMaxNodesPerChild = 3
 	defaultWorkers          = 4
 	defaultPerObjectTimeout = 5 * time.Second

--- a/live/tests/harness/evidence.go
+++ b/live/tests/harness/evidence.go
@@ -392,7 +392,11 @@ var scrubRules = []scrubRule{
 	// token]", "[redacted-slack-token]", "[redacted-github-token]") contain the word
 	// "token", and without this guard this rule would run over its own output and
 	// flatten those specific labels down to a bare "[redacted]".
-	{regexp.MustCompile(`(?i)([A-Za-z_]*(?:secret|password|passwd|token|key)[A-Za-z_]*\s*[:=]\s*)[^\s\[]\S*`), "$1[redacted]"},
+	// Bare "key" is deliberately absent from the alternation: it would redact
+	// kms_key_id ARNs and "creating KMS Key:" lines out of exactly the tofu
+	// errors this excerpt exists to show. Only qualified key forms are
+	// credential-shaped.
+	{regexp.MustCompile(`(?i)([A-Za-z_]*(?:secret|password|passwd|token|(?:api|access|private|signing|secret)[_-]?key)[A-Za-z_]*\s*[:=]\s*)[^\s\[]\S*`), "$1[redacted]"},
 	// URL-embedded credentials: scheme://user:password@host - the password never
 	// matches the keyword rule above (nothing there looks like "secret"/"token"/
 	// etc), so it needs its own rule. The username is left visible for context.

--- a/live/tests/harness/evidence_test.go
+++ b/live/tests/harness/evidence_test.go
@@ -92,12 +92,72 @@ func TestScrubRedactsSecrets(t *testing.T) {
 		{"password kv", `password="hunter2hunter"`},
 		{"base64 blob", strings.Repeat("QUJDREVGR0hJSktMTU5PUFFSU1RVVldYWVowMTIzNDU2Nzg5", 2)},
 		{"private key", "-----BEGIN RSA PRIVATE KEY-----\nMIIBogIBAAJ...\n-----END RSA PRIVATE KEY-----"},
+		{"private key pkcs8", "-----BEGIN PRIVATE KEY-----\nMIIBogIBAAJ...\n-----END PRIVATE KEY-----"},
+		{"embedded keyword env var", "AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"},
+		{"url credentials", "mysql://root:SuperSecretPw1@host/db"},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			got := Scrub(c.input)
 			if got == c.input {
 				t.Errorf("Scrub(%q) left input unchanged", c.input)
+			}
+		})
+	}
+}
+
+func TestScrubRedactsEmbeddedKeywordAndURLCredentials(t *testing.T) {
+	cases := []struct {
+		name        string
+		input       string
+		mustNotHave string
+		mustHave    string
+	}{
+		{
+			name:        "aws secret access key",
+			input:       "AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+			mustNotHave: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+			mustHave:    "AWS_SECRET_ACCESS_KEY=[redacted]",
+		},
+		{
+			name:        "mysql url password",
+			input:       "mysql://root:SuperSecretPw1@host/db",
+			mustNotHave: "SuperSecretPw1",
+			mustHave:    "mysql://root:[redacted]@host/db",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := Scrub(c.input)
+			if strings.Contains(got, c.mustNotHave) {
+				t.Errorf("Scrub(%q) = %q, must not contain the raw secret %q", c.input, got, c.mustNotHave)
+			}
+			if !strings.Contains(got, c.mustHave) {
+				t.Errorf("Scrub(%q) = %q, want it to contain %q", c.input, got, c.mustHave)
+			}
+		})
+	}
+}
+
+// TestScrubKeywordRuleDoesNotFlattenSpecificLabels guards against the widened
+// keyword rule running over its own output: several specific labels above
+// ("[redacted-vault-token]", "[redacted-slack-token]", "[redacted-github-token]")
+// contain the word "token", which the generic keyword rule also matches on.
+func TestScrubKeywordRuleDoesNotFlattenSpecificLabels(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"vault token", "VAULT_TOKEN=hvs.CAESIJf8vN3vN3vN3vN3vN3vN3vN3vN3vN3vN3vN3vN3vN3", "[redacted-vault-token]"},
+		{"slack token", "SLACK_TOKEN=xoxb-1234567890-abcdefghij", "[redacted-slack-token]"},
+		{"github token", "GH_TOKEN=ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789", "[redacted-github-token]"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := Scrub(c.input)
+			if !strings.Contains(got, c.want) {
+				t.Errorf("Scrub(%q) = %q, want the specific label %q preserved (not flattened to a bare [redacted])", c.input, got, c.want)
 			}
 		})
 	}
@@ -207,14 +267,35 @@ func TestBuildCapsAtThreeNodesPerChild(t *testing.T) {
 	_ = Build(context.Background(), WorkflowList{Items: []Workflow{wf}}, stub, BuildOptions{})
 
 	stub.mu.Lock()
-	n := len(stub.requested)
+	got := append([]string(nil), stub.requested...)
 	stub.mu.Unlock()
-	if n != 3 {
-		t.Errorf("requested %d objects, want 3 (the per-child node cap)", n)
+	if len(got) != 3 {
+		t.Errorf("requested %d objects, want 3 (the per-child node cap)", len(got))
 	}
-	for _, r := range stub.requested {
+	for _, r := range got {
 		if strings.Contains(r, "retry-a") {
-			t.Errorf("Retry node was fetched: %v", stub.requested)
+			t.Errorf("Retry node was fetched: %v", got)
+		}
+	}
+	// The cap must keep the LATEST 3 by FinishedAt (c, d, e), not the earliest (a,
+	// b, c) - the most recent failures are the ones relevant to a currently-red run.
+	for _, want := range []string{"c/main.log", "d/main.log", "e/main.log"} {
+		found := false
+		for _, r := range got {
+			if strings.Contains(r, want) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("requested %v, want it to include the latest node %q", got, want)
+		}
+	}
+	for _, notWant := range []string{"a/main.log", "b/main.log"} {
+		for _, r := range got {
+			if strings.Contains(r, notWant) {
+				t.Errorf("requested %v, want the earliest nodes dropped in favor of the latest", got)
+			}
 		}
 	}
 }
@@ -273,6 +354,37 @@ func TestBuildRespectsWireBudget(t *testing.T) {
 		}
 		if c.LogExcerpt != "" && !strings.HasSuffix(c.LogExcerpt, "…") {
 			t.Errorf("child %q: log_excerpt = %q, want it truncated with an ellipsis", c.Name, c.LogExcerpt)
+		}
+	}
+}
+
+// TestBuildDMSDiagnosticSurvivesTruncation is the CRITICAL regression for the
+// aws-sdk-go-v2 boilerplate strip: it asserts on Build's actual card-visible output
+// (ChildEvidence.LogExcerpt), not just ExtractError's return value, since Build
+// applies its own truncation on top of ExtractError and that is where the
+// diagnostic was getting cut off before the fix.
+func TestBuildDMSDiagnosticSurvivesTruncation(t *testing.T) {
+	list := loadWorkflowList(t, "workflows-list.json")
+	logs := map[string]string{
+		"dozuki-argo-artifacts-010601635461/harness-min-default-mdgxp/harness-min-default-mdgxp-run-1651265260/main.log": readTestdata(t, "min-default-upgrade.log"),
+		"dozuki-argo-artifacts-010601635461/harness-bi-ha-8dps9/harness-bi-ha-8dps9-run-3742410289/main.log":             readTestdata(t, "min-default-upgrade.log"),
+		"dozuki-argo-artifacts-010601635461/harness-bi-ha-8dps9/harness-bi-ha-8dps9-run-945485330/main.log":              readTestdata(t, "bi-ha-destroy-tail.log"),
+	}
+	stub := &stubFetcher{logs: logs}
+	children := Build(context.Background(), list, stub, BuildOptions{})
+
+	var biHa *ChildEvidence
+	for i := range children {
+		if children[i].Config == "bi_ha" {
+			biHa = &children[i]
+		}
+	}
+	if biHa == nil {
+		t.Fatal("no bi_ha child in Build() output")
+	}
+	for _, want := range []string{"InvalidResourceStateFault", "cannot be stopped"} {
+		if !strings.Contains(biHa.LogExcerpt, want) {
+			t.Errorf("bi_ha LogExcerpt = %q, want it to contain %q (the DMS diagnostic must survive both the per-line and per-child truncation)", biHa.LogExcerpt, want)
 		}
 	}
 }

--- a/live/tests/harness/evidence_test.go
+++ b/live/tests/harness/evidence_test.go
@@ -169,6 +169,11 @@ func TestScrubKeepsDiagnosticSurvivors(t *testing.T) {
 		"arn:aws:dms:us-east-1:000000000000:replication-config:REPLICATIONCONFIGID",
 		"dozuki-argo-artifacts-010601635461",
 		"smokef9b3-bi-reader",
+		// KMS diagnostics are the most common real failure shape; a bare "key"
+		// alternation redacted all three of these.
+		"kms_key_id = arn:aws:kms:us-east-1:000000000000:key/abc-def-1234",
+		"Error: creating KMS Key: AccessDeniedException: User is not authorized",
+		"keyspace: production",
 	}
 	for _, s := range survivors {
 		t.Run(s, func(t *testing.T) {

--- a/live/tests/harness/evidence_test.go
+++ b/live/tests/harness/evidence_test.go
@@ -1,0 +1,318 @@
+package harness
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"testing"
+	"unicode/utf8"
+)
+
+func readTestdata(t *testing.T, name string) string {
+	t.Helper()
+	b, err := os.ReadFile(filepath.Join("testdata", "evidence", name))
+	if err != nil {
+		t.Fatalf("read testdata %s: %v", name, err)
+	}
+	return string(b)
+}
+
+func TestExtractErrorPrefersTofuErrorOverThinVerdict(t *testing.T) {
+	got := ExtractError(readTestdata(t, "bi-ha-destroy-tail.log"))
+	for _, want := range []string{"InvalidResourceStateFault", "cannot be stopped"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("ExtractError() = %q, want it to contain %q", got, want)
+		}
+	}
+	for _, notWant := range []string{"Still destroying", "context deadline exceeded"} {
+		if strings.Contains(got, notWant) {
+			t.Errorf("ExtractError() = %q, must not contain %q (superseded/noise)", got, notWant)
+		}
+	}
+	if got == "teardown failed: destroy: exit status 1" {
+		t.Errorf("ExtractError() returned the thin verdict verbatim; the tofu error should have won")
+	}
+}
+
+func TestExtractErrorKeepsInformativeVerdict(t *testing.T) {
+	got := ExtractError(readTestdata(t, "min-default-upgrade.log"))
+	want := "upgrade failed: worktree add 8f347c78fb11039a9737c30e956fa16e5f57cd78 (8f347c78fb11039a9737c30e956fa16e5f57cd78): exit status 128"
+	if got != want {
+		t.Errorf("ExtractError() = %q, want %q", got, want)
+	}
+}
+
+func TestExtractErrorReturnsEmptyOnNoise(t *testing.T) {
+	got := ExtractError(readTestdata(t, "noise-only.log"))
+	if got != "" {
+		t.Errorf("ExtractError() = %q, want \"\" (falls back to node message)", got)
+	}
+}
+
+func TestExtractErrorStripsAnsiAndTerragruntPrefix(t *testing.T) {
+	got := ExtractError(readTestdata(t, "bi-ha-destroy-tail.log"))
+	for _, bad := range []string{"\x1b[", "STDERR", "│"} {
+		if strings.Contains(got, bad) {
+			t.Errorf("ExtractError() = %q, must not contain raw decoration %q", got, bad)
+		}
+	}
+	if strings.HasPrefix(got, "01:") {
+		t.Errorf("ExtractError() = %q, still carries a timestamp prefix", got)
+	}
+}
+
+func TestExtractErrorWindowIsBounded(t *testing.T) {
+	var b strings.Builder
+	b.WriteString("Error: the real error, but it is 50000 lines from the tail\n")
+	for i := 0; i < 50000; i++ {
+		b.WriteString("module.thing: Still destroying... [id=x, 1s elapsed]\n")
+	}
+	got := ExtractError(b.String())
+	if got != "" {
+		t.Errorf("ExtractError() = %q, want \"\" - the error is outside the 400-line window", got)
+	}
+}
+
+func TestScrubRedactsSecrets(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+	}{
+		{"vault token", "VAULT_TOKEN=hvs.CAESIJf8vN3vN3vN3vN3vN3vN3vN3vN3vN3vN3vN3vN3vN3"},
+		{"akid", "aws_access_key_id = AKIAIOSFODNN7EXAMPLE"},
+		{"asid", "aws_access_key_id = ASIAIOSFODNN7EXAMPLE"},
+		{"slack token", "SLACK_TOKEN=xoxb-1234567890-abcdefghij"},
+		{"github token", "GH_TOKEN=ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"},
+		{"jwt", "Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dQw4w9WgXcQ_dQw4w9WgXcQdQw4w9WgXcQ"},
+		{"password kv", `password="hunter2hunter"`},
+		{"base64 blob", strings.Repeat("QUJDREVGR0hJSktMTU5PUFFSU1RVVldYWVowMTIzNDU2Nzg5", 2)},
+		{"private key", "-----BEGIN RSA PRIVATE KEY-----\nMIIBogIBAAJ...\n-----END RSA PRIVATE KEY-----"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := Scrub(c.input)
+			if got == c.input {
+				t.Errorf("Scrub(%q) left input unchanged", c.input)
+			}
+		})
+	}
+}
+
+func TestScrubKeepsDiagnosticSurvivors(t *testing.T) {
+	survivors := []string{
+		"8f347c78fb11039a9737c30e956fa16e5f57cd78", // 40-hex git SHA
+		"arn:aws:dms:us-east-1:000000000000:replication-config:REPLICATIONCONFIGID",
+		"dozuki-argo-artifacts-010601635461",
+		"smokef9b3-bi-reader",
+	}
+	for _, s := range survivors {
+		t.Run(s, func(t *testing.T) {
+			if got := Scrub(s); got != s {
+				t.Errorf("Scrub(%q) = %q, want it unchanged", s, got)
+			}
+		})
+	}
+}
+
+func loadWorkflowList(t *testing.T, name string) WorkflowList {
+	t.Helper()
+	var list WorkflowList
+	if err := json.Unmarshal([]byte(readTestdata(t, name)), &list); err != nil {
+		t.Fatalf("unmarshal %s: %v", name, err)
+	}
+	return list
+}
+
+// stubFetcher answers Tail from an in-memory map keyed by "bucket/key", or via a
+// custom fn when set - so tests can simulate misses/timeouts without real S3.
+type stubFetcher struct {
+	logs      map[string]string
+	fn        func(ctx context.Context, bucket, key string) (string, error)
+	mu        sync.Mutex
+	requested []string
+}
+
+func (s *stubFetcher) Tail(ctx context.Context, bucket, key string) (string, error) {
+	s.mu.Lock()
+	s.requested = append(s.requested, bucket+"/"+key)
+	s.mu.Unlock()
+	if s.fn != nil {
+		return s.fn(ctx, bucket, key)
+	}
+	if s.logs != nil {
+		if v, ok := s.logs[bucket+"/"+key]; ok {
+			return v, nil
+		}
+	}
+	return "", errors.New("stub: no log for " + bucket + "/" + key)
+}
+
+func TestBuildSelectsArtifactKeyPerFailedPodNode(t *testing.T) {
+	list := loadWorkflowList(t, "workflows-list.json")
+	stub := &stubFetcher{logs: map[string]string{}}
+	_ = Build(context.Background(), list, stub, BuildOptions{})
+
+	stub.mu.Lock()
+	got := append([]string(nil), stub.requested...)
+	stub.mu.Unlock()
+	sort.Strings(got)
+
+	want := []string{
+		"dozuki-argo-artifacts-010601635461/harness-bi-ha-8dps9/harness-bi-ha-8dps9-run-3742410289/main.log",
+		"dozuki-argo-artifacts-010601635461/harness-bi-ha-8dps9/harness-bi-ha-8dps9-run-945485330/main.log",
+		"dozuki-argo-artifacts-010601635461/harness-min-default-mdgxp/harness-min-default-mdgxp-run-1651265260/main.log",
+	}
+	sort.Strings(want)
+	if len(got) != len(want) {
+		t.Fatalf("requested %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("requested[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestBuildCapsAtThreeNodesPerChild(t *testing.T) {
+	mkNode := func(id, finishedAt string) Node {
+		return Node{
+			ID: id, Type: "Pod", Phase: "Failed", DisplayName: id, FinishedAt: finishedAt,
+			Outputs: NodeOutputs{Artifacts: []NodeArtifact{{Name: "main-logs", S3: &NodeArtifactS3{Key: id + "/main.log"}}}},
+		}
+	}
+	wf := Workflow{
+		Metadata: WorkflowMetadata{Name: "harness-many-abcde", Labels: map[string]string{"harness/config": "many"}},
+		Status: WorkflowStatus{
+			Phase:                 "Failed",
+			ArtifactRepositoryRef: ArtifactRepositoryRef{ArtifactRepository{S3RepoRef{Bucket: "b"}}},
+			Nodes: map[string]Node{
+				"a": mkNode("a", "2026-08-04T00:00:01Z"),
+				"b": mkNode("b", "2026-08-04T00:00:02Z"),
+				"c": mkNode("c", "2026-08-04T00:00:03Z"),
+				"d": mkNode("d", "2026-08-04T00:00:04Z"),
+				"e": mkNode("e", "2026-08-04T00:00:05Z"),
+				// A Retry node with the same displayName/phase must not be fetched.
+				"retry-a": {ID: "retry-a", Type: "Retry", Phase: "Failed", DisplayName: "a"},
+			},
+		},
+	}
+	stub := &stubFetcher{fn: func(ctx context.Context, bucket, key string) (string, error) {
+		return "Error: boom\n", nil
+	}}
+	_ = Build(context.Background(), WorkflowList{Items: []Workflow{wf}}, stub, BuildOptions{})
+
+	stub.mu.Lock()
+	n := len(stub.requested)
+	stub.mu.Unlock()
+	if n != 3 {
+		t.Errorf("requested %d objects, want 3 (the per-child node cap)", n)
+	}
+	for _, r := range stub.requested {
+		if strings.Contains(r, "retry-a") {
+			t.Errorf("Retry node was fetched: %v", stub.requested)
+		}
+	}
+}
+
+func TestBuildFallsBackToNodeMessage(t *testing.T) {
+	list := loadWorkflowList(t, "workflows-list.json")
+	stub := &stubFetcher{fn: func(ctx context.Context, bucket, key string) (string, error) {
+		return "", errors.New("s3: access denied")
+	}}
+	children := Build(context.Background(), list, stub, BuildOptions{})
+
+	for _, c := range children {
+		if c.LogExcerpt != "" {
+			t.Errorf("child %q: LogExcerpt = %q, want \"\" (fetch failed)", c.Name, c.LogExcerpt)
+		}
+		if c.Config == "bi_ha" || c.Config == "min_default" {
+			if !strings.Contains(c.Detail, "main: Error (exit code 1)") {
+				t.Errorf("child %q: Detail = %q, want today's node-summary text", c.Name, c.Detail)
+			}
+		}
+	}
+}
+
+func TestBuildRespectsWireBudget(t *testing.T) {
+	bigErr := "Error: " + strings.Repeat("something failed badly here ", 300)
+	var items []Workflow
+	for i := 0; i < 20; i++ {
+		nodes := map[string]Node{}
+		for j := 0; j < 3; j++ {
+			id := "n" + string(rune('a'+i)) + string(rune('0'+j))
+			nodes[id] = Node{
+				ID: id, Type: "Pod", Phase: "Failed", DisplayName: id,
+				FinishedAt: "2026-08-04T00:00:00Z",
+				Outputs:    NodeOutputs{Artifacts: []NodeArtifact{{Name: "main-logs", S3: &NodeArtifactS3{Key: id}}}},
+			}
+		}
+		items = append(items, Workflow{
+			Metadata: WorkflowMetadata{Name: "wf" + string(rune('a'+i)), Labels: map[string]string{"harness/config": "c"}},
+			Status: WorkflowStatus{
+				Phase:                 "Failed",
+				ArtifactRepositoryRef: ArtifactRepositoryRef{ArtifactRepository{S3RepoRef{Bucket: "b"}}},
+				Nodes:                 nodes,
+			},
+		})
+	}
+	stub := &stubFetcher{fn: func(ctx context.Context, bucket, key string) (string, error) {
+		return bigErr + "\n", nil
+	}}
+	children := Build(context.Background(), WorkflowList{Items: items}, stub, BuildOptions{})
+	for _, c := range children {
+		if n := utf8.RuneCountInString(c.LogExcerpt); n > maxChildExcerptRunes {
+			t.Errorf("child %q: log_excerpt is %d runes, want <= %d", c.Name, n, maxChildExcerptRunes)
+		}
+		if !utf8.ValidString(c.LogExcerpt) {
+			t.Errorf("child %q: log_excerpt is not valid UTF-8", c.Name)
+		}
+		if c.LogExcerpt != "" && !strings.HasSuffix(c.LogExcerpt, "…") {
+			t.Errorf("child %q: log_excerpt = %q, want it truncated with an ellipsis", c.Name, c.LogExcerpt)
+		}
+	}
+}
+
+func TestBuildOutputIsDeterministic(t *testing.T) {
+	list := loadWorkflowList(t, "workflows-list.json")
+	logs := map[string]string{
+		"dozuki-argo-artifacts-010601635461/harness-min-default-mdgxp/harness-min-default-mdgxp-run-1651265260/main.log": readTestdata(t, "min-default-upgrade.log"),
+		"dozuki-argo-artifacts-010601635461/harness-bi-ha-8dps9/harness-bi-ha-8dps9-run-3742410289/main.log":             readTestdata(t, "min-default-upgrade.log"),
+		"dozuki-argo-artifacts-010601635461/harness-bi-ha-8dps9/harness-bi-ha-8dps9-run-945485330/main.log":              readTestdata(t, "bi-ha-destroy-tail.log"),
+	}
+
+	run := func() []byte {
+		stub := &stubFetcher{logs: logs}
+		children := Build(context.Background(), list, stub, BuildOptions{})
+		b, err := json.MarshalIndent(children, "", "  ")
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		return b
+	}
+
+	first := run()
+	for i := 0; i < 5; i++ {
+		if got := run(); string(got) != string(first) {
+			t.Fatalf("Build() is non-deterministic across runs:\n--- run 0 ---\n%s\n--- run %d ---\n%s", first, i+1, got)
+		}
+	}
+
+	golden := readTestdata(t, "children.golden.json")
+	var gotChildren, wantChildren []ChildEvidence
+	if err := json.Unmarshal(first, &gotChildren); err != nil {
+		t.Fatalf("unmarshal actual: %v", err)
+	}
+	if err := json.Unmarshal([]byte(golden), &wantChildren); err != nil {
+		t.Fatalf("unmarshal golden: %v", err)
+	}
+	gotJSON, _ := json.Marshal(gotChildren)
+	wantJSON, _ := json.Marshal(wantChildren)
+	if string(gotJSON) != string(wantJSON) {
+		t.Errorf("Build() output does not match children.golden.json\ngot:  %s\nwant: %s", gotJSON, wantJSON)
+	}
+}

--- a/live/tests/harness/matrix_invariants_test.go
+++ b/live/tests/harness/matrix_invariants_test.go
@@ -1,6 +1,10 @@
 package harness
 
-import "testing"
+import (
+	"os"
+	"strings"
+	"testing"
+)
 
 // Guards the real matrix.yaml, not testdata/. Everything else in this package
 // tests against the fixture, which means a new config in the production matrix
@@ -29,5 +33,28 @@ func TestAllMatrixConfigsDisableAlertmanagerSlack(t *testing.T) {
 		if v != false {
 			t.Errorf("config %q has alertmanager_slack_enabled = %v, want false", c.Name, v)
 		}
+	}
+}
+
+// TestPostStatusUsesEvidenceSubcommand guards the YAML/Go coupling: nothing else
+// keeps argo/20-matrix.yaml's post-status script pointed at `harness evidence` and
+// the relay payload carrying log_excerpt. If someone renames or drops the
+// subcommand on either side, this is what catches it - the card would otherwise
+// silently degrade to today's node summary with no test failure anywhere.
+func TestPostStatusUsesEvidenceSubcommand(t *testing.T) {
+	b, err := os.ReadFile("../argo/20-matrix.yaml")
+	if err != nil {
+		t.Fatalf("read 20-matrix.yaml: %v", err)
+	}
+	script := string(b)
+
+	if !strings.Contains(script, "harness evidence") {
+		t.Error("post-status no longer calls `harness evidence`")
+	}
+	if !strings.Contains(script, `select(.type == "Pod")`) {
+		t.Error("post-status dropped the jq fallback expression (requirement 3: evidence must never be the only path)")
+	}
+	if !strings.Contains(script, "log_excerpt") {
+		t.Error("post-status's relay payload no longer carries log_excerpt")
 	}
 }

--- a/live/tests/harness/s3logtail_test.go
+++ b/live/tests/harness/s3logtail_test.go
@@ -1,0 +1,106 @@
+package harness
+
+import (
+	"context"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+)
+
+// fakeS3GetObject answers GetObject with a fixed body and Content-Range, ignoring
+// the requested range - enough to drive S3LogTail.Tail through both the
+// partial-read and whole-object-read paths.
+type fakeS3GetObject struct {
+	body         string
+	contentRange *string
+}
+
+func (f *fakeS3GetObject) GetObject(_ context.Context, _ *s3.GetObjectInput, _ ...func(*s3.Options)) (*s3.GetObjectOutput, error) {
+	return &s3.GetObjectOutput{
+		Body:         io.NopCloser(strings.NewReader(f.body)),
+		ContentRange: f.contentRange,
+	}, nil
+}
+
+func TestS3LogTailWholeObjectKeepsFirstLine(t *testing.T) {
+	// A suffix range against an object smaller than tailRangeBytes comes back as
+	// the whole object - Content-Range still reports Partial Content, but its start
+	// offset is 0. Line 1 is intact and must survive.
+	body := "Error: the only line, and it is the one that matters\n"
+	fake := &fakeS3GetObject{body: body, contentRange: aws.String("bytes 0-53/54")}
+	tail := NewS3LogTail(fake)
+
+	got, err := tail.Tail(context.Background(), "bucket", "key")
+	if err != nil {
+		t.Fatalf("Tail() error = %v", err)
+	}
+	if !strings.Contains(got, "Error: the only line") {
+		t.Errorf("Tail() = %q, want it to keep line 1 of a whole-object read", got)
+	}
+}
+
+func TestS3LogTailShortLogWithErrorOnLineOne(t *testing.T) {
+	body := "Error: boom on the very first line\nsecond line, harmless\n"
+	fake := &fakeS3GetObject{body: body, contentRange: aws.String("bytes 0-57/58")}
+	tail := NewS3LogTail(fake)
+
+	got, err := tail.Tail(context.Background(), "bucket", "key")
+	if err != nil {
+		t.Fatalf("Tail() error = %v", err)
+	}
+	if !strings.Contains(got, "Error: boom on the very first line") {
+		t.Errorf("Tail() = %q, want the line-1 error preserved for a whole-object read", got)
+	}
+}
+
+func TestS3LogTailSingleLineNoTrailingNewline(t *testing.T) {
+	body := "Error: no newline at all"
+	fake := &fakeS3GetObject{body: body, contentRange: aws.String("bytes 0-24/25")}
+	tail := NewS3LogTail(fake)
+
+	got, err := tail.Tail(context.Background(), "bucket", "key")
+	if err != nil {
+		t.Fatalf("Tail() error = %v", err)
+	}
+	if got != body {
+		t.Errorf("Tail() = %q, want %q (a single line with no newline must not come back empty)", got, body)
+	}
+}
+
+func TestS3LogTailPartialReadDropsFirstLine(t *testing.T) {
+	// A genuine partial read (start offset > 0) starts mid-line - the fragment
+	// before the first real newline must be dropped.
+	body := "-mid-file-fragment\nError: the real second line\n"
+	fake := &fakeS3GetObject{body: body, contentRange: aws.String("bytes 262144-300000/1000000")}
+	tail := NewS3LogTail(fake)
+
+	got, err := tail.Tail(context.Background(), "bucket", "key")
+	if err != nil {
+		t.Fatalf("Tail() error = %v", err)
+	}
+	if strings.Contains(got, "mid-file-fragment") {
+		t.Errorf("Tail() = %q, want the partial first line dropped", got)
+	}
+	if !strings.Contains(got, "Error: the real second line") {
+		t.Errorf("Tail() = %q, want the real second line preserved", got)
+	}
+}
+
+func TestS3LogTailNoContentRangeKeepsFirstLine(t *testing.T) {
+	// No Content-Range header at all (e.g. a 200 OK, not 206) means the whole
+	// object came back - treat it the same as a start-offset-0 partial read.
+	body := "Error: whole object, no range header\n"
+	fake := &fakeS3GetObject{body: body, contentRange: nil}
+	tail := NewS3LogTail(fake)
+
+	got, err := tail.Tail(context.Background(), "bucket", "key")
+	if err != nil {
+		t.Fatalf("Tail() error = %v", err)
+	}
+	if !strings.Contains(got, "Error: whole object") {
+		t.Errorf("Tail() = %q, want line 1 preserved when there is no Content-Range", got)
+	}
+}

--- a/live/tests/harness/terragrunt.go
+++ b/live/tests/harness/terragrunt.go
@@ -115,8 +115,8 @@ func (o TGOptions) Apply() error {
 	// resources once the access entry is effective.
 	const maxAttempts = 4
 	var err error
+	var out string
 	for attempt := 1; attempt <= maxAttempts; attempt++ {
-		var out string
 		// No -auto-approve: terragrunt appends it itself for `run --all apply`, and
 		// passing it unforwarded is a hard error on 1.x ("flag -auto-approve is not a
 		// Terragrunt flag ... use -- to forward it"). `run -- apply -auto-approve` also
@@ -148,7 +148,7 @@ func (o TGOptions) Apply() error {
 				continue
 			}
 			fmt.Fprintf(os.Stderr, "\n>> harness: Vault token expired and re-login failed — not retrying\n\n")
-			return err
+			return fmt.Errorf("%w: %s", err, lastErrorLine(out))
 		}
 		if attempt < maxAttempts && transientNetRE.MatchString(out) {
 			wait := time.Duration(attempt*30) * time.Second
@@ -156,9 +156,9 @@ func (o TGOptions) Apply() error {
 			time.Sleep(wait)
 			continue
 		}
-		return err
+		return fmt.Errorf("%w: %s", err, lastErrorLine(out))
 	}
-	return err
+	return fmt.Errorf("%w: %s", err, lastErrorLine(out))
 }
 
 // destroyModule destroys a single layer in its own directory (not run --all), so
@@ -176,6 +176,7 @@ func (o TGOptions) Apply() error {
 func (o TGOptions) destroyModule(module string) error {
 	const maxAttempts = 4
 	var err error
+	var lastOut string
 	for attempt := 1; attempt <= maxAttempts; attempt++ {
 		cmd := exec.Command("terragrunt", "destroy", "--non-interactive", "-auto-approve")
 		cmd.Dir = filepath.Join(o.WorkingDir, module)
@@ -188,6 +189,7 @@ func (o TGOptions) destroyModule(module string) error {
 			return nil
 		}
 		out := buf.String()
+		lastOut = out
 		if attempt < maxAttempts && vaultTokenExpiredRE.MatchString(out) && refreshVaultToken() {
 			fmt.Fprintf(os.Stderr, "\n>> teardown: Vault token had expired; re-logged in and retrying %s destroy (attempt %d/%d)\n\n", module, attempt+1, maxAttempts)
 			continue
@@ -198,9 +200,9 @@ func (o TGOptions) destroyModule(module string) error {
 			time.Sleep(wait)
 			continue
 		}
-		return err
+		return fmt.Errorf("%w: %s", err, lastErrorLine(out))
 	}
-	return err
+	return fmt.Errorf("%w: %s", err, lastErrorLine(lastOut))
 }
 
 // Destroy tears the stack down resiliently. `run --all destroy` aborts the whole

--- a/live/tests/harness/terragrunt.go
+++ b/live/tests/harness/terragrunt.go
@@ -109,6 +109,20 @@ func (o TGOptions) execCapture(args ...string) (string, error) {
 	return buf.String(), err
 }
 
+// wrapTGError wraps err with the last error-shaped line of out, if there is one.
+// lastErrorLine returns "" when the captured output has no line that looks like a
+// real error (only noise, or nothing at all) - unconditionally formatting "%w: %s"
+// in that case leaves a dangling "exit status 1: " with nothing after the colon,
+// which breaks thinVerdictRE's anchored-on-$ match downstream in evidence.go and
+// makes ExtractError treat the bare verdict as already explained instead of falling
+// through to a real Error: line elsewhere in the log window.
+func wrapTGError(err error, out string) error {
+	if line := lastErrorLine(out); line != "" {
+		return fmt.Errorf("%w: %s", err, line)
+	}
+	return err
+}
+
 func (o TGOptions) Apply() error {
 	// Retry only the EKS access-entry propagation race (see kubeAuthRaceRE);
 	// terraform apply is idempotent, so a re-apply just finishes the remaining
@@ -148,7 +162,7 @@ func (o TGOptions) Apply() error {
 				continue
 			}
 			fmt.Fprintf(os.Stderr, "\n>> harness: Vault token expired and re-login failed — not retrying\n\n")
-			return fmt.Errorf("%w: %s", err, lastErrorLine(out))
+			return wrapTGError(err, out)
 		}
 		if attempt < maxAttempts && transientNetRE.MatchString(out) {
 			wait := time.Duration(attempt*30) * time.Second
@@ -156,9 +170,9 @@ func (o TGOptions) Apply() error {
 			time.Sleep(wait)
 			continue
 		}
-		return fmt.Errorf("%w: %s", err, lastErrorLine(out))
+		return wrapTGError(err, out)
 	}
-	return fmt.Errorf("%w: %s", err, lastErrorLine(out))
+	return wrapTGError(err, out)
 }
 
 // destroyModule destroys a single layer in its own directory (not run --all), so
@@ -200,9 +214,9 @@ func (o TGOptions) destroyModule(module string) error {
 			time.Sleep(wait)
 			continue
 		}
-		return fmt.Errorf("%w: %s", err, lastErrorLine(out))
+		return wrapTGError(err, out)
 	}
-	return fmt.Errorf("%w: %s", err, lastErrorLine(lastOut))
+	return wrapTGError(err, lastOut)
 }
 
 // Destroy tears the stack down resiliently. `run --all destroy` aborts the whole

--- a/live/tests/harness/terragrunt_test.go
+++ b/live/tests/harness/terragrunt_test.go
@@ -2,6 +2,7 @@ package harness
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -69,6 +70,43 @@ func TestApplyErrorCarriesOutputTail(t *testing.T) {
 	var exitErr *exec.ExitError
 	if !errors.As(err, &exitErr) {
 		t.Errorf("Apply() error does not unwrap to *exec.ExitError: %v", err)
+	}
+}
+
+// fakeNoErrorLineScript intentionally emits no Error:-prefixed line - only noise
+// and a bare exit code - so lastErrorLine(out) has nothing to append.
+const fakeNoErrorLineScript = `echo 'module.foo: Still destroying... [id=x, 1s elapsed]'
+echo 'some unrelated status line, not an Error:'
+echo 'exit status 1'`
+
+// TestApplyErrorHasNoDanglingColonWithoutErrorLine covers the P1 wrap bug: when the
+// captured output has no error-shaped line, wrapping unconditionally with "%w: %s"
+// leaves a dangling "exit status 1: " (trailing colon, nothing after it). That
+// breaks thinVerdictRE's anchored-on-$ match once main.go turns this error into a
+// "<phase> failed: ..." verdict line, which then makes ExtractError treat the bare
+// verdict as already explained instead of preferring a real Error: line elsewhere in
+// the log window.
+func TestApplyErrorHasNoDanglingColonWithoutErrorLine(t *testing.T) {
+	writeFakeTerragrunt(t, fakeNoErrorLineScript)
+	o := TGOptions{WorkingDir: t.TempDir(), Region: "us-east-1"}
+
+	err := o.Apply()
+	if err == nil {
+		t.Fatal("Apply() = nil, want an error")
+	}
+	if strings.HasSuffix(err.Error(), ":") || strings.HasSuffix(err.Error(), ": ") {
+		t.Fatalf("Apply() error has a dangling colon with nothing after it: %q", err.Error())
+	}
+
+	// Reproduce the shape a real failed run's captured log takes: main.go's verdict
+	// line sitting below the real tofu Error: line, separated by whatever noise fell
+	// in between.
+	verdict := fmt.Sprintf("teardown failed: %s", err)
+	log := "Error: the real explanation, from earlier in the run\n" + verdict + "\n"
+
+	got := ExtractError(log)
+	if !strings.Contains(got, "the real explanation") {
+		t.Errorf("ExtractError() = %q, want it to prefer the real Error: line over the thin verdict %q", got, verdict)
 	}
 }
 

--- a/live/tests/harness/terragrunt_test.go
+++ b/live/tests/harness/terragrunt_test.go
@@ -1,6 +1,10 @@
 package harness
 
 import (
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -26,5 +30,68 @@ func TestTGEnv(t *testing.T) {
 		if !strings.Contains(joined, want) {
 			t.Errorf("env missing %q", want)
 		}
+	}
+}
+
+// writeFakeTerragrunt drops an executable named "terragrunt" on the front of PATH
+// that prints script (a tofu-shaped error block, none of which matches any of the
+// retry regexes above) and exits 1. Tests use this instead of the real binary so
+// Apply/destroyModule fail on the first attempt, deterministically and fast.
+func writeFakeTerragrunt(t *testing.T, script string) {
+	t.Helper()
+	bin := t.TempDir()
+	body := "#!/bin/sh\n" + script + "\nexit 1\n"
+	path := filepath.Join(bin, "terragrunt")
+	if err := os.WriteFile(path, []byte(body), 0o755); err != nil {
+		t.Fatalf("write fake terragrunt: %v", err)
+	}
+	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
+const fakeTofuErrorScript = `echo 'module.foo: Still destroying... [id=x, 1s elapsed]'
+echo 'Error: stopping widget (arn:aws:widget:us-east-1:000000000000:thing/abc): cannot proceed'
+echo 'exit status 1'`
+
+func TestApplyErrorCarriesOutputTail(t *testing.T) {
+	writeFakeTerragrunt(t, fakeTofuErrorScript)
+	o := TGOptions{WorkingDir: t.TempDir(), Region: "us-east-1"}
+
+	err := o.Apply()
+	if err == nil {
+		t.Fatal("Apply() = nil, want an error")
+	}
+	if !strings.Contains(err.Error(), "stopping widget") || !strings.Contains(err.Error(), "cannot proceed") {
+		t.Errorf("Apply() error = %q, want it to carry the tofu error text", err.Error())
+	}
+	if len(err.Error()) > 500 {
+		t.Errorf("Apply() error is %d chars, want it capped near 400", len(err.Error()))
+	}
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		t.Errorf("Apply() error does not unwrap to *exec.ExitError: %v", err)
+	}
+}
+
+func TestDestroyModuleErrorCarriesOutputTail(t *testing.T) {
+	writeFakeTerragrunt(t, fakeTofuErrorScript)
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "logical"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	o := TGOptions{WorkingDir: dir, Region: "us-east-1"}
+
+	err := o.destroyModule("logical")
+	if err == nil {
+		t.Fatal("destroyModule() = nil, want an error")
+	}
+	if !strings.Contains(err.Error(), "stopping widget") || !strings.Contains(err.Error(), "cannot proceed") {
+		t.Errorf("destroyModule() error = %q, want it to carry the tofu error text", err.Error())
+	}
+	if len(err.Error()) > 500 {
+		t.Errorf("destroyModule() error is %d chars, want it capped near 400", len(err.Error()))
+	}
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		t.Errorf("destroyModule() error does not unwrap to *exec.ExitError: %v", err)
 	}
 }

--- a/live/tests/harness/testdata/evidence/bi-ha-destroy-tail.log
+++ b/live/tests/harness/testdata/evidence/bi-ha-destroy-tail.log
@@ -1,0 +1,366 @@
+[0;90m01:11:38.596[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mkubernetes_namespace_v1.cert_manager: Destroying... [id=cert-manager][0m[0m[0m
+[0;90m01:11:41.141[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mkubernetes_namespace_v1.flux_system: Still destroying... [id=flux-system, 20s elapsed][0m[0m[0m
+[0;90m01:11:46.306[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mkubernetes_namespace_v1.app: Still destroying... [id=dozuki, 20s elapsed][0m[0m[0m
+[0;90m01:11:48.597[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mkubernetes_namespace_v1.cert_manager: Still destroying... [id=cert-manager, 10s elapsed][0m[0m[0m
+[0;90m01:11:51.142[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mkubernetes_namespace_v1.flux_system: Still destroying... [id=flux-system, 30s elapsed][0m[0m[0m
+[0;90m01:11:51.269[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mkubernetes_namespace_v1.cert_manager: Destruction complete after 12s[0m[0m
+[0;90m01:11:56.307[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mkubernetes_namespace_v1.app: Still destroying... [id=dozuki, 30s elapsed][0m[0m[0m
+[0;90m01:12:01.143[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mkubernetes_namespace_v1.flux_system: Still destroying... [id=flux-system, 40s elapsed][0m[0m[0m
+[0;90m01:12:06.308[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mkubernetes_namespace_v1.app: Still destroying... [id=dozuki, 40s elapsed][0m[0m[0m
+[0;90m01:12:11.143[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mkubernetes_namespace_v1.flux_system: Still destroying... [id=flux-system, 50s elapsed][0m[0m[0m
+[0;90m01:12:16.310[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mkubernetes_namespace_v1.app: Still destroying... [id=dozuki, 50s elapsed][0m[0m[0m
+[0;90m01:12:19.010[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mkubernetes_namespace_v1.app: Destruction complete after 53s[0m[0m
+[0;90m01:12:21.144[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mkubernetes_namespace_v1.flux_system: Still destroying... [id=flux-system, 1m0s elapsed][0m[0m[0m
+[0;90m01:12:31.144[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mkubernetes_namespace_v1.flux_system: Still destroying... [id=flux-system, 1m10s elapsed][0m[0m[0m
+[0;90m01:12:41.144[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mkubernetes_namespace_v1.flux_system: Still destroying... [id=flux-system, 1m20s elapsed][0m[0m[0m
+[0;90m01:12:51.145[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mkubernetes_namespace_v1.flux_system: Still destroying... [id=flux-system, 1m30s elapsed][0m[0m[0m
+[0;90m01:13:01.146[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mkubernetes_namespace_v1.flux_system: Still destroying... [id=flux-system, 1m40s elapsed][0m[0m[0m
+[0;90m01:13:11.152[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mkubernetes_namespace_v1.flux_system: Still destroying... [id=flux-system, 1m50s elapsed][0m[0m[0m
+[0;90m01:13:21.152[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mkubernetes_namespace_v1.flux_system: Still destroying... [id=flux-system, 2m0s elapsed][0m[0m[0m
+[0;90m01:13:31.153[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mkubernetes_namespace_v1.flux_system: Still destroying... [id=flux-system, 2m10s elapsed][0m[0m[0m
+[0;90m01:13:41.154[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mkubernetes_namespace_v1.flux_system: Still destroying... [id=flux-system, 2m20s elapsed][0m[0m[0m
+[0;90m01:13:51.158[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mkubernetes_namespace_v1.flux_system: Still destroying... [id=flux-system, 2m30s elapsed][0m[0m[0m
+[0;90m01:14:01.162[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mkubernetes_namespace_v1.flux_system: Still destroying... [id=flux-system, 2m40s elapsed][0m[0m[0m
+[0;90m01:14:11.165[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mkubernetes_namespace_v1.flux_system: Still destroying... [id=flux-system, 2m50s elapsed][0m[0m[0m
+[0;90m01:14:21.166[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mkubernetes_namespace_v1.flux_system: Still destroying... [id=flux-system, 3m0s elapsed][0m[0m[0m
+[0;90m01:14:31.172[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mkubernetes_namespace_v1.flux_system: Still destroying... [id=flux-system, 3m10s elapsed][0m[0m[0m
+[0;90m01:14:41.175[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mkubernetes_namespace_v1.flux_system: Still destroying... [id=flux-system, 3m20s elapsed][0m[0m[0m
+[0;90m01:14:51.176[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mkubernetes_namespace_v1.flux_system: Still destroying... [id=flux-system, 3m30s elapsed][0m[0m[0m
+[0;90m01:15:01.182[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mkubernetes_namespace_v1.flux_system: Still destroying... [id=flux-system, 3m40s elapsed][0m[0m[0m
+[0;90m01:15:11.183[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mkubernetes_namespace_v1.flux_system: Still destroying... [id=flux-system, 3m50s elapsed][0m[0m[0m
+[0;90m01:15:21.190[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mkubernetes_namespace_v1.flux_system: Still destroying... [id=flux-system, 4m0s elapsed][0m[0m[0m
+[0;90m01:15:31.191[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mkubernetes_namespace_v1.flux_system: Still destroying... [id=flux-system, 4m10s elapsed][0m[0m[0m
+[0;90m01:15:41.192[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mkubernetes_namespace_v1.flux_system: Still destroying... [id=flux-system, 4m20s elapsed][0m[0m[0m
+[0;90m01:15:51.194[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mkubernetes_namespace_v1.flux_system: Still destroying... [id=flux-system, 4m30s elapsed][0m[0m[0m
+[0;90m01:16:01.198[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mkubernetes_namespace_v1.flux_system: Still destroying... [id=flux-system, 4m40s elapsed][0m[0m[0m
+[0;90m01:16:11.198[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mkubernetes_namespace_v1.flux_system: Still destroying... [id=flux-system, 4m50s elapsed][0m[0m[0m
+[0;90m01:16:21.300[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[33m╷[0m[0m[0m
+[0;90m01:16:21.300[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[33m│[0m [0m[1m[33mWarning: [0m[0m[1mHelm uninstall returned an information message[0m[0m
+[0;90m01:16:21.300[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[33m│[0m [0m[0m
+[0;90m01:16:21.300[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[33m│[0m [0m[0mThese resources were kept due to the resource policy:[0m
+[0;90m01:16:21.300[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[33m│[0m [0m[CustomResourceDefinition] challenges.acme.cert-manager.io[0m
+[0;90m01:16:21.300[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[33m│[0m [0m[CustomResourceDefinition] orders.acme.cert-manager.io[0m
+[0;90m01:16:21.299[0m [0;31mSTDERR[0m [0;36mtofu: [0m[31m╷[0m[0m[0m
+[0;90m01:16:21.299[0m [0;31mSTDERR[0m [0;36mtofu: [0m[31m│[0m [0m[1m[31mError: [0m[0m[1mcontext deadline exceeded[0m[0m
+[0;90m01:16:21.299[0m [0;31mSTDERR[0m [0;36mtofu: [0m[31m│[0m [0m[0m
+[0;90m01:16:21.299[0m [0;31mSTDERR[0m [0;36mtofu: [0m[31m│[0m [0m[0m[0m
+[0;90m01:16:21.300[0m [0;31mSTDERR[0m [0;36mtofu: [0m[31m╵[0m[0m[0m
+[0;90m01:16:21.300[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[33m│[0m [0m[CustomResourceDefinition] certificaterequests.cert-manager.io[0m
+[0;90m01:16:21.300[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[33m│[0m [0m[CustomResourceDefinition] certificates.cert-manager.io[0m
+[0;90m01:16:21.300[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[33m│[0m [0m[CustomResourceDefinition] clusterissuers.cert-manager.io[0m
+[0;90m01:16:21.301[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[33m│[0m [0m[CustomResourceDefinition] issuers.cert-manager.io[0m
+[0;90m01:16:21.301[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[33m│[0m [0m[0m
+[0;90m01:16:21.301[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[33m╵[0m[0m[0m
+[0;90m01:16:21.384[0m [0;31mERROR [0m error occurred:
+
+* Failed to execute "tofu destroy -auto-approve" in ./.terragrunt-cache/6r1V_fvHzfFk3XLueLGLHL3fAYw/H0Rx20aAgwFbyJVuXFgGUpBRBwU/logical
+  [31m╷[0m[0m
+  [31m│[0m [0m[1m[31mError: [0m[0m[1mcontext deadline exceeded[0m
+  [31m│[0m [0m
+  [31m│[0m [0m[0m
+  [31m╵[0m[0m
+  
+  exit status 1
+
+
+>> teardown: logical destroy failed (continuing to physical so infra isn't stranded): exit status 1
+... [truncated ~11460 lines of destroy polling noise: aurora, bi_aurora, eks, vpc teardown] ...
+[0;90m01:18:26.723[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.vpc[0].aws_internet_gateway.this[0]: Still destroying... [id=igw-0611aa19bbe91699b, 20s elapsed][0m[0m[0m
+[0;90m01:18:28.064[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.bi_aurora[0].aws_rds_cluster_instance.this["writer"]: Still destroying... [id=smokef9b3-bi-bi-writer, 1m30s elapsed][0m[0m[0m
+[0;90m01:18:28.456[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1maws_route53_zone.vault_private: Still destroying... [id=Z09762332S9H9AP59BM6P, 1m10s elapsed][0m[0m[0m
+[0;90m01:18:29.721[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1maws_rds_cluster.dr_aurora_secondary[0]: Still destroying... [id=smokef9b3-bi-dr, 1m20s elapsed][0m[0m[0m
+[0;90m01:18:31.008[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1maws_vpc_endpoint.vault: Still destroying... [id=vpce-02e02f38c9bacdf5c, 1m0s elapsed][0m[0m[0m
+[0;90m01:18:31.196[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.eks_cluster.aws_eks_cluster.this[0]: Still destroying... [id=smokef9b3-bi, 1m0s elapsed][0m[0m[0m
+[0;90m01:18:36.723[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.vpc[0].aws_internet_gateway.this[0]: Still destroying... [id=igw-0611aa19bbe91699b, 30s elapsed][0m[0m[0m
+[0;90m01:18:38.064[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.bi_aurora[0].aws_rds_cluster_instance.this["writer"]: Still destroying... [id=smokef9b3-bi-bi-writer, 1m40s elapsed][0m[0m[0m
+[0;90m01:18:38.457[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1maws_route53_zone.vault_private: Still destroying... [id=Z09762332S9H9AP59BM6P, 1m20s elapsed][0m[0m[0m
+[0;90m01:18:39.722[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1maws_rds_cluster.dr_aurora_secondary[0]: Still destroying... [id=smokef9b3-bi-dr, 1m30s elapsed][0m[0m[0m
+[0;90m01:18:41.010[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1maws_vpc_endpoint.vault: Still destroying... [id=vpce-02e02f38c9bacdf5c, 1m10s elapsed][0m[0m[0m
+[0;90m01:18:41.196[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.eks_cluster.aws_eks_cluster.this[0]: Still destroying... [id=smokef9b3-bi, 1m10s elapsed][0m[0m[0m
+[0;90m01:18:46.724[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.vpc[0].aws_internet_gateway.this[0]: Still destroying... [id=igw-0611aa19bbe91699b, 40s elapsed][0m[0m[0m
+[0;90m01:18:48.065[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.bi_aurora[0].aws_rds_cluster_instance.this["writer"]: Still destroying... [id=smokef9b3-bi-bi-writer, 1m50s elapsed][0m[0m[0m
+[0;90m01:18:48.457[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1maws_route53_zone.vault_private: Still destroying... [id=Z09762332S9H9AP59BM6P, 1m30s elapsed][0m[0m[0m
+[0;90m01:18:48.714[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1maws_route53_zone.vault_private: Destruction complete after 1m31s[0m[0m
+[0;90m01:18:49.723[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1maws_rds_cluster.dr_aurora_secondary[0]: Still destroying... [id=smokef9b3-bi-dr, 1m40s elapsed][0m[0m[0m
+[0;90m01:18:51.011[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1maws_vpc_endpoint.vault: Still destroying... [id=vpce-02e02f38c9bacdf5c, 1m20s elapsed][0m[0m[0m
+[0;90m01:18:51.197[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.eks_cluster.aws_eks_cluster.this[0]: Still destroying... [id=smokef9b3-bi, 1m20s elapsed][0m[0m[0m
+[0;90m01:18:51.567[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1maws_vpc_endpoint.vault: Destruction complete after 1m21s[0m[0m
+[0;90m01:18:51.569[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1maws_security_group.vault_endpoint: Destroying... [id=sg-0edab5540abc08351][0m[0m[0m
+[0;90m01:18:52.178[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1maws_security_group.vault_endpoint: Destruction complete after 0s[0m[0m
+[0;90m01:18:56.725[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.vpc[0].aws_internet_gateway.this[0]: Still destroying... [id=igw-0611aa19bbe91699b, 50s elapsed][0m[0m[0m
+[0;90m01:18:58.065[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.bi_aurora[0].aws_rds_cluster_instance.this["writer"]: Still destroying... [id=smokef9b3-bi-bi-writer, 2m0s elapsed][0m[0m[0m
+[0;90m01:18:58.301[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.vpc[0].aws_internet_gateway.this[0]: Destruction complete after 51s[0m[0m
+[0;90m01:18:59.723[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1maws_rds_cluster.dr_aurora_secondary[0]: Still destroying... [id=smokef9b3-bi-dr, 1m50s elapsed][0m[0m[0m
+[0;90m01:19:01.197[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.eks_cluster.aws_eks_cluster.this[0]: Still destroying... [id=smokef9b3-bi, 1m30s elapsed][0m[0m[0m
+[0;90m01:19:08.066[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.bi_aurora[0].aws_rds_cluster_instance.this["writer"]: Still destroying... [id=smokef9b3-bi-bi-writer, 2m10s elapsed][0m[0m[0m
+[0;90m01:19:09.729[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1maws_rds_cluster.dr_aurora_secondary[0]: Still destroying... [id=smokef9b3-bi-dr, 2m0s elapsed][0m[0m[0m
+[0;90m01:19:11.197[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.eks_cluster.aws_eks_cluster.this[0]: Still destroying... [id=smokef9b3-bi, 1m40s elapsed][0m[0m[0m
+[0;90m01:19:12.644[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1maws_rds_cluster.dr_aurora_secondary[0]: Destruction complete after 2m3s[0m[0m
+[0;90m01:19:12.788[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1maws_rds_global_cluster.aurora[0]: Destroying... [id=smokef9b3-bi-global][0m[0m[0m
+[0;90m01:19:12.789[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1maws_kms_key.dr_aurora[0]: Destroying... [id=6f9be8e5-3dae-4a17-b43d-e5a96a216b45][0m[0m[0m
+[0;90m01:19:12.792[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1maws_cloudwatch_log_group.dr_aurora["general"]: Destroying... [id=/aws/rds/cluster/smokef9b3-bi-dr/general][0m[0m[0m
+[0;90m01:19:12.793[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1maws_db_subnet_group.dr_aurora[0]: Destroying... [id=smokef9b3-bi-dr-aurora-e08355a639e8ac1b609b6c90b3][0m[0m[0m
+[0;90m01:19:12.793[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1maws_cloudwatch_log_group.dr_aurora["error"]: Destroying... [id=/aws/rds/cluster/smokef9b3-bi-dr/error][0m[0m[0m
+[0;90m01:19:12.793[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1maws_cloudwatch_log_group.dr_aurora["audit"]: Destroying... [id=/aws/rds/cluster/smokef9b3-bi-dr/audit][0m[0m[0m
+[0;90m01:19:12.798[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1maws_security_group.dr_aurora[0]: Destroying... [id=sg-01272e9ef7f9545c2][0m[0m[0m
+[0;90m01:19:12.800[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.aurora[0].aws_rds_cluster_instance.this["reader"]: Destroying... [id=smokef9b3-bi-reader][0m[0m[0m
+[0;90m01:19:13.074[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1maws_db_subnet_group.dr_aurora[0]: Destruction complete after 0s[0m[0m
+[0;90m01:19:13.077[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.aurora[0].aws_rds_cluster_instance.this["writer"]: Destroying... [id=smokef9b3-bi-writer][0m[0m[0m
+[0;90m01:19:13.113[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1maws_kms_key.dr_aurora[0]: Destruction complete after 0s[0m[0m
+[0;90m01:19:13.115[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1maws_cloudwatch_log_group.dr_aurora["slowquery"]: Destroying... [id=/aws/rds/cluster/smokef9b3-bi-dr/slowquery][0m[0m[0m
+[0;90m01:19:13.135[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1maws_cloudwatch_log_group.dr_aurora["audit"]: Destruction complete after 0s[0m[0m
+[0;90m01:19:13.139[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1maws_subnet.dr_aurora["us-west-2a"]: Destroying... [id=subnet-023c67e6abd6d6e6e][0m[0m[0m
+[0;90m01:19:13.157[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1maws_cloudwatch_log_group.dr_aurora["general"]: Destruction complete after 0s[0m[0m
+[0;90m01:19:13.160[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1maws_subnet.dr_aurora["us-west-2c"]: Destroying... [id=subnet-034c58b2eeed76dd2][0m[0m[0m
+[0;90m01:19:13.212[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1maws_cloudwatch_log_group.dr_aurora["error"]: Destruction complete after 0s[0m[0m
+[0;90m01:19:13.216[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1maws_subnet.dr_aurora["us-west-2b"]: Destroying... [id=subnet-0d400e2792fffe89e][0m[0m[0m
+[0;90m01:19:13.249[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1maws_cloudwatch_log_group.dr_aurora["slowquery"]: Destruction complete after 0s[0m[0m
+[0;90m01:19:13.701[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1maws_security_group.dr_aurora[0]: Destruction complete after 1s[0m[0m
+[0;90m01:19:13.945[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1maws_subnet.dr_aurora["us-west-2c"]: Destruction complete after 1s[0m[0m
+[0;90m01:19:13.985[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1maws_subnet.dr_aurora["us-west-2a"]: Destruction complete after 1s[0m[0m
+[0;90m01:19:14.034[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1maws_rds_global_cluster.aurora[0]: Destruction complete after 1s[0m[0m
+[0;90m01:19:14.067[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1maws_subnet.dr_aurora["us-west-2b"]: Destruction complete after 1s[0m[0m
+[0;90m01:19:14.070[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1maws_vpc.dr_aurora[0]: Destroying... [id=vpc-046c0e3d4627616d2][0m[0m[0m
+[0;90m01:19:14.724[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1maws_vpc.dr_aurora[0]: Destruction complete after 1s[0m[0m
+[0;90m01:19:18.066[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.bi_aurora[0].aws_rds_cluster_instance.this["writer"]: Still destroying... [id=smokef9b3-bi-bi-writer, 2m20s elapsed][0m[0m[0m
+[0;90m01:19:21.198[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.eks_cluster.aws_eks_cluster.this[0]: Still destroying... [id=smokef9b3-bi, 1m50s elapsed][0m[0m[0m
+[0;90m01:19:22.801[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.aurora[0].aws_rds_cluster_instance.this["reader"]: Still destroying... [id=smokef9b3-bi-reader, 10s elapsed][0m[0m[0m
+[0;90m01:19:23.078[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.aurora[0].aws_rds_cluster_instance.this["writer"]: Still destroying... [id=smokef9b3-bi-writer, 10s elapsed][0m[0m[0m
+[0;90m01:19:28.069[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.bi_aurora[0].aws_rds_cluster_instance.this["writer"]: Still destroying... [id=smokef9b3-bi-bi-writer, 2m30s elapsed][0m[0m[0m
+[0;90m01:19:31.198[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.eks_cluster.aws_eks_cluster.this[0]: Still destroying... [id=smokef9b3-bi, 2m0s elapsed][0m[0m[0m
+[0;90m01:19:32.802[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.aurora[0].aws_rds_cluster_instance.this["reader"]: Still destroying... [id=smokef9b3-bi-reader, 20s elapsed][0m[0m[0m
+[0;90m01:19:33.079[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.aurora[0].aws_rds_cluster_instance.this["writer"]: Still destroying... [id=smokef9b3-bi-writer, 20s elapsed][0m[0m[0m
+[0;90m01:19:38.072[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.bi_aurora[0].aws_rds_cluster_instance.this["writer"]: Still destroying... [id=smokef9b3-bi-bi-writer, 2m40s elapsed][0m[0m[0m
+[0;90m01:19:41.200[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.eks_cluster.aws_eks_cluster.this[0]: Still destroying... [id=smokef9b3-bi, 2m10s elapsed][0m[0m[0m
+[0;90m01:19:42.803[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.aurora[0].aws_rds_cluster_instance.this["reader"]: Still destroying... [id=smokef9b3-bi-reader, 30s elapsed][0m[0m[0m
+[0;90m01:19:43.080[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.aurora[0].aws_rds_cluster_instance.this["writer"]: Still destroying... [id=smokef9b3-bi-writer, 30s elapsed][0m[0m[0m
+[0;90m01:19:48.075[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.bi_aurora[0].aws_rds_cluster_instance.this["writer"]: Still destroying... [id=smokef9b3-bi-bi-writer, 2m50s elapsed][0m[0m[0m
+[0;90m01:19:51.200[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.eks_cluster.aws_eks_cluster.this[0]: Still destroying... [id=smokef9b3-bi, 2m20s elapsed][0m[0m[0m
+[0;90m01:19:52.804[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.aurora[0].aws_rds_cluster_instance.this["reader"]: Still destroying... [id=smokef9b3-bi-reader, 40s elapsed][0m[0m[0m
+[0;90m01:19:53.081[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.aurora[0].aws_rds_cluster_instance.this["writer"]: Still destroying... [id=smokef9b3-bi-writer, 40s elapsed][0m[0m[0m
+[0;90m01:19:58.075[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.bi_aurora[0].aws_rds_cluster_instance.this["writer"]: Still destroying... [id=smokef9b3-bi-bi-writer, 3m0s elapsed][0m[0m[0m
+[0;90m01:20:01.200[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.eks_cluster.aws_eks_cluster.this[0]: Still destroying... [id=smokef9b3-bi, 2m30s elapsed][0m[0m[0m
+[0;90m01:20:02.805[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.aurora[0].aws_rds_cluster_instance.this["reader"]: Still destroying... [id=smokef9b3-bi-reader, 50s elapsed][0m[0m[0m
+[0;90m01:20:03.081[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.aurora[0].aws_rds_cluster_instance.this["writer"]: Still destroying... [id=smokef9b3-bi-writer, 50s elapsed][0m[0m[0m
+[0;90m01:20:08.076[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.bi_aurora[0].aws_rds_cluster_instance.this["writer"]: Still destroying... [id=smokef9b3-bi-bi-writer, 3m10s elapsed][0m[0m[0m
+[0;90m01:20:11.200[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.eks_cluster.aws_eks_cluster.this[0]: Still destroying... [id=smokef9b3-bi, 2m40s elapsed][0m[0m[0m
+[0;90m01:20:12.805[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.aurora[0].aws_rds_cluster_instance.this["reader"]: Still destroying... [id=smokef9b3-bi-reader, 1m0s elapsed][0m[0m[0m
+[0;90m01:20:13.082[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.aurora[0].aws_rds_cluster_instance.this["writer"]: Still destroying... [id=smokef9b3-bi-writer, 1m0s elapsed][0m[0m[0m
+[0;90m01:20:18.076[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.bi_aurora[0].aws_rds_cluster_instance.this["writer"]: Still destroying... [id=smokef9b3-bi-bi-writer, 3m20s elapsed][0m[0m[0m
+[0;90m01:20:21.201[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.eks_cluster.aws_eks_cluster.this[0]: Still destroying... [id=smokef9b3-bi, 2m50s elapsed][0m[0m[0m
+[0;90m01:20:22.806[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.aurora[0].aws_rds_cluster_instance.this["reader"]: Still destroying... [id=smokef9b3-bi-reader, 1m10s elapsed][0m[0m[0m
+[0;90m01:20:23.082[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.aurora[0].aws_rds_cluster_instance.this["writer"]: Still destroying... [id=smokef9b3-bi-writer, 1m10s elapsed][0m[0m[0m
+[0;90m01:20:28.076[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.bi_aurora[0].aws_rds_cluster_instance.this["writer"]: Still destroying... [id=smokef9b3-bi-bi-writer, 3m30s elapsed][0m[0m[0m
+[0;90m01:20:31.202[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.eks_cluster.aws_eks_cluster.this[0]: Still destroying... [id=smokef9b3-bi, 3m0s elapsed][0m[0m[0m
+[0;90m01:20:32.806[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.aurora[0].aws_rds_cluster_instance.this["reader"]: Still destroying... [id=smokef9b3-bi-reader, 1m20s elapsed][0m[0m[0m
+[0;90m01:20:33.083[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.aurora[0].aws_rds_cluster_instance.this["writer"]: Still destroying... [id=smokef9b3-bi-writer, 1m20s elapsed][0m[0m[0m
+[0;90m01:20:38.076[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.bi_aurora[0].aws_rds_cluster_instance.this["writer"]: Still destroying... [id=smokef9b3-bi-bi-writer, 3m40s elapsed][0m[0m[0m
+[0;90m01:20:41.202[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.eks_cluster.aws_eks_cluster.this[0]: Still destroying... [id=smokef9b3-bi, 3m10s elapsed][0m[0m[0m
+[0;90m01:20:42.807[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.aurora[0].aws_rds_cluster_instance.this["reader"]: Still destroying... [id=smokef9b3-bi-reader, 1m30s elapsed][0m[0m[0m
+[0;90m01:20:43.084[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.aurora[0].aws_rds_cluster_instance.this["writer"]: Still destroying... [id=smokef9b3-bi-writer, 1m30s elapsed][0m[0m[0m
+[0;90m01:20:48.076[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.bi_aurora[0].aws_rds_cluster_instance.this["writer"]: Still destroying... [id=smokef9b3-bi-bi-writer, 3m50s elapsed][0m[0m[0m
+[0;90m01:20:51.203[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.eks_cluster.aws_eks_cluster.this[0]: Still destroying... [id=smokef9b3-bi, 3m20s elapsed][0m[0m[0m
+[0;90m01:20:52.807[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.aurora[0].aws_rds_cluster_instance.this["reader"]: Still destroying... [id=smokef9b3-bi-reader, 1m40s elapsed][0m[0m[0m
+[0;90m01:20:53.084[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.aurora[0].aws_rds_cluster_instance.this["writer"]: Still destroying... [id=smokef9b3-bi-writer, 1m40s elapsed][0m[0m[0m
+[0;90m01:20:58.076[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.bi_aurora[0].aws_rds_cluster_instance.this["writer"]: Still destroying... [id=smokef9b3-bi-bi-writer, 4m0s elapsed][0m[0m[0m
+[0;90m01:21:01.203[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.eks_cluster.aws_eks_cluster.this[0]: Still destroying... [id=smokef9b3-bi, 3m30s elapsed][0m[0m[0m
+[0;90m01:21:02.808[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.aurora[0].aws_rds_cluster_instance.this["reader"]: Still destroying... [id=smokef9b3-bi-reader, 1m50s elapsed][0m[0m[0m
+[0;90m01:21:03.084[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.aurora[0].aws_rds_cluster_instance.this["writer"]: Still destroying... [id=smokef9b3-bi-writer, 1m50s elapsed][0m[0m[0m
+[0;90m01:21:08.077[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.bi_aurora[0].aws_rds_cluster_instance.this["writer"]: Still destroying... [id=smokef9b3-bi-bi-writer, 4m10s elapsed][0m[0m[0m
+[0;90m01:21:11.206[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.eks_cluster.aws_eks_cluster.this[0]: Still destroying... [id=smokef9b3-bi, 3m40s elapsed][0m[0m[0m
+[0;90m01:21:12.808[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.aurora[0].aws_rds_cluster_instance.this["reader"]: Still destroying... [id=smokef9b3-bi-reader, 2m0s elapsed][0m[0m[0m
+[0;90m01:21:13.084[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.aurora[0].aws_rds_cluster_instance.this["writer"]: Still destroying... [id=smokef9b3-bi-writer, 2m0s elapsed][0m[0m[0m
+[0;90m01:21:18.077[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.bi_aurora[0].aws_rds_cluster_instance.this["writer"]: Still destroying... [id=smokef9b3-bi-bi-writer, 4m20s elapsed][0m[0m[0m
+[0;90m01:21:21.206[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.eks_cluster.aws_eks_cluster.this[0]: Still destroying... [id=smokef9b3-bi, 3m50s elapsed][0m[0m[0m
+[0;90m01:21:22.808[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.aurora[0].aws_rds_cluster_instance.this["reader"]: Still destroying... [id=smokef9b3-bi-reader, 2m10s elapsed][0m[0m[0m
+[0;90m01:21:23.084[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.aurora[0].aws_rds_cluster_instance.this["writer"]: Still destroying... [id=smokef9b3-bi-writer, 2m10s elapsed][0m[0m[0m
+[0;90m01:21:28.077[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.bi_aurora[0].aws_rds_cluster_instance.this["writer"]: Still destroying... [id=smokef9b3-bi-bi-writer, 4m30s elapsed][0m[0m[0m
+[0;90m01:21:31.209[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.eks_cluster.aws_eks_cluster.this[0]: Still destroying... [id=smokef9b3-bi, 4m0s elapsed][0m[0m[0m
+[0;90m01:21:32.808[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.aurora[0].aws_rds_cluster_instance.this["reader"]: Still destroying... [id=smokef9b3-bi-reader, 2m20s elapsed][0m[0m[0m
+[0;90m01:21:33.084[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.aurora[0].aws_rds_cluster_instance.this["writer"]: Still destroying... [id=smokef9b3-bi-writer, 2m20s elapsed][0m[0m[0m
+[0;90m01:21:38.077[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.bi_aurora[0].aws_rds_cluster_instance.this["writer"]: Still destroying... [id=smokef9b3-bi-bi-writer, 4m40s elapsed][0m[0m[0m
+[0;90m01:21:41.212[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.eks_cluster.aws_eks_cluster.this[0]: Still destroying... [id=smokef9b3-bi, 4m10s elapsed][0m[0m[0m
+[0;90m01:21:42.808[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.aurora[0].aws_rds_cluster_instance.this["reader"]: Still destroying... [id=smokef9b3-bi-reader, 2m30s elapsed][0m[0m[0m
+[0;90m01:21:43.085[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.aurora[0].aws_rds_cluster_instance.this["writer"]: Still destroying... [id=smokef9b3-bi-writer, 2m30s elapsed][0m[0m[0m
+[0;90m01:21:48.077[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.bi_aurora[0].aws_rds_cluster_instance.this["writer"]: Still destroying... [id=smokef9b3-bi-bi-writer, 4m50s elapsed][0m[0m[0m
+[0;90m01:21:51.213[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.eks_cluster.aws_eks_cluster.this[0]: Still destroying... [id=smokef9b3-bi, 4m20s elapsed][0m[0m[0m
+[0;90m01:21:52.808[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.aurora[0].aws_rds_cluster_instance.this["reader"]: Still destroying... [id=smokef9b3-bi-reader, 2m40s elapsed][0m[0m[0m
+[0;90m01:21:53.085[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.aurora[0].aws_rds_cluster_instance.this["writer"]: Still destroying... [id=smokef9b3-bi-writer, 2m40s elapsed][0m[0m[0m
+[0;90m01:21:58.079[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.bi_aurora[0].aws_rds_cluster_instance.this["writer"]: Still destroying... [id=smokef9b3-bi-bi-writer, 5m0s elapsed][0m[0m[0m
+[0;90m01:22:01.213[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.eks_cluster.aws_eks_cluster.this[0]: Still destroying... [id=smokef9b3-bi, 4m30s elapsed][0m[0m[0m
+[0;90m01:22:02.809[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.aurora[0].aws_rds_cluster_instance.this["reader"]: Still destroying... [id=smokef9b3-bi-reader, 2m50s elapsed][0m[0m[0m
+[0;90m01:22:03.086[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.aurora[0].aws_rds_cluster_instance.this["writer"]: Still destroying... [id=smokef9b3-bi-writer, 2m50s elapsed][0m[0m[0m
+[0;90m01:22:08.079[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.bi_aurora[0].aws_rds_cluster_instance.this["writer"]: Still destroying... [id=smokef9b3-bi-bi-writer, 5m10s elapsed][0m[0m[0m
+[0;90m01:22:11.214[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.eks_cluster.aws_eks_cluster.this[0]: Still destroying... [id=smokef9b3-bi, 4m40s elapsed][0m[0m[0m
+[0;90m01:22:12.810[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.aurora[0].aws_rds_cluster_instance.this["reader"]: Still destroying... [id=smokef9b3-bi-reader, 3m0s elapsed][0m[0m[0m
+[0;90m01:22:13.086[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.aurora[0].aws_rds_cluster_instance.this["writer"]: Still destroying... [id=smokef9b3-bi-writer, 3m0s elapsed][0m[0m[0m
+[0;90m01:22:18.079[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.bi_aurora[0].aws_rds_cluster_instance.this["writer"]: Still destroying... [id=smokef9b3-bi-bi-writer, 5m20s elapsed][0m[0m[0m
+[0;90m01:22:21.217[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.eks_cluster.aws_eks_cluster.this[0]: Still destroying... [id=smokef9b3-bi, 4m50s elapsed][0m[0m[0m
+[0;90m01:22:22.811[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.aurora[0].aws_rds_cluster_instance.this["reader"]: Still destroying... [id=smokef9b3-bi-reader, 3m10s elapsed][0m[0m[0m
+[0;90m01:22:23.086[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.aurora[0].aws_rds_cluster_instance.this["writer"]: Still destroying... [id=smokef9b3-bi-writer, 3m10s elapsed][0m[0m[0m
+[0;90m01:22:28.079[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.bi_aurora[0].aws_rds_cluster_instance.this["writer"]: Still destroying... [id=smokef9b3-bi-bi-writer, 5m30s elapsed][0m[0m[0m
+[0;90m01:22:31.218[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.eks_cluster.aws_eks_cluster.this[0]: Still destroying... [id=smokef9b3-bi, 5m0s elapsed][0m[0m[0m
+[0;90m01:22:32.812[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.aurora[0].aws_rds_cluster_instance.this["reader"]: Still destroying... [id=smokef9b3-bi-reader, 3m20s elapsed][0m[0m[0m
+[0;90m01:22:33.087[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.aurora[0].aws_rds_cluster_instance.this["writer"]: Still destroying... [id=smokef9b3-bi-writer, 3m20s elapsed][0m[0m[0m
+[0;90m01:22:38.081[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.bi_aurora[0].aws_rds_cluster_instance.this["writer"]: Still destroying... [id=smokef9b3-bi-bi-writer, 5m40s elapsed][0m[0m[0m
+[0;90m01:22:41.219[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.eks_cluster.aws_eks_cluster.this[0]: Still destroying... [id=smokef9b3-bi, 5m10s elapsed][0m[0m[0m
+[0;90m01:22:42.812[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.aurora[0].aws_rds_cluster_instance.this["reader"]: Still destroying... [id=smokef9b3-bi-reader, 3m30s elapsed][0m[0m[0m
+[0;90m01:22:43.088[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.aurora[0].aws_rds_cluster_instance.this["writer"]: Still destroying... [id=smokef9b3-bi-writer, 3m30s elapsed][0m[0m[0m
+[0;90m01:22:48.081[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.bi_aurora[0].aws_rds_cluster_instance.this["writer"]: Still destroying... [id=smokef9b3-bi-bi-writer, 5m50s elapsed][0m[0m[0m
+[0;90m01:22:51.220[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.eks_cluster.aws_eks_cluster.this[0]: Still destroying... [id=smokef9b3-bi, 5m20s elapsed][0m[0m[0m
+[0;90m01:22:52.813[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.aurora[0].aws_rds_cluster_instance.this["reader"]: Still destroying... [id=smokef9b3-bi-reader, 3m40s elapsed][0m[0m[0m
+[0;90m01:22:53.088[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.aurora[0].aws_rds_cluster_instance.this["writer"]: Still destroying... [id=smokef9b3-bi-writer, 3m40s elapsed][0m[0m[0m
+[0;90m01:22:58.082[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.bi_aurora[0].aws_rds_cluster_instance.this["writer"]: Still destroying... [id=smokef9b3-bi-bi-writer, 6m0s elapsed][0m[0m[0m
+[0;90m01:23:01.220[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.eks_cluster.aws_eks_cluster.this[0]: Still destroying... [id=smokef9b3-bi, 5m30s elapsed][0m[0m[0m
+[0;90m01:23:02.813[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.aurora[0].aws_rds_cluster_instance.this["reader"]: Still destroying... [id=smokef9b3-bi-reader, 3m50s elapsed][0m[0m[0m
+[0;90m01:23:03.089[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.aurora[0].aws_rds_cluster_instance.this["writer"]: Still destroying... [id=smokef9b3-bi-writer, 3m50s elapsed][0m[0m[0m
+[0;90m01:23:07.401[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.eks_cluster.aws_eks_cluster.this[0]: Destruction complete after 5m36s[0m[0m
+[0;90m01:23:07.603[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.eks_cluster.aws_security_group_rule.node["ingress_cluster_4443_webhook"]: Destroying... [id=sgrule-2294978313][0m[0m[0m
+[0;90m01:23:07.603[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.eks_cluster.aws_security_group_rule.node["ingress_self_coredns_udp"]: Destroying... [id=sgrule-2170967884][0m[0m[0m
+[0;90m01:23:07.603[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.eks_cluster.aws_security_group_rule.cluster["ingress_nodes_443"]: Destroying... [id=sgrule-1819625096][0m[0m[0m
+[0;90m01:23:07.604[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.eks_cluster.aws_iam_role.eks_auto[0]: Destroying... [id=smokef9b3-bi-eks-auto-a224fa65e5bc2aeaadec193df5][0m[0m[0m
+[0;90m01:23:07.607[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.eks_cluster.aws_security_group_rule.node["ingress_cluster_8443_webhook"]: Destroying... [id=sgrule-1389677758][0m[0m[0m
+[0;90m01:23:07.611[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.eks_cluster.module.kms.aws_kms_key.this[0]: Destroying... [id=f61ca9f2-4b6d-4381-83a4-99c2e2c113d6][0m[0m[0m
+[0;90m01:23:07.613[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.eks_cluster.aws_security_group_rule.node["ingress_self_coredns_tcp"]: Destroying... [id=sgrule-624555171][0m[0m[0m
+[0;90m01:23:07.694[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.eks_cluster.module.kms.aws_kms_key.this[0]: Destruction complete after 0s[0m[0m
+[0;90m01:23:07.696[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.eks_cluster.aws_security_group_rule.node["egress_all"]: Destroying... [id=sgrule-1280231865][0m[0m[0m
+[0;90m01:23:07.850[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.eks_cluster.aws_iam_role.eks_auto[0]: Destruction complete after 0s[0m[0m
+[0;90m01:23:07.852[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.eks_cluster.aws_security_group_rule.node["ingress_cluster_10251_webhook"]: Destroying... [id=sgrule-662475610][0m[0m[0m
+[0;90m01:23:07.999[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.eks_cluster.aws_security_group_rule.cluster["ingress_nodes_443"]: Destruction complete after 0s[0m[0m
+[0;90m01:23:08.001[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.eks_cluster.aws_iam_role_policy_attachment.this["AmazonEKSComputePolicy"]: Destroying... [id=smokef9b3-bi-cluster-9e18d41e2ffbed06f78a2191ee/arn:aws:iam::aws:policy/AmazonEKSComputePolicy][0m[0m[0m
+[0;90m01:23:08.006[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.eks_cluster.aws_security_group_rule.node["ingress_cluster_4443_webhook"]: Destruction complete after 0s[0m[0m
+[0;90m01:23:08.008[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.eks_cluster.aws_security_group_rule.node["ingress_cluster_kubelet"]: Destroying... [id=sgrule-322290465][0m[0m[0m
+[0;90m01:23:08.083[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.bi_aurora[0].aws_rds_cluster_instance.this["writer"]: Still destroying... [id=smokef9b3-bi-bi-writer, 6m10s elapsed][0m[0m[0m
+[0;90m01:23:08.085[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.eks_cluster.aws_iam_role_policy_attachment.this["AmazonEKSComputePolicy"]: Destruction complete after 0s[0m[0m
+[0;90m01:23:08.086[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.eks_cluster.aws_iam_role_policy_attachment.this["AmazonEKSBlockStoragePolicy"]: Destroying... [id=smokef9b3-bi-cluster-9e18d41e2ffbed06f78a2191ee/arn:aws:iam::aws:policy/AmazonEKSBlockStoragePolicy][0m[0m[0m
+[0;90m01:23:08.182[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.eks_cluster.aws_iam_role_policy_attachment.this["AmazonEKSBlockStoragePolicy"]: Destruction complete after 0s[0m[0m
+[0;90m01:23:08.184[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.eks_cluster.aws_iam_role_policy_attachment.this["AmazonEKSClusterPolicy"]: Destroying... [id=smokef9b3-bi-cluster-9e18d41e2ffbed06f78a2191ee/arn:aws:iam::aws:policy/AmazonEKSClusterPolicy][0m[0m[0m
+[0;90m01:23:08.261[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.eks_cluster.aws_iam_role_policy_attachment.this["AmazonEKSClusterPolicy"]: Destruction complete after 0s[0m[0m
+[0;90m01:23:08.263[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.eks_cluster.aws_security_group_rule.node["ingress_cluster_6443_webhook"]: Destroying... [id=sgrule-1099493535][0m[0m[0m
+[0;90m01:23:08.507[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.eks_cluster.aws_security_group_rule.node["ingress_self_coredns_udp"]: Destruction complete after 1s[0m[0m
+[0;90m01:23:08.508[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.eks_cluster.aws_iam_role_policy_attachment.this["AmazonEKSNetworkingPolicy"]: Destroying... [id=smokef9b3-bi-cluster-9e18d41e2ffbed06f78a2191ee/arn:aws:iam::aws:policy/AmazonEKSNetworkingPolicy][0m[0m[0m
+[0;90m01:23:08.572[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.eks_cluster.aws_iam_role_policy_attachment.this["AmazonEKSNetworkingPolicy"]: Destruction complete after 0s[0m[0m
+[0;90m01:23:08.574[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.eks_cluster.aws_security_group_rule.node["ingress_nodes_ephemeral"]: Destroying... [id=sgrule-2693374753][0m[0m[0m
+[0;90m01:23:09.008[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.eks_cluster.aws_security_group_rule.node["ingress_cluster_8443_webhook"]: Destruction complete after 1s[0m[0m
+[0;90m01:23:09.009[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.eks_cluster.aws_security_group_rule.node["ingress_cluster_443"]: Destroying... [id=sgrule-939112924][0m[0m[0m
+[0;90m01:23:09.534[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.eks_cluster.aws_security_group_rule.node["ingress_self_coredns_tcp"]: Destruction complete after 2s[0m[0m
+[0;90m01:23:09.536[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.eks_cluster.aws_cloudwatch_log_group.this[0]: Destroying... [id=/aws/eks/smokef9b3-bi/cluster][0m[0m[0m
+[0;90m01:23:09.674[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.eks_cluster.aws_cloudwatch_log_group.this[0]: Destruction complete after 0s[0m[0m
+[0;90m01:23:09.676[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.eks_cluster.aws_iam_role_policy_attachment.this["AmazonEKSLoadBalancingPolicy"]: Destroying... [id=smokef9b3-bi-cluster-9e18d41e2ffbed06f78a2191ee/arn:aws:iam::aws:policy/AmazonEKSLoadBalancingPolicy][0m[0m[0m
+[0;90m01:23:09.735[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.eks_cluster.aws_iam_role_policy_attachment.this["AmazonEKSLoadBalancingPolicy"]: Destruction complete after 0s[0m[0m
+[0;90m01:23:09.737[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.eks_cluster.aws_security_group_rule.node["ingress_cluster_9443_webhook"]: Destroying... [id=sgrule-913702773][0m[0m[0m
+[0;90m01:23:10.038[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.eks_cluster.aws_security_group_rule.node["egress_all"]: Destruction complete after 2s[0m[0m
+[0;90m01:23:10.040[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1maws_kms_key.eks[0]: Destroying... [id=1d14d0a3-20c4-492e-a9b2-e88d530a8ad1][0m[0m[0m
+[0;90m01:23:10.086[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1maws_kms_key.eks[0]: Destruction complete after 0s[0m[0m
+[0;90m01:23:10.089[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.eks_cluster.aws_iam_role.this[0]: Destroying... [id=smokef9b3-bi-cluster-9e18d41e2ffbed06f78a2191ee][0m[0m[0m
+[0;90m01:23:10.261[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.eks_cluster.aws_iam_role.this[0]: Destruction complete after 0s[0m[0m
+[0;90m01:23:10.553[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.eks_cluster.aws_security_group_rule.node["ingress_cluster_10251_webhook"]: Destruction complete after 3s[0m[0m
+[0;90m01:23:11.052[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.eks_cluster.aws_security_group_rule.node["ingress_cluster_kubelet"]: Destruction complete after 3s[0m[0m
+[0;90m01:23:11.580[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.eks_cluster.aws_security_group_rule.node["ingress_cluster_6443_webhook"]: Destruction complete after 4s[0m[0m
+[0;90m01:23:12.107[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.eks_cluster.aws_security_group_rule.node["ingress_nodes_ephemeral"]: Destruction complete after 3s[0m[0m
+[0;90m01:23:12.616[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.eks_cluster.aws_security_group_rule.node["ingress_cluster_443"]: Destruction complete after 4s[0m[0m
+[0;90m01:23:12.814[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.aurora[0].aws_rds_cluster_instance.this["reader"]: Still destroying... [id=smokef9b3-bi-reader, 4m0s elapsed][0m[0m[0m
+[0;90m01:23:13.090[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.aurora[0].aws_rds_cluster_instance.this["writer"]: Still destroying... [id=smokef9b3-bi-writer, 4m0s elapsed][0m[0m[0m
+[0;90m01:23:13.122[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.eks_cluster.aws_security_group_rule.node["ingress_cluster_9443_webhook"]: Destruction complete after 3s[0m[0m
+[0;90m01:23:13.127[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.eks_cluster.aws_security_group.cluster[0]: Destroying... [id=sg-0c78671e37d576cbc][0m[0m[0m
+[0;90m01:23:13.133[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.eks_cluster.aws_security_group.node[0]: Destroying... [id=sg-0c8d6a1ae2c80af6a][0m[0m[0m
+[0;90m01:23:13.670[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.eks_cluster.aws_security_group.cluster[0]: Destruction complete after 1s[0m[0m
+[0;90m01:23:13.686[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.eks_cluster.aws_security_group.node[0]: Destruction complete after 1s[0m[0m
+[0;90m01:23:18.083[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.bi_aurora[0].aws_rds_cluster_instance.this["writer"]: Still destroying... [id=smokef9b3-bi-bi-writer, 6m20s elapsed][0m[0m[0m
+[0;90m01:23:22.819[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.aurora[0].aws_rds_cluster_instance.this["reader"]: Still destroying... [id=smokef9b3-bi-reader, 4m10s elapsed][0m[0m[0m
+[0;90m01:23:23.091[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.aurora[0].aws_rds_cluster_instance.this["writer"]: Still destroying... [id=smokef9b3-bi-writer, 4m10s elapsed][0m[0m[0m
+[0;90m01:23:28.083[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.bi_aurora[0].aws_rds_cluster_instance.this["writer"]: Still destroying... [id=smokef9b3-bi-bi-writer, 6m30s elapsed][0m[0m[0m
+[0;90m01:23:32.823[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.aurora[0].aws_rds_cluster_instance.this["reader"]: Still destroying... [id=smokef9b3-bi-reader, 4m20s elapsed][0m[0m[0m
+[0;90m01:23:33.091[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.aurora[0].aws_rds_cluster_instance.this["writer"]: Still destroying... [id=smokef9b3-bi-writer, 4m20s elapsed][0m[0m[0m
+[0;90m01:23:38.083[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.bi_aurora[0].aws_rds_cluster_instance.this["writer"]: Still destroying... [id=smokef9b3-bi-bi-writer, 6m40s elapsed][0m[0m[0m
+[0;90m01:23:42.823[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.aurora[0].aws_rds_cluster_instance.this["reader"]: Still destroying... [id=smokef9b3-bi-reader, 4m30s elapsed][0m[0m[0m
+[0;90m01:23:43.091[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.aurora[0].aws_rds_cluster_instance.this["writer"]: Still destroying... [id=smokef9b3-bi-writer, 4m30s elapsed][0m[0m[0m
+[0;90m01:23:48.083[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.bi_aurora[0].aws_rds_cluster_instance.this["writer"]: Still destroying... [id=smokef9b3-bi-bi-writer, 6m50s elapsed][0m[0m[0m
+[0;90m01:23:52.826[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.aurora[0].aws_rds_cluster_instance.this["reader"]: Still destroying... [id=smokef9b3-bi-reader, 4m40s elapsed][0m[0m[0m
+[0;90m01:23:53.091[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.aurora[0].aws_rds_cluster_instance.this["writer"]: Still destroying... [id=smokef9b3-bi-writer, 4m40s elapsed][0m[0m[0m
+[0;90m01:23:58.083[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.bi_aurora[0].aws_rds_cluster_instance.this["writer"]: Still destroying... [id=smokef9b3-bi-bi-writer, 7m0s elapsed][0m[0m[0m
+[0;90m01:24:02.830[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.aurora[0].aws_rds_cluster_instance.this["reader"]: Still destroying... [id=smokef9b3-bi-reader, 4m50s elapsed][0m[0m[0m
+[0;90m01:24:03.092[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.aurora[0].aws_rds_cluster_instance.this["writer"]: Still destroying... [id=smokef9b3-bi-writer, 4m50s elapsed][0m[0m[0m
+[0;90m01:24:08.084[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.bi_aurora[0].aws_rds_cluster_instance.this["writer"]: Still destroying... [id=smokef9b3-bi-bi-writer, 7m10s elapsed][0m[0m[0m
+[0;90m01:24:12.830[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.aurora[0].aws_rds_cluster_instance.this["reader"]: Still destroying... [id=smokef9b3-bi-reader, 5m0s elapsed][0m[0m[0m
+[0;90m01:24:13.092[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.aurora[0].aws_rds_cluster_instance.this["writer"]: Still destroying... [id=smokef9b3-bi-writer, 5m0s elapsed][0m[0m[0m
+[0;90m01:24:18.085[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.bi_aurora[0].aws_rds_cluster_instance.this["writer"]: Still destroying... [id=smokef9b3-bi-bi-writer, 7m20s elapsed][0m[0m[0m
+[0;90m01:24:22.832[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.aurora[0].aws_rds_cluster_instance.this["reader"]: Still destroying... [id=smokef9b3-bi-reader, 5m10s elapsed][0m[0m[0m
+[0;90m01:24:23.092[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.aurora[0].aws_rds_cluster_instance.this["writer"]: Still destroying... [id=smokef9b3-bi-writer, 5m10s elapsed][0m[0m[0m
+[0;90m01:24:27.073[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.aurora[0].aws_rds_cluster_instance.this["writer"]: Destruction complete after 5m14s[0m[0m
+[0;90m01:24:28.086[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.bi_aurora[0].aws_rds_cluster_instance.this["writer"]: Still destroying... [id=smokef9b3-bi-bi-writer, 7m30s elapsed][0m[0m[0m
+[0;90m01:24:32.835[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.aurora[0].aws_rds_cluster_instance.this["reader"]: Still destroying... [id=smokef9b3-bi-reader, 5m20s elapsed][0m[0m[0m
+[0;90m01:24:38.086[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.bi_aurora[0].aws_rds_cluster_instance.this["writer"]: Still destroying... [id=smokef9b3-bi-bi-writer, 7m40s elapsed][0m[0m[0m
+[0;90m01:24:42.835[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.aurora[0].aws_rds_cluster_instance.this["reader"]: Still destroying... [id=smokef9b3-bi-reader, 5m30s elapsed][0m[0m[0m
+[0;90m01:24:48.086[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.bi_aurora[0].aws_rds_cluster_instance.this["writer"]: Still destroying... [id=smokef9b3-bi-bi-writer, 7m50s elapsed][0m[0m[0m
+[0;90m01:24:52.839[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.aurora[0].aws_rds_cluster_instance.this["reader"]: Still destroying... [id=smokef9b3-bi-reader, 5m40s elapsed][0m[0m[0m
+[0;90m01:24:58.086[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.bi_aurora[0].aws_rds_cluster_instance.this["writer"]: Still destroying... [id=smokef9b3-bi-bi-writer, 8m0s elapsed][0m[0m[0m
+[0;90m01:25:02.842[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.aurora[0].aws_rds_cluster_instance.this["reader"]: Still destroying... [id=smokef9b3-bi-reader, 5m50s elapsed][0m[0m[0m
+[0;90m01:25:08.087[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.bi_aurora[0].aws_rds_cluster_instance.this["writer"]: Still destroying... [id=smokef9b3-bi-bi-writer, 8m10s elapsed][0m[0m[0m
+[0;90m01:25:12.846[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.aurora[0].aws_rds_cluster_instance.this["reader"]: Still destroying... [id=smokef9b3-bi-reader, 6m0s elapsed][0m[0m[0m
+[0;90m01:25:18.088[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.bi_aurora[0].aws_rds_cluster_instance.this["writer"]: Still destroying... [id=smokef9b3-bi-bi-writer, 8m20s elapsed][0m[0m[0m
+[0;90m01:25:22.848[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.aurora[0].aws_rds_cluster_instance.this["reader"]: Still destroying... [id=smokef9b3-bi-reader, 6m10s elapsed][0m[0m[0m
+[0;90m01:25:28.089[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.bi_aurora[0].aws_rds_cluster_instance.this["writer"]: Still destroying... [id=smokef9b3-bi-bi-writer, 8m30s elapsed][0m[0m[0m
+[0;90m01:25:32.852[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.aurora[0].aws_rds_cluster_instance.this["reader"]: Still destroying... [id=smokef9b3-bi-reader, 6m20s elapsed][0m[0m[0m
+[0;90m01:25:38.089[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.bi_aurora[0].aws_rds_cluster_instance.this["writer"]: Still destroying... [id=smokef9b3-bi-bi-writer, 8m40s elapsed][0m[0m[0m
+[0;90m01:25:42.853[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.aurora[0].aws_rds_cluster_instance.this["reader"]: Still destroying... [id=smokef9b3-bi-reader, 6m30s elapsed][0m[0m[0m
+[0;90m01:25:48.089[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.bi_aurora[0].aws_rds_cluster_instance.this["writer"]: Still destroying... [id=smokef9b3-bi-bi-writer, 8m50s elapsed][0m[0m[0m
+[0;90m01:25:52.857[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.aurora[0].aws_rds_cluster_instance.this["reader"]: Still destroying... [id=smokef9b3-bi-reader, 6m40s elapsed][0m[0m[0m
+[0;90m01:25:58.089[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.bi_aurora[0].aws_rds_cluster_instance.this["writer"]: Still destroying... [id=smokef9b3-bi-bi-writer, 9m0s elapsed][0m[0m[0m
+[0;90m01:26:02.859[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.aurora[0].aws_rds_cluster_instance.this["reader"]: Still destroying... [id=smokef9b3-bi-reader, 6m50s elapsed][0m[0m[0m
+[0;90m01:26:08.090[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.bi_aurora[0].aws_rds_cluster_instance.this["writer"]: Still destroying... [id=smokef9b3-bi-bi-writer, 9m10s elapsed][0m[0m[0m
+[0;90m01:26:12.862[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.aurora[0].aws_rds_cluster_instance.this["reader"]: Still destroying... [id=smokef9b3-bi-reader, 7m0s elapsed][0m[0m[0m
+[0;90m01:26:18.092[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.bi_aurora[0].aws_rds_cluster_instance.this["writer"]: Still destroying... [id=smokef9b3-bi-bi-writer, 9m20s elapsed][0m[0m[0m
+[0;90m01:26:22.865[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.aurora[0].aws_rds_cluster_instance.this["reader"]: Still destroying... [id=smokef9b3-bi-reader, 7m10s elapsed][0m[0m[0m
+[0;90m01:26:28.095[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.bi_aurora[0].aws_rds_cluster_instance.this["writer"]: Still destroying... [id=smokef9b3-bi-bi-writer, 9m30s elapsed][0m[0m[0m
+[0;90m01:26:32.868[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.aurora[0].aws_rds_cluster_instance.this["reader"]: Still destroying... [id=smokef9b3-bi-reader, 7m20s elapsed][0m[0m[0m
+[0;90m01:26:38.095[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.bi_aurora[0].aws_rds_cluster_instance.this["writer"]: Still destroying... [id=smokef9b3-bi-bi-writer, 9m40s elapsed][0m[0m[0m
+[0;90m01:26:42.872[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.aurora[0].aws_rds_cluster_instance.this["reader"]: Still destroying... [id=smokef9b3-bi-reader, 7m30s elapsed][0m[0m[0m
+[0;90m01:26:48.095[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.bi_aurora[0].aws_rds_cluster_instance.this["writer"]: Still destroying... [id=smokef9b3-bi-bi-writer, 9m50s elapsed][0m[0m[0m
+[0;90m01:26:52.875[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.aurora[0].aws_rds_cluster_instance.this["reader"]: Still destroying... [id=smokef9b3-bi-reader, 7m40s elapsed][0m[0m[0m
+[0;90m01:26:58.095[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.bi_aurora[0].aws_rds_cluster_instance.this["writer"]: Still destroying... [id=smokef9b3-bi-bi-writer, 10m0s elapsed][0m[0m[0m
+[0;90m01:27:02.876[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.aurora[0].aws_rds_cluster_instance.this["reader"]: Still destroying... [id=smokef9b3-bi-reader, 7m50s elapsed][0m[0m[0m
+[0;90m01:27:06.059[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.bi_aurora[0].aws_rds_cluster_instance.this["writer"]: Destruction complete after 10m8s[0m[0m
+[0;90m01:27:06.218[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.bi_aurora[0].aws_db_parameter_group.this[0]: Destroying... [id=smokef9b3-bi-bi-cbd1ffb31fa948489874aca049][0m[0m[0m
+[0;90m01:27:06.314[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.bi_aurora[0].aws_db_parameter_group.this[0]: Destruction complete after 0s[0m[0m
+[0;90m01:27:12.876[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.aurora[0].aws_rds_cluster_instance.this["reader"]: Still destroying... [id=smokef9b3-bi-reader, 8m0s elapsed][0m[0m[0m
+[0;90m01:27:22.876[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.aurora[0].aws_rds_cluster_instance.this["reader"]: Still destroying... [id=smokef9b3-bi-reader, 8m10s elapsed][0m[0m[0m
+[0;90m01:27:32.877[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.aurora[0].aws_rds_cluster_instance.this["reader"]: Still destroying... [id=smokef9b3-bi-reader, 8m20s elapsed][0m[0m[0m
+[0;90m01:27:42.879[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.aurora[0].aws_rds_cluster_instance.this["reader"]: Still destroying... [id=smokef9b3-bi-reader, 8m30s elapsed][0m[0m[0m
+[0;90m01:27:52.882[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.aurora[0].aws_rds_cluster_instance.this["reader"]: Still destroying... [id=smokef9b3-bi-reader, 8m40s elapsed][0m[0m[0m
+[0;90m01:28:02.882[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.aurora[0].aws_rds_cluster_instance.this["reader"]: Still destroying... [id=smokef9b3-bi-reader, 8m50s elapsed][0m[0m[0m
+[0;90m01:28:12.882[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.aurora[0].aws_rds_cluster_instance.this["reader"]: Still destroying... [id=smokef9b3-bi-reader, 9m0s elapsed][0m[0m[0m
+[0;90m01:28:22.883[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.aurora[0].aws_rds_cluster_instance.this["reader"]: Still destroying... [id=smokef9b3-bi-reader, 9m10s elapsed][0m[0m[0m
+[0;90m01:28:32.884[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.aurora[0].aws_rds_cluster_instance.this["reader"]: Still destroying... [id=smokef9b3-bi-reader, 9m20s elapsed][0m[0m[0m
+[0;90m01:28:42.886[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.aurora[0].aws_rds_cluster_instance.this["reader"]: Still destroying... [id=smokef9b3-bi-reader, 9m30s elapsed][0m[0m[0m
+[0;90m01:28:52.886[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.aurora[0].aws_rds_cluster_instance.this["reader"]: Still destroying... [id=smokef9b3-bi-reader, 9m40s elapsed][0m[0m[0m
+[0;90m01:29:02.886[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.aurora[0].aws_rds_cluster_instance.this["reader"]: Still destroying... [id=smokef9b3-bi-reader, 9m50s elapsed][0m[0m[0m
+[0;90m01:29:12.886[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.aurora[0].aws_rds_cluster_instance.this["reader"]: Still destroying... [id=smokef9b3-bi-reader, 10m0s elapsed][0m[0m[0m
+[0;90m01:29:22.887[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.aurora[0].aws_rds_cluster_instance.this["reader"]: Still destroying... [id=smokef9b3-bi-reader, 10m10s elapsed][0m[0m[0m
+[0;90m01:29:32.887[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.aurora[0].aws_rds_cluster_instance.this["reader"]: Still destroying... [id=smokef9b3-bi-reader, 10m20s elapsed][0m[0m[0m
+[0;90m01:29:42.887[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.aurora[0].aws_rds_cluster_instance.this["reader"]: Still destroying... [id=smokef9b3-bi-reader, 10m30s elapsed][0m[0m[0m
+[0;90m01:29:52.887[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.aurora[0].aws_rds_cluster_instance.this["reader"]: Still destroying... [id=smokef9b3-bi-reader, 10m40s elapsed][0m[0m[0m
+[0;90m01:30:02.888[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.aurora[0].aws_rds_cluster_instance.this["reader"]: Still destroying... [id=smokef9b3-bi-reader, 10m50s elapsed][0m[0m[0m
+[0;90m01:30:12.888[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.aurora[0].aws_rds_cluster_instance.this["reader"]: Still destroying... [id=smokef9b3-bi-reader, 11m0s elapsed][0m[0m[0m
+[0;90m01:30:21.175[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.aurora[0].aws_rds_cluster_instance.this["reader"]: Destruction complete after 11m8s[0m[0m
+[0;90m01:30:21.309[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.aurora[0].aws_db_parameter_group.this[0]: Destroying... [id=smokef9b3-bi-852046f801a88c462240d125d5][0m[0m[0m
+[0;90m01:30:21.430[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.aurora[0].aws_db_parameter_group.this[0]: Destruction complete after 0s[0m[0m
+[0;90m01:30:21.508[0m [0;31mSTDERR[0m [0;36mtofu: [0m[31m╷[0m[0m[0m
+[0;90m01:30:21.509[0m [0;31mSTDERR[0m [0;36mtofu: [0m[31m│[0m [0m[1m[31mError: [0m[0m[1mstopping DMS Serverless Replication (arn:aws:dms:us-east-1:000000000000:replication-config:REPLICATIONCONFIGID): operation error Database Migration Service: StopReplication, https response error StatusCode: 400, RequestID: 00000000-0000-0000-0000-000000000000, InvalidResourceStateFault: Replication for Replication Config, '2NVGVK6QFZEZZNCFFNKECQNLJI' is in 'provisioning_capacity' state and cannot be stopped. [0m[0m
+[0;90m01:30:21.510[0m [0;31mSTDERR[0m [0;36mtofu: [0m[31m│[0m [0m[0m
+[0;90m01:30:21.510[0m [0;31mSTDERR[0m [0;36mtofu: [0m[31m│[0m [0m[0m[0m
+[0;90m01:30:21.510[0m [0;31mSTDERR[0m [0;36mtofu: [0m[31m╵[0m[0m[0m
+[0;90m01:30:21.577[0m [0;31mERROR [0m error occurred:
+
+* Failed to execute "tofu destroy -auto-approve" in ./.terragrunt-cache/Bc7T44J9r9cIplenGG-aOjOmtGU/H0Rx20aAgwFbyJVuXFgGUpBRBwU/physical
+  [31m╷[0m[0m
+  [31m│[0m [0m[1m[31mError: [0m[0m[1mstopping DMS Serverless Replication (arn:aws:dms:us-east-1:000000000000:replication-config:REPLICATIONCONFIGID): operation error Database Migration Service: StopReplication, https response error StatusCode: 400, RequestID: 00000000-0000-0000-0000-000000000000, InvalidResourceStateFault: Replication for Replication Config, '2NVGVK6QFZEZZNCFFNKECQNLJI' is in 'provisioning_capacity' state and cannot be stopped. [0m
+  [31m│[0m [0m
+  [31m│[0m [0m[0m
+  [31m╵[0m[0m
+  
+  exit status 1
+
+
+>> keeping worktree /workspace/repo/live/tests/__worktrees__/harness-bi-ha-8dps9/v8.12.1 (run failed) so the cleanup backstop can destroy against the deployed code; 'git worktree remove' it after cleanup
+teardown failed: destroy: exit status 1

--- a/live/tests/harness/testdata/evidence/children.golden.json
+++ b/live/tests/harness/testdata/evidence/children.golden.json
@@ -1,0 +1,18 @@
+[
+  {
+    "name": "harness-bi-ha-8dps9",
+    "config": "bi_ha",
+    "phase": "Failed",
+    "msg": "child 'harness-bi-ha-8dps9-3308889610' failed",
+    "detail": "upgrade(0): main: Error (exit code 1); destroy(0): main: Error (exit code 1)",
+    "log_excerpt": "upgrade(0): upgrade failed: worktree add 8f347c78fb11039a9737c30e956fa16e5f57cd78 (8f347c78fb11039a9737c30e956fa16e5f57cd78): exit status 128; destroy(0): Error: stopping DMS Serverless Replication (arn:aws:dms:us-east-1:000000000000:replication-config:REPLICATIONCONFIGID): operation error Database Migration Service: StopReplication, https response error StatusCode: 400, \u2026"
+  },
+  {
+    "name": "harness-min-default-mdgxp",
+    "config": "min_default",
+    "phase": "Failed",
+    "msg": "child 'harness-min-default-mdgxp-1377804381' failed",
+    "detail": "upgrade(0): main: Error (exit code 1)",
+    "log_excerpt": "upgrade(0): upgrade failed: worktree add 8f347c78fb11039a9737c30e956fa16e5f57cd78 (8f347c78fb11039a9737c30e956fa16e5f57cd78): exit status 128"
+  }
+]

--- a/live/tests/harness/testdata/evidence/children.golden.json
+++ b/live/tests/harness/testdata/evidence/children.golden.json
@@ -5,7 +5,7 @@
     "phase": "Failed",
     "msg": "child 'harness-bi-ha-8dps9-3308889610' failed",
     "detail": "upgrade(0): main: Error (exit code 1); destroy(0): main: Error (exit code 1)",
-    "log_excerpt": "upgrade(0): upgrade failed: worktree add 8f347c78fb11039a9737c30e956fa16e5f57cd78 (8f347c78fb11039a9737c30e956fa16e5f57cd78): exit status 128; destroy(0): Error: stopping DMS Serverless Replication (arn:aws:dms:us-east-1:000000000000:replication-config:REPLICATIONCONFIGID): operation error Database Migration Service: StopReplication, https response error StatusCode: 400, \u2026"
+    "log_excerpt": "upgrade(0): upgrade failed: worktree add 8f347c78fb11039a9737c30e956fa16e5f57cd78 (8f347c78fb11039a9737c30e956fa16e5f57cd78): exit status 128; destroy(0): Error: stopping DMS Serverless Replication (arn:aws:dms:us-east-1:000000000000:replication-config:REPLICATIONCONFIGID): InvalidResourceStateFault: Replication for Replication Config, '2NVGVK6QFZEZZNCFFNKECQNLJI' is in 'provisioning_capacity' state and cannot be stopped."
   },
   {
     "name": "harness-min-default-mdgxp",

--- a/live/tests/harness/testdata/evidence/min-default-upgrade.log
+++ b/live/tests/harness/testdata/evidence/min-default-upgrade.log
@@ -1,0 +1,11 @@
+>> [entrypoint] repo present at /workspace/repo; fetching
+>> [entrypoint] repo at 2942fc5 (master)
+>> [entrypoint] TLS: generated a self-signed cert for the manual-TLS path
+>> [entrypoint] Vault: aws login (addr=http://vault.internal.dozuki.com:8200 role=deployer)
+>> [entrypoint] Vault: token acquired
+>> [entrypoint] AWS: profile ddvtest chains into arn:aws:iam::000000000000:role/cloudprem-upgrade-tests
+>> [entrypoint] AWS: assumed arn:aws:sts::000000000000:assumed-role/cloudprem-upgrade-tests/harness-harness-min-default-mdgxp
+>> [entrypoint] toolchain: OpenTofu v1.11.8 | terragrunt 0.99.4 | v4.2.3+g43e8b7f | kubectl v1.36.3
+>> [entrypoint] provider cache: /opt/tofu-plugin-cache
+fatal: invalid reference: 8f347c78fb11039a9737c30e956fa16e5f57cd78
+upgrade failed: worktree add 8f347c78fb11039a9737c30e956fa16e5f57cd78 (8f347c78fb11039a9737c30e956fa16e5f57cd78): exit status 128

--- a/live/tests/harness/testdata/evidence/noise-only.log
+++ b/live/tests/harness/testdata/evidence/noise-only.log
@@ -1,0 +1,97 @@
+[0;90m01:18:26.723[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.vpc[0].aws_internet_gateway.this[0]: Still destroying... [id=igw-0611aa19bbe91699b, 20s elapsed][0m[0m[0m
+[0;90m01:18:28.064[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.bi_aurora[0].aws_rds_cluster_instance.this["writer"]: Still destroying... [id=smokef9b3-bi-bi-writer, 1m30s elapsed][0m[0m[0m
+[0;90m01:18:28.456[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1maws_route53_zone.vault_private: Still destroying... [id=Z09762332S9H9AP59BM6P, 1m10s elapsed][0m[0m[0m
+[0;90m01:18:29.721[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1maws_rds_cluster.dr_aurora_secondary[0]: Still destroying... [id=smokef9b3-bi-dr, 1m20s elapsed][0m[0m[0m
+[0;90m01:18:31.008[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1maws_vpc_endpoint.vault: Still destroying... [id=vpce-02e02f38c9bacdf5c, 1m0s elapsed][0m[0m[0m
+[0;90m01:18:31.196[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.eks_cluster.aws_eks_cluster.this[0]: Still destroying... [id=smokef9b3-bi, 1m0s elapsed][0m[0m[0m
+[0;90m01:18:36.723[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.vpc[0].aws_internet_gateway.this[0]: Still destroying... [id=igw-0611aa19bbe91699b, 30s elapsed][0m[0m[0m
+[0;90m01:18:38.064[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.bi_aurora[0].aws_rds_cluster_instance.this["writer"]: Still destroying... [id=smokef9b3-bi-bi-writer, 1m40s elapsed][0m[0m[0m
+[0;90m01:18:38.457[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1maws_route53_zone.vault_private: Still destroying... [id=Z09762332S9H9AP59BM6P, 1m20s elapsed][0m[0m[0m
+[0;90m01:18:39.722[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1maws_rds_cluster.dr_aurora_secondary[0]: Still destroying... [id=smokef9b3-bi-dr, 1m30s elapsed][0m[0m[0m
+[0;90m01:18:41.010[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1maws_vpc_endpoint.vault: Still destroying... [id=vpce-02e02f38c9bacdf5c, 1m10s elapsed][0m[0m[0m
+[0;90m01:18:41.196[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.eks_cluster.aws_eks_cluster.this[0]: Still destroying... [id=smokef9b3-bi, 1m10s elapsed][0m[0m[0m
+[0;90m01:18:46.724[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.vpc[0].aws_internet_gateway.this[0]: Still destroying... [id=igw-0611aa19bbe91699b, 40s elapsed][0m[0m[0m
+[0;90m01:18:48.065[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.bi_aurora[0].aws_rds_cluster_instance.this["writer"]: Still destroying... [id=smokef9b3-bi-bi-writer, 1m50s elapsed][0m[0m[0m
+[0;90m01:18:48.457[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1maws_route53_zone.vault_private: Still destroying... [id=Z09762332S9H9AP59BM6P, 1m30s elapsed][0m[0m[0m
+[0;90m01:18:48.714[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1maws_route53_zone.vault_private: Destruction complete after 1m31s[0m[0m
+[0;90m01:18:49.723[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1maws_rds_cluster.dr_aurora_secondary[0]: Still destroying... [id=smokef9b3-bi-dr, 1m40s elapsed][0m[0m[0m
+[0;90m01:18:51.011[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1maws_vpc_endpoint.vault: Still destroying... [id=vpce-02e02f38c9bacdf5c, 1m20s elapsed][0m[0m[0m
+[0;90m01:18:51.197[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.eks_cluster.aws_eks_cluster.this[0]: Still destroying... [id=smokef9b3-bi, 1m20s elapsed][0m[0m[0m
+[0;90m01:18:51.567[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1maws_vpc_endpoint.vault: Destruction complete after 1m21s[0m[0m
+[0;90m01:18:51.569[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1maws_security_group.vault_endpoint: Destroying... [id=sg-0edab5540abc08351][0m[0m[0m
+[0;90m01:18:52.178[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1maws_security_group.vault_endpoint: Destruction complete after 0s[0m[0m
+[0;90m01:18:56.725[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.vpc[0].aws_internet_gateway.this[0]: Still destroying... [id=igw-0611aa19bbe91699b, 50s elapsed][0m[0m[0m
+[0;90m01:18:58.065[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.bi_aurora[0].aws_rds_cluster_instance.this["writer"]: Still destroying... [id=smokef9b3-bi-bi-writer, 2m0s elapsed][0m[0m[0m
+[0;90m01:18:58.301[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.vpc[0].aws_internet_gateway.this[0]: Destruction complete after 51s[0m[0m
+[0;90m01:18:59.723[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1maws_rds_cluster.dr_aurora_secondary[0]: Still destroying... [id=smokef9b3-bi-dr, 1m50s elapsed][0m[0m[0m
+[0;90m01:19:01.197[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.eks_cluster.aws_eks_cluster.this[0]: Still destroying... [id=smokef9b3-bi, 1m30s elapsed][0m[0m[0m
+[0;90m01:19:08.066[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.bi_aurora[0].aws_rds_cluster_instance.this["writer"]: Still destroying... [id=smokef9b3-bi-bi-writer, 2m10s elapsed][0m[0m[0m
+[0;90m01:19:09.729[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1maws_rds_cluster.dr_aurora_secondary[0]: Still destroying... [id=smokef9b3-bi-dr, 2m0s elapsed][0m[0m[0m
+[0;90m01:19:11.197[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.eks_cluster.aws_eks_cluster.this[0]: Still destroying... [id=smokef9b3-bi, 1m40s elapsed][0m[0m[0m
+[0;90m01:19:12.644[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1maws_rds_cluster.dr_aurora_secondary[0]: Destruction complete after 2m3s[0m[0m
+[0;90m01:19:12.788[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1maws_rds_global_cluster.aurora[0]: Destroying... [id=smokef9b3-bi-global][0m[0m[0m
+[0;90m01:19:12.789[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1maws_kms_key.dr_aurora[0]: Destroying... [id=6f9be8e5-3dae-4a17-b43d-e5a96a216b45][0m[0m[0m
+[0;90m01:19:12.792[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1maws_cloudwatch_log_group.dr_aurora["general"]: Destroying... [id=/aws/rds/cluster/smokef9b3-bi-dr/general][0m[0m[0m
+[0;90m01:19:12.793[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1maws_db_subnet_group.dr_aurora[0]: Destroying... [id=smokef9b3-bi-dr-aurora-e08355a639e8ac1b609b6c90b3][0m[0m[0m
+[0;90m01:19:12.793[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1maws_cloudwatch_log_group.dr_aurora["error"]: Destroying... [id=/aws/rds/cluster/smokef9b3-bi-dr/error][0m[0m[0m
+[0;90m01:19:12.793[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1maws_cloudwatch_log_group.dr_aurora["audit"]: Destroying... [id=/aws/rds/cluster/smokef9b3-bi-dr/audit][0m[0m[0m
+[0;90m01:19:12.798[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1maws_security_group.dr_aurora[0]: Destroying... [id=sg-01272e9ef7f9545c2][0m[0m[0m
+[0;90m01:19:12.800[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.aurora[0].aws_rds_cluster_instance.this["reader"]: Destroying... [id=smokef9b3-bi-reader][0m[0m[0m
+[0;90m01:19:13.074[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1maws_db_subnet_group.dr_aurora[0]: Destruction complete after 0s[0m[0m
+[0;90m01:19:13.077[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.aurora[0].aws_rds_cluster_instance.this["writer"]: Destroying... [id=smokef9b3-bi-writer][0m[0m[0m
+[0;90m01:19:13.113[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1maws_kms_key.dr_aurora[0]: Destruction complete after 0s[0m[0m
+[0;90m01:19:13.115[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1maws_cloudwatch_log_group.dr_aurora["slowquery"]: Destroying... [id=/aws/rds/cluster/smokef9b3-bi-dr/slowquery][0m[0m[0m
+[0;90m01:19:13.135[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1maws_cloudwatch_log_group.dr_aurora["audit"]: Destruction complete after 0s[0m[0m
+[0;90m01:19:13.139[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1maws_subnet.dr_aurora["us-west-2a"]: Destroying... [id=subnet-023c67e6abd6d6e6e][0m[0m[0m
+[0;90m01:19:13.157[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1maws_cloudwatch_log_group.dr_aurora["general"]: Destruction complete after 0s[0m[0m
+[0;90m01:19:13.160[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1maws_subnet.dr_aurora["us-west-2c"]: Destroying... [id=subnet-034c58b2eeed76dd2][0m[0m[0m
+[0;90m01:19:13.212[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1maws_cloudwatch_log_group.dr_aurora["error"]: Destruction complete after 0s[0m[0m
+[0;90m01:19:13.216[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1maws_subnet.dr_aurora["us-west-2b"]: Destroying... [id=subnet-0d400e2792fffe89e][0m[0m[0m
+[0;90m01:19:13.249[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1maws_cloudwatch_log_group.dr_aurora["slowquery"]: Destruction complete after 0s[0m[0m
+[0;90m01:19:13.701[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1maws_security_group.dr_aurora[0]: Destruction complete after 1s[0m[0m
+[0;90m01:19:13.945[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1maws_subnet.dr_aurora["us-west-2c"]: Destruction complete after 1s[0m[0m
+[0;90m01:19:13.985[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1maws_subnet.dr_aurora["us-west-2a"]: Destruction complete after 1s[0m[0m
+[0;90m01:19:14.034[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1maws_rds_global_cluster.aurora[0]: Destruction complete after 1s[0m[0m
+[0;90m01:19:14.067[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1maws_subnet.dr_aurora["us-west-2b"]: Destruction complete after 1s[0m[0m
+[0;90m01:19:14.070[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1maws_vpc.dr_aurora[0]: Destroying... [id=vpc-046c0e3d4627616d2][0m[0m[0m
+[0;90m01:19:14.724[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1maws_vpc.dr_aurora[0]: Destruction complete after 1s[0m[0m
+[0;90m01:19:18.066[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.bi_aurora[0].aws_rds_cluster_instance.this["writer"]: Still destroying... [id=smokef9b3-bi-bi-writer, 2m20s elapsed][0m[0m[0m
+[0;90m01:19:21.198[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.eks_cluster.aws_eks_cluster.this[0]: Still destroying... [id=smokef9b3-bi, 1m50s elapsed][0m[0m[0m
+[0;90m01:19:22.801[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.aurora[0].aws_rds_cluster_instance.this["reader"]: Still destroying... [id=smokef9b3-bi-reader, 10s elapsed][0m[0m[0m
+[0;90m01:19:23.078[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.aurora[0].aws_rds_cluster_instance.this["writer"]: Still destroying... [id=smokef9b3-bi-writer, 10s elapsed][0m[0m[0m
+[0;90m01:19:28.069[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.bi_aurora[0].aws_rds_cluster_instance.this["writer"]: Still destroying... [id=smokef9b3-bi-bi-writer, 2m30s elapsed][0m[0m[0m
+[0;90m01:19:31.198[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.eks_cluster.aws_eks_cluster.this[0]: Still destroying... [id=smokef9b3-bi, 2m0s elapsed][0m[0m[0m
+[0;90m01:19:32.802[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.aurora[0].aws_rds_cluster_instance.this["reader"]: Still destroying... [id=smokef9b3-bi-reader, 20s elapsed][0m[0m[0m
+[0;90m01:19:33.079[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.aurora[0].aws_rds_cluster_instance.this["writer"]: Still destroying... [id=smokef9b3-bi-writer, 20s elapsed][0m[0m[0m
+[0;90m01:19:38.072[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.bi_aurora[0].aws_rds_cluster_instance.this["writer"]: Still destroying... [id=smokef9b3-bi-bi-writer, 2m40s elapsed][0m[0m[0m
+[0;90m01:19:41.200[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.eks_cluster.aws_eks_cluster.this[0]: Still destroying... [id=smokef9b3-bi, 2m10s elapsed][0m[0m[0m
+[0;90m01:19:42.803[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.aurora[0].aws_rds_cluster_instance.this["reader"]: Still destroying... [id=smokef9b3-bi-reader, 30s elapsed][0m[0m[0m
+[0;90m01:19:43.080[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.aurora[0].aws_rds_cluster_instance.this["writer"]: Still destroying... [id=smokef9b3-bi-writer, 30s elapsed][0m[0m[0m
+[0;90m01:19:48.075[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.bi_aurora[0].aws_rds_cluster_instance.this["writer"]: Still destroying... [id=smokef9b3-bi-bi-writer, 2m50s elapsed][0m[0m[0m
+[0;90m01:19:51.200[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.eks_cluster.aws_eks_cluster.this[0]: Still destroying... [id=smokef9b3-bi, 2m20s elapsed][0m[0m[0m
+[0;90m01:19:52.804[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.aurora[0].aws_rds_cluster_instance.this["reader"]: Still destroying... [id=smokef9b3-bi-reader, 40s elapsed][0m[0m[0m
+[0;90m01:19:53.081[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.aurora[0].aws_rds_cluster_instance.this["writer"]: Still destroying... [id=smokef9b3-bi-writer, 40s elapsed][0m[0m[0m
+[0;90m01:19:58.075[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.bi_aurora[0].aws_rds_cluster_instance.this["writer"]: Still destroying... [id=smokef9b3-bi-bi-writer, 3m0s elapsed][0m[0m[0m
+[0;90m01:20:01.200[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.eks_cluster.aws_eks_cluster.this[0]: Still destroying... [id=smokef9b3-bi, 2m30s elapsed][0m[0m[0m
+[0;90m01:20:02.805[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.aurora[0].aws_rds_cluster_instance.this["reader"]: Still destroying... [id=smokef9b3-bi-reader, 50s elapsed][0m[0m[0m
+[0;90m01:20:03.081[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.aurora[0].aws_rds_cluster_instance.this["writer"]: Still destroying... [id=smokef9b3-bi-writer, 50s elapsed][0m[0m[0m
+[0;90m01:20:08.076[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.bi_aurora[0].aws_rds_cluster_instance.this["writer"]: Still destroying... [id=smokef9b3-bi-bi-writer, 3m10s elapsed][0m[0m[0m
+[0;90m01:20:11.200[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.eks_cluster.aws_eks_cluster.this[0]: Still destroying... [id=smokef9b3-bi, 2m40s elapsed][0m[0m[0m
+[0;90m01:20:12.805[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.aurora[0].aws_rds_cluster_instance.this["reader"]: Still destroying... [id=smokef9b3-bi-reader, 1m0s elapsed][0m[0m[0m
+[0;90m01:20:13.082[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.aurora[0].aws_rds_cluster_instance.this["writer"]: Still destroying... [id=smokef9b3-bi-writer, 1m0s elapsed][0m[0m[0m
+[0;90m01:20:18.076[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.bi_aurora[0].aws_rds_cluster_instance.this["writer"]: Still destroying... [id=smokef9b3-bi-bi-writer, 3m20s elapsed][0m[0m[0m
+[0;90m01:20:21.201[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.eks_cluster.aws_eks_cluster.this[0]: Still destroying... [id=smokef9b3-bi, 2m50s elapsed][0m[0m[0m
+[0;90m01:20:22.806[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.aurora[0].aws_rds_cluster_instance.this["reader"]: Still destroying... [id=smokef9b3-bi-reader, 1m10s elapsed][0m[0m[0m
+[0;90m01:20:23.082[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.aurora[0].aws_rds_cluster_instance.this["writer"]: Still destroying... [id=smokef9b3-bi-writer, 1m10s elapsed][0m[0m[0m
+[0;90m01:20:28.076[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.bi_aurora[0].aws_rds_cluster_instance.this["writer"]: Still destroying... [id=smokef9b3-bi-bi-writer, 3m30s elapsed][0m[0m[0m
+[0;90m01:20:31.202[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.eks_cluster.aws_eks_cluster.this[0]: Still destroying... [id=smokef9b3-bi, 3m0s elapsed][0m[0m[0m
+[0;90m01:20:32.806[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.aurora[0].aws_rds_cluster_instance.this["reader"]: Still destroying... [id=smokef9b3-bi-reader, 1m20s elapsed][0m[0m[0m
+[0;90m01:20:33.083[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.aurora[0].aws_rds_cluster_instance.this["writer"]: Still destroying... [id=smokef9b3-bi-writer, 1m20s elapsed][0m[0m[0m
+[0;90m01:20:38.076[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.bi_aurora[0].aws_rds_cluster_instance.this["writer"]: Still destroying... [id=smokef9b3-bi-bi-writer, 3m40s elapsed][0m[0m[0m
+[0;90m01:20:41.202[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.eks_cluster.aws_eks_cluster.this[0]: Still destroying... [id=smokef9b3-bi, 3m10s elapsed][0m[0m[0m
+[0;90m01:20:42.807[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.aurora[0].aws_rds_cluster_instance.this["reader"]: Still destroying... [id=smokef9b3-bi-reader, 1m30s elapsed][0m[0m[0m
+[0;90m01:20:43.084[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.aurora[0].aws_rds_cluster_instance.this["writer"]: Still destroying... [id=smokef9b3-bi-writer, 1m30s elapsed][0m[0m[0m
+[0;90m01:20:48.076[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.bi_aurora[0].aws_rds_cluster_instance.this["writer"]: Still destroying... [id=smokef9b3-bi-bi-writer, 3m50s elapsed][0m[0m[0m
+[0;90m01:20:51.203[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.eks_cluster.aws_eks_cluster.this[0]: Still destroying... [id=smokef9b3-bi, 3m20s elapsed][0m[0m[0m
+[0;90m01:20:52.807[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.aurora[0].aws_rds_cluster_instance.this["reader"]: Still destroying... [id=smokef9b3-bi-reader, 1m40s elapsed][0m[0m[0m
+[0;90m01:20:53.084[0m [0;37mSTDOUT[0m [0;36mtofu: [0m[0m[1mmodule.aurora[0].aws_rds_cluster_instance.this["writer"]: Still destroying... [id=smokef9b3-bi-writer, 1m40s elapsed][0m[0m[0m

--- a/live/tests/harness/testdata/evidence/workflows-list.json
+++ b/live/tests/harness/testdata/evidence/workflows-list.json
@@ -1,0 +1,1240 @@
+{
+  "apiVersion": "v1",
+  "kind": "List",
+  "items": [
+    {
+      "metadata": {
+        "name": "harness-bi-ha-8dps9",
+        "labels": {
+          "harness/config": "bi_ha",
+          "harness/parent": "harness-pr440-fkm85",
+          "harness/scenario": "upgrade",
+          "workflows.argoproj.io/completed": "true",
+          "workflows.argoproj.io/phase": "Failed"
+        }
+      },
+      "status": {
+        "phase": "Failed",
+        "message": "child 'harness-bi-ha-8dps9-3308889610' failed",
+        "artifactRepositoryRef": {
+          "artifactRepository": {
+            "s3": {
+              "bucket": "dozuki-argo-artifacts-010601635461",
+              "endpoint": "s3.amazonaws.com",
+              "region": "us-east-1",
+              "useSDKCreds": true
+            }
+          },
+          "default": true
+        },
+        "nodes": {
+          "harness-bi-ha-8dps9": {
+            "children": [
+              "harness-bi-ha-8dps9-4095453574"
+            ],
+            "displayName": "harness-bi-ha-8dps9",
+            "finishedAt": "2026-08-04T01:07:38Z",
+            "id": "harness-bi-ha-8dps9",
+            "message": "child 'harness-bi-ha-8dps9-3308889610' failed",
+            "name": "harness-bi-ha-8dps9",
+            "outboundNodes": [
+              "harness-bi-ha-8dps9-3742410289"
+            ],
+            "phase": "Failed",
+            "progress": "2/3",
+            "resourcesDuration": {
+              "cpu": 2114,
+              "memory": 80651
+            },
+            "startedAt": "2026-08-04T00:33:48Z",
+            "templateName": "scenario",
+            "templateScope": "local/",
+            "type": "Steps"
+          },
+          "harness-bi-ha-8dps9-1058228422": {
+            "boundaryID": "harness-bi-ha-8dps9",
+            "children": [
+              "harness-bi-ha-8dps9-2572215237"
+            ],
+            "displayName": "provision",
+            "finishedAt": "2026-08-04T01:06:38Z",
+            "id": "harness-bi-ha-8dps9-1058228422",
+            "inputs": {
+              "parameters": [
+                {
+                  "name": "phase",
+                  "value": "provision"
+                },
+                {
+                  "name": "run-id",
+                  "value": "harness-bi-ha-8dps9"
+                },
+                {
+                  "name": "config",
+                  "value": "bi_ha"
+                },
+                {
+                  "name": "extra-args",
+                  "value": "--scenario upgrade --from-ref auto:latest --to-ref 8f347c78fb11039a9737c30e956fa16e5f57cd78"
+                },
+                {
+                  "name": "repo-ref",
+                  "value": "master"
+                },
+                {
+                  "name": "deadline",
+                  "value": "5400"
+                },
+                {
+                  "name": "keep-on-failure",
+                  "value": "false"
+                },
+                {
+                  "name": "workflow-status",
+                  "value": ""
+                }
+              ]
+            },
+            "name": "harness-bi-ha-8dps9[1].provision",
+            "outputs": {
+              "artifacts": [
+                {
+                  "name": "main-logs",
+                  "s3": {
+                    "key": "harness-bi-ha-8dps9/harness-bi-ha-8dps9-run-2572215237/main.log"
+                  }
+                }
+              ],
+              "exitCode": "0"
+            },
+            "phase": "Succeeded",
+            "progress": "1/2",
+            "resourcesDuration": {
+              "cpu": 2114,
+              "memory": 80649
+            },
+            "startedAt": "2026-08-04T00:34:08Z",
+            "templateRef": {
+              "name": "harness-phase",
+              "template": "run"
+            },
+            "templateScope": "local/",
+            "type": "Retry"
+          },
+          "harness-bi-ha-8dps9-1404467215": {
+            "boundaryID": "harness-bi-ha-8dps9-2319326335",
+            "children": [
+              "harness-bi-ha-8dps9-945485330"
+            ],
+            "displayName": "destroy",
+            "finishedAt": "2026-08-04T01:30:34Z",
+            "id": "harness-bi-ha-8dps9-1404467215",
+            "inputs": {
+              "parameters": [
+                {
+                  "name": "phase",
+                  "value": "teardown"
+                },
+                {
+                  "name": "run-id",
+                  "value": "harness-bi-ha-8dps9"
+                },
+                {
+                  "name": "config",
+                  "value": "bi_ha"
+                },
+                {
+                  "name": "extra-args",
+                  "value": ""
+                },
+                {
+                  "name": "repo-ref",
+                  "value": "master"
+                },
+                {
+                  "name": "deadline",
+                  "value": "10800"
+                },
+                {
+                  "name": "keep-on-failure",
+                  "value": "false"
+                },
+                {
+                  "name": "workflow-status",
+                  "value": "Failed"
+                }
+              ]
+            },
+            "message": "Max duration limit exceeded",
+            "name": "harness-bi-ha-8dps9.onExit[0].destroy",
+            "outputs": {
+              "artifacts": [
+                {
+                  "name": "main-logs",
+                  "s3": {
+                    "key": "harness-bi-ha-8dps9/harness-bi-ha-8dps9-run-945485330/main.log"
+                  }
+                }
+              ],
+              "exitCode": "1"
+            },
+            "phase": "Failed",
+            "progress": "0/1",
+            "resourcesDuration": {
+              "cpu": 1488,
+              "memory": 56772
+            },
+            "startedAt": "2026-08-04T01:07:38Z",
+            "templateRef": {
+              "name": "harness-phase",
+              "template": "run"
+            },
+            "templateScope": "local/",
+            "type": "Retry"
+          },
+          "harness-bi-ha-8dps9-2319326335": {
+            "children": [
+              "harness-bi-ha-8dps9-3272611691"
+            ],
+            "displayName": "harness-bi-ha-8dps9.onExit",
+            "finishedAt": "2026-08-04T01:30:34Z",
+            "id": "harness-bi-ha-8dps9-2319326335",
+            "message": "child 'harness-bi-ha-8dps9-1404467215' failed",
+            "name": "harness-bi-ha-8dps9.onExit",
+            "nodeFlag": {
+              "hooked": true
+            },
+            "outboundNodes": [
+              "harness-bi-ha-8dps9-945485330"
+            ],
+            "phase": "Failed",
+            "progress": "0/1",
+            "resourcesDuration": {
+              "cpu": 1488,
+              "memory": 56772
+            },
+            "startedAt": "2026-08-04T01:07:38Z",
+            "templateName": "teardown",
+            "templateScope": "local/",
+            "type": "Steps"
+          },
+          "harness-bi-ha-8dps9-2572215237": {
+            "boundaryID": "harness-bi-ha-8dps9",
+            "children": [
+              "harness-bi-ha-8dps9-4028740456"
+            ],
+            "displayName": "provision(0)",
+            "finishedAt": "2026-08-04T01:06:29Z",
+            "hostNodeName": "i-03cfe00b9dd900ec1",
+            "id": "harness-bi-ha-8dps9-2572215237",
+            "inputs": {
+              "parameters": [
+                {
+                  "name": "phase",
+                  "value": "provision"
+                },
+                {
+                  "name": "run-id",
+                  "value": "harness-bi-ha-8dps9"
+                },
+                {
+                  "name": "config",
+                  "value": "bi_ha"
+                },
+                {
+                  "name": "extra-args",
+                  "value": "--scenario upgrade --from-ref auto:latest --to-ref 8f347c78fb11039a9737c30e956fa16e5f57cd78"
+                },
+                {
+                  "name": "repo-ref",
+                  "value": "master"
+                },
+                {
+                  "name": "deadline",
+                  "value": "5400"
+                },
+                {
+                  "name": "keep-on-failure",
+                  "value": "false"
+                },
+                {
+                  "name": "workflow-status",
+                  "value": ""
+                }
+              ]
+            },
+            "name": "harness-bi-ha-8dps9[1].provision(0)",
+            "nodeFlag": {
+              "retried": true
+            },
+            "outputs": {
+              "artifacts": [
+                {
+                  "name": "main-logs",
+                  "s3": {
+                    "key": "harness-bi-ha-8dps9/harness-bi-ha-8dps9-run-2572215237/main.log"
+                  }
+                }
+              ],
+              "exitCode": "0"
+            },
+            "phase": "Succeeded",
+            "progress": "1/1",
+            "resourcesDuration": {
+              "cpu": 2110,
+              "memory": 80481
+            },
+            "startedAt": "2026-08-04T00:34:08Z",
+            "taskResultSynced": true,
+            "templateRef": {
+              "name": "harness-phase",
+              "template": "run"
+            },
+            "templateScope": "local/",
+            "type": "Pod"
+          },
+          "harness-bi-ha-8dps9-2875709487": {
+            "boundaryID": "harness-bi-ha-8dps9",
+            "children": [
+              "harness-bi-ha-8dps9-4028196003"
+            ],
+            "displayName": "gate",
+            "finishedAt": "2026-08-04T00:33:59Z",
+            "hostNodeName": "i-03cfe00b9dd900ec1",
+            "id": "harness-bi-ha-8dps9-2875709487",
+            "name": "harness-bi-ha-8dps9[0].gate",
+            "outputs": {
+              "exitCode": "0",
+              "result": "run"
+            },
+            "phase": "Succeeded",
+            "progress": "1/1",
+            "resourcesDuration": {
+              "cpu": 0,
+              "memory": 2
+            },
+            "startedAt": "2026-08-04T00:33:48Z",
+            "taskResultSynced": true,
+            "templateName": "staleness-gate",
+            "templateScope": "local/",
+            "type": "Pod"
+          },
+          "harness-bi-ha-8dps9-3272611691": {
+            "boundaryID": "harness-bi-ha-8dps9-2319326335",
+            "children": [
+              "harness-bi-ha-8dps9-1404467215"
+            ],
+            "displayName": "[0]",
+            "finishedAt": "2026-08-04T01:30:34Z",
+            "id": "harness-bi-ha-8dps9-3272611691",
+            "message": "child 'harness-bi-ha-8dps9-1404467215' failed",
+            "name": "harness-bi-ha-8dps9.onExit[0]",
+            "nodeFlag": {},
+            "phase": "Failed",
+            "progress": "0/1",
+            "resourcesDuration": {
+              "cpu": 1488,
+              "memory": 56772
+            },
+            "startedAt": "2026-08-04T01:07:38Z",
+            "templateScope": "local/",
+            "type": "StepGroup"
+          },
+          "harness-bi-ha-8dps9-3308889610": {
+            "boundaryID": "harness-bi-ha-8dps9",
+            "children": [
+              "harness-bi-ha-8dps9-3742410289"
+            ],
+            "displayName": "upgrade",
+            "finishedAt": "2026-08-04T01:07:38Z",
+            "id": "harness-bi-ha-8dps9-3308889610",
+            "inputs": {
+              "parameters": [
+                {
+                  "name": "phase",
+                  "value": "upgrade"
+                },
+                {
+                  "name": "run-id",
+                  "value": "harness-bi-ha-8dps9"
+                },
+                {
+                  "name": "config",
+                  "value": "bi_ha"
+                },
+                {
+                  "name": "extra-args",
+                  "value": ""
+                },
+                {
+                  "name": "repo-ref",
+                  "value": "master"
+                },
+                {
+                  "name": "deadline",
+                  "value": "5400"
+                },
+                {
+                  "name": "keep-on-failure",
+                  "value": "false"
+                },
+                {
+                  "name": "workflow-status",
+                  "value": ""
+                }
+              ]
+            },
+            "message": "main: Error (exit code 1)",
+            "name": "harness-bi-ha-8dps9[2].upgrade",
+            "outputs": {
+              "artifacts": [
+                {
+                  "name": "main-logs",
+                  "s3": {
+                    "key": "harness-bi-ha-8dps9/harness-bi-ha-8dps9-run-3742410289/main.log"
+                  }
+                }
+              ],
+              "exitCode": "1"
+            },
+            "phase": "Failed",
+            "progress": "0/1",
+            "resourcesDuration": {
+              "cpu": 4,
+              "memory": 168
+            },
+            "startedAt": "2026-08-04T01:06:38Z",
+            "templateRef": {
+              "name": "harness-phase",
+              "template": "run"
+            },
+            "templateScope": "local/",
+            "type": "Retry"
+          },
+          "harness-bi-ha-8dps9-3742410289": {
+            "boundaryID": "harness-bi-ha-8dps9",
+            "displayName": "upgrade(0)",
+            "finishedAt": "2026-08-04T01:06:53Z",
+            "hostNodeName": "i-03cfe00b9dd900ec1",
+            "id": "harness-bi-ha-8dps9-3742410289",
+            "inputs": {
+              "parameters": [
+                {
+                  "name": "phase",
+                  "value": "upgrade"
+                },
+                {
+                  "name": "run-id",
+                  "value": "harness-bi-ha-8dps9"
+                },
+                {
+                  "name": "config",
+                  "value": "bi_ha"
+                },
+                {
+                  "name": "extra-args",
+                  "value": ""
+                },
+                {
+                  "name": "repo-ref",
+                  "value": "master"
+                },
+                {
+                  "name": "deadline",
+                  "value": "5400"
+                },
+                {
+                  "name": "keep-on-failure",
+                  "value": "false"
+                },
+                {
+                  "name": "workflow-status",
+                  "value": ""
+                }
+              ]
+            },
+            "message": "main: Error (exit code 1)",
+            "name": "harness-bi-ha-8dps9[2].upgrade(0)",
+            "nodeFlag": {
+              "retried": true
+            },
+            "outputs": {
+              "artifacts": [
+                {
+                  "name": "main-logs",
+                  "s3": {
+                    "key": "harness-bi-ha-8dps9/harness-bi-ha-8dps9-run-3742410289/main.log"
+                  }
+                }
+              ],
+              "exitCode": "1"
+            },
+            "phase": "Failed",
+            "progress": "0/1",
+            "resourcesDuration": {
+              "cpu": 4,
+              "memory": 168
+            },
+            "startedAt": "2026-08-04T01:06:38Z",
+            "taskResultSynced": true,
+            "templateRef": {
+              "name": "harness-phase",
+              "template": "run"
+            },
+            "templateScope": "local/",
+            "type": "Pod"
+          },
+          "harness-bi-ha-8dps9-4028196003": {
+            "boundaryID": "harness-bi-ha-8dps9",
+            "children": [
+              "harness-bi-ha-8dps9-1058228422"
+            ],
+            "displayName": "[1]",
+            "finishedAt": "2026-08-04T01:06:38Z",
+            "id": "harness-bi-ha-8dps9-4028196003",
+            "name": "harness-bi-ha-8dps9[1]",
+            "nodeFlag": {},
+            "phase": "Succeeded",
+            "progress": "1/2",
+            "resourcesDuration": {
+              "cpu": 2114,
+              "memory": 80649
+            },
+            "startedAt": "2026-08-04T00:34:08Z",
+            "templateScope": "local/",
+            "type": "StepGroup"
+          },
+          "harness-bi-ha-8dps9-4028740456": {
+            "boundaryID": "harness-bi-ha-8dps9",
+            "children": [
+              "harness-bi-ha-8dps9-3308889610"
+            ],
+            "displayName": "[2]",
+            "finishedAt": "2026-08-04T01:07:38Z",
+            "id": "harness-bi-ha-8dps9-4028740456",
+            "message": "child 'harness-bi-ha-8dps9-3308889610' failed",
+            "name": "harness-bi-ha-8dps9[2]",
+            "nodeFlag": {},
+            "phase": "Failed",
+            "progress": "0/1",
+            "resourcesDuration": {
+              "cpu": 4,
+              "memory": 168
+            },
+            "startedAt": "2026-08-04T01:06:38Z",
+            "templateScope": "local/",
+            "type": "StepGroup"
+          },
+          "harness-bi-ha-8dps9-4095453574": {
+            "boundaryID": "harness-bi-ha-8dps9",
+            "children": [
+              "harness-bi-ha-8dps9-2875709487"
+            ],
+            "displayName": "[0]",
+            "finishedAt": "2026-08-04T00:34:08Z",
+            "id": "harness-bi-ha-8dps9-4095453574",
+            "name": "harness-bi-ha-8dps9[0]",
+            "nodeFlag": {},
+            "phase": "Succeeded",
+            "progress": "2/3",
+            "resourcesDuration": {
+              "cpu": 2114,
+              "memory": 80651
+            },
+            "startedAt": "2026-08-04T00:33:48Z",
+            "templateScope": "local/",
+            "type": "StepGroup"
+          },
+          "harness-bi-ha-8dps9-945485330": {
+            "boundaryID": "harness-bi-ha-8dps9-2319326335",
+            "displayName": "destroy(0)",
+            "finishedAt": "2026-08-04T01:30:24Z",
+            "hostNodeName": "i-03cfe00b9dd900ec1",
+            "id": "harness-bi-ha-8dps9-945485330",
+            "inputs": {
+              "parameters": [
+                {
+                  "name": "phase",
+                  "value": "teardown"
+                },
+                {
+                  "name": "run-id",
+                  "value": "harness-bi-ha-8dps9"
+                },
+                {
+                  "name": "config",
+                  "value": "bi_ha"
+                },
+                {
+                  "name": "extra-args",
+                  "value": ""
+                },
+                {
+                  "name": "repo-ref",
+                  "value": "master"
+                },
+                {
+                  "name": "deadline",
+                  "value": "10800"
+                },
+                {
+                  "name": "keep-on-failure",
+                  "value": "false"
+                },
+                {
+                  "name": "workflow-status",
+                  "value": "Failed"
+                }
+              ]
+            },
+            "message": "main: Error (exit code 1)",
+            "name": "harness-bi-ha-8dps9.onExit[0].destroy(0)",
+            "nodeFlag": {
+              "retried": true
+            },
+            "outputs": {
+              "artifacts": [
+                {
+                  "name": "main-logs",
+                  "s3": {
+                    "key": "harness-bi-ha-8dps9/harness-bi-ha-8dps9-run-945485330/main.log"
+                  }
+                }
+              ],
+              "exitCode": "1"
+            },
+            "phase": "Failed",
+            "progress": "0/1",
+            "resourcesDuration": {
+              "cpu": 1488,
+              "memory": 56772
+            },
+            "startedAt": "2026-08-04T01:07:38Z",
+            "taskResultSynced": true,
+            "templateRef": {
+              "name": "harness-phase",
+              "template": "run"
+            },
+            "templateScope": "local/",
+            "type": "Pod"
+          }
+        }
+      }
+    },
+    {
+      "metadata": {
+        "name": "harness-min-default-mdgxp",
+        "labels": {
+          "harness/config": "min_default",
+          "harness/parent": "harness-pr440-fkm85",
+          "harness/scenario": "upgrade",
+          "workflows.argoproj.io/completed": "true",
+          "workflows.argoproj.io/phase": "Failed"
+        }
+      },
+      "status": {
+        "phase": "Failed",
+        "message": "child 'harness-min-default-mdgxp-1377804381' failed",
+        "artifactRepositoryRef": {
+          "artifactRepository": {
+            "s3": {
+              "bucket": "dozuki-argo-artifacts-010601635461",
+              "endpoint": "s3.amazonaws.com",
+              "region": "us-east-1",
+              "useSDKCreds": true
+            }
+          },
+          "default": true
+        },
+        "nodes": {
+          "harness-min-default-mdgxp": {
+            "children": [
+              "harness-min-default-mdgxp-1618521269"
+            ],
+            "displayName": "harness-min-default-mdgxp",
+            "finishedAt": "2026-08-04T00:46:20Z",
+            "id": "harness-min-default-mdgxp",
+            "message": "child 'harness-min-default-mdgxp-1377804381' failed",
+            "name": "harness-min-default-mdgxp",
+            "outboundNodes": [
+              "harness-min-default-mdgxp-1651265260"
+            ],
+            "phase": "Failed",
+            "progress": "2/3",
+            "resourcesDuration": {
+              "cpu": 1790,
+              "memory": 68315
+            },
+            "startedAt": "2026-08-04T00:17:20Z",
+            "templateName": "scenario",
+            "templateScope": "local/",
+            "type": "Steps"
+          },
+          "harness-min-default-mdgxp-1068304776": {
+            "children": [
+              "harness-min-default-mdgxp-3724164466"
+            ],
+            "displayName": "harness-min-default-mdgxp.onExit",
+            "finishedAt": "2026-08-04T01:07:13Z",
+            "id": "harness-min-default-mdgxp-1068304776",
+            "name": "harness-min-default-mdgxp.onExit",
+            "nodeFlag": {
+              "hooked": true
+            },
+            "outboundNodes": [
+              "harness-min-default-mdgxp-3396737381"
+            ],
+            "phase": "Succeeded",
+            "progress": "1/1",
+            "resourcesDuration": {
+              "cpu": 1354,
+              "memory": 51655
+            },
+            "startedAt": "2026-08-04T00:46:20Z",
+            "templateName": "teardown",
+            "templateScope": "local/",
+            "type": "Steps"
+          },
+          "harness-min-default-mdgxp-1377804381": {
+            "boundaryID": "harness-min-default-mdgxp",
+            "children": [
+              "harness-min-default-mdgxp-1651265260"
+            ],
+            "displayName": "upgrade",
+            "finishedAt": "2026-08-04T00:46:20Z",
+            "id": "harness-min-default-mdgxp-1377804381",
+            "inputs": {
+              "parameters": [
+                {
+                  "name": "phase",
+                  "value": "upgrade"
+                },
+                {
+                  "name": "run-id",
+                  "value": "harness-min-default-mdgxp"
+                },
+                {
+                  "name": "config",
+                  "value": "min_default"
+                },
+                {
+                  "name": "extra-args",
+                  "value": ""
+                },
+                {
+                  "name": "repo-ref",
+                  "value": "master"
+                },
+                {
+                  "name": "deadline",
+                  "value": "5400"
+                },
+                {
+                  "name": "keep-on-failure",
+                  "value": "false"
+                },
+                {
+                  "name": "workflow-status",
+                  "value": ""
+                }
+              ]
+            },
+            "message": "main: Error (exit code 1)",
+            "name": "harness-min-default-mdgxp[2].upgrade",
+            "outputs": {
+              "artifacts": [
+                {
+                  "name": "main-logs",
+                  "s3": {
+                    "key": "harness-min-default-mdgxp/harness-min-default-mdgxp-run-1651265260/main.log"
+                  }
+                }
+              ],
+              "exitCode": "1"
+            },
+            "phase": "Failed",
+            "progress": "0/1",
+            "resourcesDuration": {
+              "cpu": 4,
+              "memory": 168
+            },
+            "startedAt": "2026-08-04T00:45:10Z",
+            "templateRef": {
+              "name": "harness-phase",
+              "template": "run"
+            },
+            "templateScope": "local/",
+            "type": "Retry"
+          },
+          "harness-min-default-mdgxp-145041638": {
+            "boundaryID": "harness-min-default-mdgxp-1068304776",
+            "children": [
+              "harness-min-default-mdgxp-3396737381"
+            ],
+            "displayName": "destroy",
+            "finishedAt": "2026-08-04T01:07:13Z",
+            "id": "harness-min-default-mdgxp-145041638",
+            "inputs": {
+              "parameters": [
+                {
+                  "name": "phase",
+                  "value": "teardown"
+                },
+                {
+                  "name": "run-id",
+                  "value": "harness-min-default-mdgxp"
+                },
+                {
+                  "name": "config",
+                  "value": "min_default"
+                },
+                {
+                  "name": "extra-args",
+                  "value": ""
+                },
+                {
+                  "name": "repo-ref",
+                  "value": "master"
+                },
+                {
+                  "name": "deadline",
+                  "value": "10800"
+                },
+                {
+                  "name": "keep-on-failure",
+                  "value": "false"
+                },
+                {
+                  "name": "workflow-status",
+                  "value": "Failed"
+                }
+              ]
+            },
+            "name": "harness-min-default-mdgxp.onExit[0].destroy",
+            "outputs": {
+              "artifacts": [
+                {
+                  "name": "main-logs",
+                  "s3": {
+                    "key": "harness-min-default-mdgxp/harness-min-default-mdgxp-run-3396737381/main.log"
+                  }
+                }
+              ],
+              "exitCode": "0"
+            },
+            "phase": "Succeeded",
+            "progress": "1/1",
+            "resourcesDuration": {
+              "cpu": 1354,
+              "memory": 51655
+            },
+            "startedAt": "2026-08-04T00:46:20Z",
+            "templateRef": {
+              "name": "harness-phase",
+              "template": "run"
+            },
+            "templateScope": "local/",
+            "type": "Retry"
+          },
+          "harness-min-default-mdgxp-1551557888": {
+            "boundaryID": "harness-min-default-mdgxp",
+            "children": [
+              "harness-min-default-mdgxp-2472796141"
+            ],
+            "displayName": "[1]",
+            "finishedAt": "2026-08-04T00:45:10Z",
+            "id": "harness-min-default-mdgxp-1551557888",
+            "name": "harness-min-default-mdgxp[1]",
+            "nodeFlag": {},
+            "phase": "Succeeded",
+            "progress": "1/2",
+            "resourcesDuration": {
+              "cpu": 1790,
+              "memory": 68313
+            },
+            "startedAt": "2026-08-04T00:17:40Z",
+            "templateScope": "local/",
+            "type": "StepGroup"
+          },
+          "harness-min-default-mdgxp-1618521269": {
+            "boundaryID": "harness-min-default-mdgxp",
+            "children": [
+              "harness-min-default-mdgxp-2045085062"
+            ],
+            "displayName": "[0]",
+            "finishedAt": "2026-08-04T00:17:40Z",
+            "id": "harness-min-default-mdgxp-1618521269",
+            "name": "harness-min-default-mdgxp[0]",
+            "nodeFlag": {},
+            "phase": "Succeeded",
+            "progress": "2/3",
+            "resourcesDuration": {
+              "cpu": 1790,
+              "memory": 68315
+            },
+            "startedAt": "2026-08-04T00:17:20Z",
+            "templateScope": "local/",
+            "type": "StepGroup"
+          },
+          "harness-min-default-mdgxp-1651265260": {
+            "boundaryID": "harness-min-default-mdgxp",
+            "displayName": "upgrade(0)",
+            "finishedAt": "2026-08-04T00:45:34Z",
+            "hostNodeName": "i-04c9ce08e9cec77cb",
+            "id": "harness-min-default-mdgxp-1651265260",
+            "inputs": {
+              "parameters": [
+                {
+                  "name": "phase",
+                  "value": "upgrade"
+                },
+                {
+                  "name": "run-id",
+                  "value": "harness-min-default-mdgxp"
+                },
+                {
+                  "name": "config",
+                  "value": "min_default"
+                },
+                {
+                  "name": "extra-args",
+                  "value": ""
+                },
+                {
+                  "name": "repo-ref",
+                  "value": "master"
+                },
+                {
+                  "name": "deadline",
+                  "value": "5400"
+                },
+                {
+                  "name": "keep-on-failure",
+                  "value": "false"
+                },
+                {
+                  "name": "workflow-status",
+                  "value": ""
+                }
+              ]
+            },
+            "message": "main: Error (exit code 1)",
+            "name": "harness-min-default-mdgxp[2].upgrade(0)",
+            "nodeFlag": {
+              "retried": true
+            },
+            "outputs": {
+              "artifacts": [
+                {
+                  "name": "main-logs",
+                  "s3": {
+                    "key": "harness-min-default-mdgxp/harness-min-default-mdgxp-run-1651265260/main.log"
+                  }
+                }
+              ],
+              "exitCode": "1"
+            },
+            "phase": "Failed",
+            "progress": "0/1",
+            "resourcesDuration": {
+              "cpu": 4,
+              "memory": 168
+            },
+            "startedAt": "2026-08-04T00:45:10Z",
+            "taskResultSynced": true,
+            "templateRef": {
+              "name": "harness-phase",
+              "template": "run"
+            },
+            "templateScope": "local/",
+            "type": "Pod"
+          },
+          "harness-min-default-mdgxp-2045085062": {
+            "boundaryID": "harness-min-default-mdgxp",
+            "children": [
+              "harness-min-default-mdgxp-1551557888"
+            ],
+            "displayName": "gate",
+            "finishedAt": "2026-08-04T00:17:31Z",
+            "hostNodeName": "i-04c9ce08e9cec77cb",
+            "id": "harness-min-default-mdgxp-2045085062",
+            "name": "harness-min-default-mdgxp[0].gate",
+            "outputs": {
+              "exitCode": "0",
+              "result": "run"
+            },
+            "phase": "Succeeded",
+            "progress": "1/1",
+            "resourcesDuration": {
+              "cpu": 0,
+              "memory": 2
+            },
+            "startedAt": "2026-08-04T00:17:20Z",
+            "taskResultSynced": true,
+            "templateName": "staleness-gate",
+            "templateScope": "local/",
+            "type": "Pod"
+          },
+          "harness-min-default-mdgxp-2472796141": {
+            "boundaryID": "harness-min-default-mdgxp",
+            "children": [
+              "harness-min-default-mdgxp-4225676220"
+            ],
+            "displayName": "provision",
+            "finishedAt": "2026-08-04T00:45:10Z",
+            "id": "harness-min-default-mdgxp-2472796141",
+            "inputs": {
+              "parameters": [
+                {
+                  "name": "phase",
+                  "value": "provision"
+                },
+                {
+                  "name": "run-id",
+                  "value": "harness-min-default-mdgxp"
+                },
+                {
+                  "name": "config",
+                  "value": "min_default"
+                },
+                {
+                  "name": "extra-args",
+                  "value": "--scenario upgrade --from-ref auto:latest --to-ref 8f347c78fb11039a9737c30e956fa16e5f57cd78"
+                },
+                {
+                  "name": "repo-ref",
+                  "value": "master"
+                },
+                {
+                  "name": "deadline",
+                  "value": "5400"
+                },
+                {
+                  "name": "keep-on-failure",
+                  "value": "false"
+                },
+                {
+                  "name": "workflow-status",
+                  "value": ""
+                }
+              ]
+            },
+            "name": "harness-min-default-mdgxp[1].provision",
+            "outputs": {
+              "artifacts": [
+                {
+                  "name": "main-logs",
+                  "s3": {
+                    "key": "harness-min-default-mdgxp/harness-min-default-mdgxp-run-4225676220/main.log"
+                  }
+                }
+              ],
+              "exitCode": "0"
+            },
+            "phase": "Succeeded",
+            "progress": "1/2",
+            "resourcesDuration": {
+              "cpu": 1790,
+              "memory": 68313
+            },
+            "startedAt": "2026-08-04T00:17:40Z",
+            "templateRef": {
+              "name": "harness-phase",
+              "template": "run"
+            },
+            "templateScope": "local/",
+            "type": "Retry"
+          },
+          "harness-min-default-mdgxp-2624884219": {
+            "boundaryID": "harness-min-default-mdgxp",
+            "children": [
+              "harness-min-default-mdgxp-1377804381"
+            ],
+            "displayName": "[2]",
+            "finishedAt": "2026-08-04T00:46:20Z",
+            "id": "harness-min-default-mdgxp-2624884219",
+            "message": "child 'harness-min-default-mdgxp-1377804381' failed",
+            "name": "harness-min-default-mdgxp[2]",
+            "nodeFlag": {},
+            "phase": "Failed",
+            "progress": "0/1",
+            "resourcesDuration": {
+              "cpu": 4,
+              "memory": 168
+            },
+            "startedAt": "2026-08-04T00:45:10Z",
+            "templateScope": "local/",
+            "type": "StepGroup"
+          },
+          "harness-min-default-mdgxp-3396737381": {
+            "boundaryID": "harness-min-default-mdgxp-1068304776",
+            "displayName": "destroy(0)",
+            "finishedAt": "2026-08-04T01:07:04Z",
+            "hostNodeName": "i-04c9ce08e9cec77cb",
+            "id": "harness-min-default-mdgxp-3396737381",
+            "inputs": {
+              "parameters": [
+                {
+                  "name": "phase",
+                  "value": "teardown"
+                },
+                {
+                  "name": "run-id",
+                  "value": "harness-min-default-mdgxp"
+                },
+                {
+                  "name": "config",
+                  "value": "min_default"
+                },
+                {
+                  "name": "extra-args",
+                  "value": ""
+                },
+                {
+                  "name": "repo-ref",
+                  "value": "master"
+                },
+                {
+                  "name": "deadline",
+                  "value": "10800"
+                },
+                {
+                  "name": "keep-on-failure",
+                  "value": "false"
+                },
+                {
+                  "name": "workflow-status",
+                  "value": "Failed"
+                }
+              ]
+            },
+            "name": "harness-min-default-mdgxp.onExit[0].destroy(0)",
+            "nodeFlag": {
+              "retried": true
+            },
+            "outputs": {
+              "artifacts": [
+                {
+                  "name": "main-logs",
+                  "s3": {
+                    "key": "harness-min-default-mdgxp/harness-min-default-mdgxp-run-3396737381/main.log"
+                  }
+                }
+              ],
+              "exitCode": "0"
+            },
+            "phase": "Succeeded",
+            "progress": "1/1",
+            "resourcesDuration": {
+              "cpu": 1354,
+              "memory": 51655
+            },
+            "startedAt": "2026-08-04T00:46:20Z",
+            "taskResultSynced": true,
+            "templateRef": {
+              "name": "harness-phase",
+              "template": "run"
+            },
+            "templateScope": "local/",
+            "type": "Pod"
+          },
+          "harness-min-default-mdgxp-3724164466": {
+            "boundaryID": "harness-min-default-mdgxp-1068304776",
+            "children": [
+              "harness-min-default-mdgxp-145041638"
+            ],
+            "displayName": "[0]",
+            "finishedAt": "2026-08-04T01:07:13Z",
+            "id": "harness-min-default-mdgxp-3724164466",
+            "name": "harness-min-default-mdgxp.onExit[0]",
+            "nodeFlag": {},
+            "phase": "Succeeded",
+            "progress": "1/1",
+            "resourcesDuration": {
+              "cpu": 1354,
+              "memory": 51655
+            },
+            "startedAt": "2026-08-04T00:46:20Z",
+            "templateScope": "local/",
+            "type": "StepGroup"
+          },
+          "harness-min-default-mdgxp-4225676220": {
+            "boundaryID": "harness-min-default-mdgxp",
+            "children": [
+              "harness-min-default-mdgxp-2624884219"
+            ],
+            "displayName": "provision(0)",
+            "finishedAt": "2026-08-04T00:45:00Z",
+            "hostNodeName": "i-04c9ce08e9cec77cb",
+            "id": "harness-min-default-mdgxp-4225676220",
+            "inputs": {
+              "parameters": [
+                {
+                  "name": "phase",
+                  "value": "provision"
+                },
+                {
+                  "name": "run-id",
+                  "value": "harness-min-default-mdgxp"
+                },
+                {
+                  "name": "config",
+                  "value": "min_default"
+                },
+                {
+                  "name": "extra-args",
+                  "value": "--scenario upgrade --from-ref auto:latest --to-ref 8f347c78fb11039a9737c30e956fa16e5f57cd78"
+                },
+                {
+                  "name": "repo-ref",
+                  "value": "master"
+                },
+                {
+                  "name": "deadline",
+                  "value": "5400"
+                },
+                {
+                  "name": "keep-on-failure",
+                  "value": "false"
+                },
+                {
+                  "name": "workflow-status",
+                  "value": ""
+                }
+              ]
+            },
+            "name": "harness-min-default-mdgxp[1].provision(0)",
+            "nodeFlag": {
+              "retried": true
+            },
+            "outputs": {
+              "artifacts": [
+                {
+                  "name": "main-logs",
+                  "s3": {
+                    "key": "harness-min-default-mdgxp/harness-min-default-mdgxp-run-4225676220/main.log"
+                  }
+                }
+              ],
+              "exitCode": "0"
+            },
+            "phase": "Succeeded",
+            "progress": "1/1",
+            "resourcesDuration": {
+              "cpu": 1786,
+              "memory": 68145
+            },
+            "startedAt": "2026-08-04T00:17:40Z",
+            "taskResultSynced": true,
+            "templateRef": {
+              "name": "harness-phase",
+              "template": "run"
+            },
+            "templateScope": "local/",
+            "type": "Pod"
+          }
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## What

The harness failure card's EVIDENCE bullets only ever showed Argo's generic node
summary (`upgrade(0): main: Error (exit code 1)`), never the actual
tofu/terragrunt/helm error. This adds a `harness evidence` subcommand that pulls
the real proximate error out of each failed config's archived pod log.

## Why this is cheap

Every failed Pod node on the child Workflow CR already carries the exact S3 key
of its own archived container log, and the CR carries the bucket. No `kubectl
logs`, no new RBAC: post-status already runs as a ServiceAccount whose Pod
Identity role holds `s3:GetObject` on that bucket. So this is a new Go
subcommand plus a YAML pipe change, not new infra.

## How the extraction works (`harness/evidence.go`)

- Fetch only the tail of each log (S3 suffix range, last 256KiB) - bounded cost
  regardless of log size.
- Normalize: strip ANSI, strip terragrunt's timestamp/level prefix, strip
  box-drawing decoration.
- Scan the last 400 normalized lines **bottom-up** for the last line that looks
  like a real error, skipping polling noise (`Still destroying...`,
  `Destruction complete`, ...). Bottom-up is deliberate: a real specimen has a
  superseded, non-fatal error the harness continued past sitting thousands of
  lines above the actual failure.
- Prefer the harness's own `<phase> failed: ...` verdict line unless it's just a
  bare exit code, in which case fall back to the scanned error line.
- Scrub secret-shaped substrings before the text leaves the cluster (Vault/AWS/
  Slack/GitHub tokens, JWTs, generic password/token kv pairs, PEM keys) - a
  40-char git SHA and ARNs are deliberately left alone since they're often the
  diagnostic itself.

## Wire format

Adds one new per-child key, `log_excerpt`, alongside the existing `detail`.
`detail` is unchanged in meaning and computation. The renderer (separate PR)
prefers `log_excerpt` and falls back to `detail`, so this is compatible in both
directions: an un-bumped renderer ignores the new field, and a stale image
missing the `evidence` subcommand (or an S3 hiccup) makes `argo/20-matrix.yaml`
fall back to the old jq expression - the card never goes silent, it just
degrades to today's text.

## Also in this PR

`harness/terragrunt.go`'s `Apply`/`destroyModule` now wrap their returned error
with the same bottom-up scan over the output they already capture for retry
matching, so a tofu failure is specific in the pod log itself instead of a bare
`exit status 1` - this is what keeps the "thin verdict" fallback path from being
the *only* thing that can surface a tofu error.

## Testing

Fixtures under `live/tests/harness/testdata/evidence/` are real specimens
pulled from a genuine failed run (account id and ARNs replaced with
placeholders before commit). `go test ./...` covers the extraction heuristic,
secret scrubbing, the S3 fan-out (dedup of Retry nodes, per-child node cap,
determinism, wire budget), the new CLI subcommand, and a YAML/Go coupling guard
that fails if the post-status script and the binary drift apart.

```
go build ./... && go vet ./... && go test ./...
```
all green, including `-race` on the packages touched here.