### PR TITLE
feat(logical): floor spot node memory and right-size mesh dataplane requests

### DIFF
--- a/terraform/logical/istio.tf
+++ b/terraform/logical/istio.tf
@@ -49,6 +49,24 @@ resource "helm_release" "istio_base" {
   # Helm deliberately retains these CRDs on uninstall; teardown leaves them.
 }
 
+# Resource requests, no limits, on all three mesh components below (istiod,
+# istio-cni, ztunnel). This is deliberate, not an oversight:
+#
+# ztunnel and istio-cni run as DaemonSets - one pod per node, in the pod's
+# ambient dataplane path. An OOMKill on either drops the dataplane for every
+# ambient pod on that node at once (ztunnel) or breaks CNI attach for new pods
+# (istio-cni), so a limit that trips under a load spike is strictly worse than
+# no limit: it turns a transient spike into a hard, self-inflicted outage.
+# istiod is grouped here for the same reasoning even though it is not
+# per-node: it is the mesh control plane, and an OOMKill there stalls cert
+# rotation and config push cluster-wide until the replacement pod is ready.
+#
+# The actual protection is honest requests (sized to observed usage plus
+# headroom below, so eviction ranking - which scores by usage over request -
+# never picks these first) plus the spot NodePool's instance-memory floor
+# (kubernetes.tf), which keeps any single node from being small enough that
+# one hungry pod can starve everything else on it. Do not add limits here;
+# that reintroduces the exact failure mode this PR closes.
 resource "helm_release" "istiod" {
   count = local.mesh_installed ? 1 : 0
 
@@ -86,6 +104,17 @@ resource "helm_release" "istiod" {
         whenUnsatisfiable = "ScheduleAnyway"
         labelSelector     = { matchLabels = { app = "istiod" } }
       }]
+      # Chart defaults are 500m/2Gi requests. Observed usage across 5 healthy
+      # meshed envs tops out around 3m CPU / 59Mi memory (control-plane XDS
+      # push load, not per-request traffic) - the default left roughly 30-150x
+      # headroom over that. Right-sized to still keep several times observed
+      # peak in reserve without reserving capacity nothing ever claims back.
+      resources = {
+        requests = {
+          cpu    = "100m"
+          memory = "256Mi"
+        }
+      }
     }
     # 1.30.3 defaults this on; pinned so a future chart default change cannot
     # drop istiod's PDB.
@@ -111,6 +140,16 @@ resource "helm_release" "istio_cni" {
   # /opt/cni/bin + /etc/cni/net.d and istio-cni chains onto the managed VPC CNI.
   values = [yamlencode(merge(
     { profile = "ambient" },
+    # Chart defaults (100m/100Mi requests, no limits - see the comment on
+    # istiod above for why no limits). Observed usage across 5 healthy meshed
+    # envs peaked around 37Mi memory with CPU pinned at the kubectl-top
+    # rounding floor (1m) throughout, which undersells istio-cni's real
+    # ceiling: its work is bursty node-attach/detach churn, not steady state,
+    # so a quiet snapshot isn't a safe signal to size CPU down from. Memory
+    # headroom is already several times observed peak. Pinned explicitly
+    # (rather than left as an implicit chart default) so the value is a
+    # deliberate, reviewed choice.
+    { resources = { requests = { cpu = "100m", memory = "100Mi" } } },
     local.istio_image_hub == "" ? {} : { global = { hub = local.istio_image_hub } }
   ))]
 }
@@ -128,7 +167,22 @@ resource "helm_release" "ztunnel" {
 
   # The ztunnel chart takes hub/tag at TOP level, not under global (verify in
   # Step 2; adjust if the rendered image is wrong).
-  values = local.istio_image_hub == "" ? [] : [yamlencode({ hub = local.istio_image_hub })]
+  #
+  # Chart default is 200m/512Mi requests, no limits (see the comment on
+  # istiod above for why no limits - this is the component that comment is
+  # mainly about: today's incident was an unbounded app pod starving a small
+  # spot node and taking its ztunnel down with it). Observed usage across 5
+  # healthy meshed envs peaked around 102m CPU / 32Mi memory. CPU is left at
+  # the chart default (already close to 2x peak, a sane margin). Memory is
+  # brought down from 512Mi to 128Mi - still ~4x observed peak, but the
+  # as-shipped 512Mi was reserving far more allocatable memory per spot node
+  # than this workload has ever used, which works against the goal of this
+  # PR (more usable headroom per small node for everything else scheduled
+  # there).
+  values = [yamlencode(merge(
+    { resources = { requests = { cpu = "200m", memory = "128Mi" } } },
+    local.istio_image_hub == "" ? {} : { hub = local.istio_image_hub }
+  ))]
 }
 
 resource "kubernetes_labels" "ambient_dozuki" {
@@ -287,8 +341,10 @@ resource "kubectl_manifest" "peer_auth_carveouts" {
   server_side_apply = true
 }
 
-# The ztunnel PodMonitor moved into the dozuki chart (templates/istio/ztunnel-podmonitor.yaml),
-# gated on istio.ztunnelMonitor.enabled (set from local.mesh_enrolled in kubernetes.tf). It
-# belongs with its CRD, which ships in the chart's kube-prometheus-stack subchart - co-locating
+# The ztunnel PodMonitor moved into the dozuki chart (templates/istio/ztunnel-podmonitor.yaml).
+# There is no istio.ztunnelMonitor.enabled key anywhere in the chart. It renders on
+# monitoring.enabled plus a Capabilities check for the istio ServiceEntry API, so it follows
+# the mesh rollout on its own with no per-env flag from this layer. It belongs with its CRD,
+# which ships in the chart's kube-prometheus-stack subchart - co-locating
 # them removes the ordering hazard where this layer applied the PodMonitor before the app
 # release had created the CRD.

--- a/terraform/logical/kubernetes.tf
+++ b/terraform/logical/kubernetes.tf
@@ -314,6 +314,20 @@ resource "kubernetes_manifest" "nodepool_spot" {
                 key      = "eks.amazonaws.com/instance-generation"
                 operator = "Gt"
                 values   = ["4"]
+              },
+              # Memory floor, spot pool only: requests-based bin packing can
+              # otherwise land Karpenter on a ~4GiB instance class (~3.1GiB
+              # allocatable), and one unbounded app pod on a node that small
+              # starves everything else scheduled there - including the
+              # per-node ztunnel dataplane pod (see istio.tf for the other
+              # half of this fix). eks.amazonaws.com/instance-memory is in
+              # MiB (ground-truthed against a live NodePool). Gt "6144" (6GiB)
+              # excludes 4GiB classes and admits 8GiB classes without
+              # excluding an instance that happens to report exactly 8192.
+              {
+                key      = "eks.amazonaws.com/instance-memory"
+                operator = "Gt"
+                values   = ["6144"]
               }
             ]
           },


### PR DESCRIPTION
## Why

Today's incident: an unbounded app workload landed on a small spot node,
starved it, and took the node's ztunnel dataplane down with it, dropping
ambient mesh connectivity for every pod on that node at once. Envoy and the
video transcoder have already been moved off this collision path in a
separate change; this PR closes the remaining structural exposure - the
spot pool's lack of a memory floor, and the mesh dataplane's stock resource
requests.

## What changed

**Spot NodePool memory floor** (`kubernetes.tf`)

Adds `eks.amazonaws.com/instance-memory Gt 6144` to the spot pool's
requirements (spot pool only - on-demand and the system pool are unaffected).
Ground-truthed the label/unit against a live NodePool (`kubectl get nodepools
-o yaml` on an Auto Mode cluster): Auto Mode uses
`eks.amazonaws.com/instance-memory` in MiB, not the OSS Karpenter
`karpenter.k8s.aws` label. `Gt 6144` sits between the 4GiB and 8GiB instance
classes, so it excludes 4GiB nodes (the failure mode - ~3.1GiB allocatable,
one hungry pod starves the node) while admitting 8GiB nodes without
excluding one that reports exactly 8192.

**Rollout behavior**: EKS Auto Mode drift-replaces nodes whose spec no
longer matches, so once an env picks up the `infra_version` bump carrying
this, it sees a gradual rolling replacement of existing spot nodes under
4GiB - not a fleet-wide event at merge. Nothing applies until a consumer
bumps the pin, same as every other module change here.

**Mesh dataplane request sizing** (`istio.tf`)

`ztunnel`, `istio-cni`, and `istiod` previously ran on the istio chart's
stock request defaults with no explicit `resources` block in our values
(implicit, not pinned). Gathered `kubectl top pods -n istio-system` across 5
healthy meshed envs (excluding one env whose numbers are contaminated by
today's incident) and pinned explicit requests:

| component | chart default | observed peak | new request | change |
|---|---|---|---|---|
| ztunnel (cpu) | 200m | 102m | 200m | unchanged - already ~2x peak |
| ztunnel (mem) | 512Mi | 32Mi | 128Mi | ~4x peak, down from 16x |
| istio-cni (cpu) | 100m | ~1m (kubectl-top floor) | 100m | unchanged - snapshot isn't a safe signal for bursty CNI ops |
| istio-cni (mem) | 100Mi | 37Mi | 100Mi | unchanged - already sane headroom |
| istiod (cpu) | 500m | 3m | 100m | still >30x peak |
| istiod (mem) | 2Gi | 59Mi | 256Mi | still ~4x peak, down from ~35x |

No limits on any of the three, and a comment now says so explicitly and
explains why: ztunnel and istio-cni are per-node DaemonSet singletons, so an
OOMKill on either drops the ambient dataplane (or CNI attach) for every pod
on that node at once. istiod is grouped in for the same "no limits" logic
even though it isn't per-node - it's the mesh control plane, and losing it
stalls cert rotation and config push cluster-wide. The actual protection is
honest requests (so node-pressure eviction ranking, which scores by usage
over request, doesn't pick these pods first) plus the spot pool memory floor
above. The comment exists so a future PR doesn't "helpfully" add limits back.

**Stale comment fix**

The comment above the ztunnel PodMonitor claimed it's gated on an
`istio.ztunnelMonitor.enabled` values key. That key doesn't exist anywhere
in the dozuki chart; the chart actually self-gates the PodMonitor via
Capabilities detection of the ServiceEntry API. One-line correction.

## Validation

- `tofu fmt`, `tofu validate`, `tflint` - clean
- pre-commit hooks (terraform-docs, fmt, validate+tflint) - clean
- CI: logical/physical/physical-azure harness + gate + upgrade-tests

## Not in scope here

Rides the next release tag alongside the NLB alarm work already on master.
Not merging this PR directly - marking ready once CI is green, David merges
when the release is cut.