### PR TITLE
ci(harness): gate the bi_ha PR scenario on what actually changed

### DIFF
--- a/.github/workflows/upgrade-tests.yml
+++ b/.github/workflows/upgrade-tests.yml
@@ -48,7 +48,6 @@ env:
   TO_REF: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || inputs.to-ref }}
   PR_REPO: ${{ github.event_name == 'pull_request' && github.repository || '' }}
   PR_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || '' }}
-  PR_BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || '' }}
   PR_BASE_REF: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.ref || '' }}
   NAME_HINT: ${{ github.event_name == 'pull_request' && format('pr{0}', github.event.pull_request.number) || 'manual' }}
 
@@ -59,49 +58,88 @@ jobs:
     steps:
       # Only PR runs need the repo: the scenario-selection step below diffs it. Dispatch
       # runs take configs verbatim from the input and never touch git.
+      #
+      # fetch-depth 0 so the merge base is reachable. No fetch-tags here on purpose: with a
+      # bare SHA as the ref, checkout fetches that one commit's history with no destination
+      # refspec, and fetch-tags only drops --no-tags, which follows nothing in that shape.
+      # The selection step fetches the base branch and the tags itself.
       - name: Check out the repo
         if: github.event_name == 'pull_request'
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
-          fetch-tags: true
           persist-credentials: false
 
       # Narrows CONFIGS for a PR run so it doesn't pay for a scenario nothing relevant
-      # changed. min_default always survives (it carries no paths list). Every other PR
-      # scenario runs iff:
+      # changed. A scenario with no `paths:` list in live/tests/matrix.yaml is the always-on
+      # baseline (min_default today) and always survives. Every other PR scenario runs iff:
       #   - the relevant diff touches one of its live/tests/matrix.yaml `paths:` globs, or
       #   - the relevant diff touches the harness itself (live/tests/** or this workflow
-      #     file) — a harness change has to prove the WHOLE matrix still passes, or
+      #     file) - a harness change has to prove the WHOLE matrix still passes, or
       #   - the PR carries the `harness-full` label (manual escape hatch).
       #
-      # "Relevant diff" depends on what kind of PR this is. A normal PR: base...head of the
-      # PR (three-dot — merge-base to head, so unrelated master history that landed after
-      # the branch forked doesn't count). A release-please PR (branch release-please--*):
-      # the PR's own diff is just the changelog/manifest bump, so the diff that matters is
-      # everything the release will actually ship — last tag..current base-branch HEAD
+      # "Relevant diff" depends on what kind of PR this is. A normal PR: merge-base(base
+      # branch tip, head)..head, so unrelated base-branch history that landed after the
+      # branch forked doesn't count. A release-please PR (branch release-please--*): the
+      # PR's own diff is just the changelog/manifest bump, so the diff that matters is
+      # everything the release will actually ship - last tag..current base-branch HEAD
       # (two-dot, direct diff), covering every commit merged since the last release.
+      #
+      # Narrowing is an optimisation. Losing coverage on the PR that needed it is not an
+      # acceptable failure mode, so every error path here keeps the full PR set and says
+      # so in the job summary instead of exiting non-zero: a step failure would abort the
+      # job before it submits anything, and the commit status the PR gates on is only
+      # written after the submit.
       - name: Select PR scenarios
         if: github.event_name == 'pull_request'
         env:
           HARNESS_FULL_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'harness-full') }}
         run: |
-          set -euo pipefail
+          # Deliberately no -e: see the fail-safe note above. Errors are handled per command.
+          set -uo pipefail
+
+          keep_everything() {
+            echo "scenario gating unavailable ($1); keeping the full PR set $CONFIGS"
+            echo "scenario gating unavailable ($1); kept the full PR set \`$CONFIGS\`" >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          }
+
+          # The checkout above was given a bare SHA, so git created no remote-tracking refs
+          # and fetched no tags: fetch-tags only drops --no-tags, and a refspec with no
+          # destination follows no tags anyway. Both have to be asked for explicitly, or
+          # `git describe` below finds nothing and the base tip is not a resolvable name.
+          git fetch --quiet --tags origin "+refs/heads/${PR_BASE_REF}:refs/remotes/origin/${PR_BASE_REF}" \
+            || keep_everything "cannot fetch ${PR_BASE_REF}"
+          BASE_TIP=$(git rev-parse "refs/remotes/origin/${PR_BASE_REF}") \
+            || keep_everything "cannot resolve ${PR_BASE_REF}"
 
           if [[ "$GITHUB_HEAD_REF" == release-please--* ]]; then
             echo "release-please PR ($GITHUB_HEAD_REF): diff basis = last tag..${PR_BASE_REF} HEAD"
-            git fetch --quiet origin "$PR_BASE_REF"
-            BASE_TIP=$(git rev-parse FETCH_HEAD)
-            LAST_TAG=$(git describe --tags --abbrev=0 "$BASE_TIP")
+            LAST_TAG=$(git describe --tags --abbrev=0 "$BASE_TIP") \
+              || keep_everything "no tag reachable from ${PR_BASE_REF}"
             echo "last tag: $LAST_TAG, base tip: $BASE_TIP"
-            CHANGED=$(git diff --name-only "$LAST_TAG" "$BASE_TIP")
+            CHANGED=$(git diff --name-only "$LAST_TAG" "$BASE_TIP") \
+              || keep_everything "diff ${LAST_TAG}..${BASE_TIP} failed"
           else
-            echo "normal PR: diff basis = ${PR_BASE_SHA}...${PR_SHA}"
-            CHANGED=$(git diff --name-only "${PR_BASE_SHA}...${PR_SHA}")
+            # NOT github.event.pull_request.base.sha: that is the base branch tip at event
+            # time, not the merge base, and once the base branch moves ahead of the branch
+            # it is not in the history a bare-SHA checkout fetched - `git diff base...head`
+            # then dies with "Invalid symmetric difference expression". The merge base of
+            # the freshly fetched base tip and the head gives the same three-dot semantics
+            # without depending on an object the runner may not have.
+            MERGE_BASE=$(git merge-base "$BASE_TIP" "$PR_SHA") \
+              || keep_everything "no merge base between ${PR_BASE_REF} and the head"
+            echo "normal PR: diff basis = ${MERGE_BASE}..${PR_SHA}"
+            CHANGED=$(git diff --name-only "$MERGE_BASE" "$PR_SHA") \
+              || keep_everything "diff ${MERGE_BASE}..${PR_SHA} failed"
           fi
 
-          echo "relevant diff (${#CHANGED} bytes):"
+          # A PR always changes something. Nothing here means the diff basis is wrong, not
+          # that the PR is empty, so it takes the safe branch rather than dropping scenarios.
+          [[ -n "$CHANGED" ]] || keep_everything "the relevant diff is empty"
+
+          echo "relevant diff:"
           echo "$CHANGED"
 
           HARNESS_CHANGED=false
@@ -116,22 +154,34 @@ jobs:
           # live/tests/matrix.yaml is itself under live/tests/**, so any edit to the path
           # map below is already covered by HARNESS_CHANGED and never needs its own entry.
           SCENARIO_PATHS=$(python3 - <<'PY'
-          import json
+          import json, subprocess, sys
           try:
               import yaml
           except ImportError:
-              import subprocess, sys
-              subprocess.run([sys.executable, "-m", "pip", "install", "-q", "pyyaml"], check=True)
+              # The runner image normally ships PyYAML. If it ever doesn't, try both the
+              # plain install and the PEP 668 one a system-managed python needs.
+              for extra in ([], ["--break-system-packages"]):
+                  if subprocess.run([sys.executable, "-m", "pip", "install", "-q", *extra, "pyyaml"]).returncode == 0:
+                      break
               import yaml
           with open("live/tests/matrix.yaml") as f:
               data = yaml.safe_load(f)
           print(json.dumps({c["name"]: c.get("paths", []) for c in data["configs"]}))
           PY
-          )
+          ) || keep_everything "cannot read the path map out of live/tests/matrix.yaml"
+          [[ -n "$SCENARIO_PATHS" ]] || keep_everything "the matrix.yaml path map came back empty"
+
+          NAMES=$(printf '%s' "$CONFIGS" | jq -r '.[]') || keep_everything "cannot parse CONFIGS"
 
           SELECTED=()
-          for name in $(echo "$CONFIGS" | jq -r '.[]'); do
-            if [[ "$name" == "min_default" ]]; then
+          for name in $NAMES; do
+            # No paths list at all (or a name matrix.yaml doesn't know) means always-on:
+            # this is what makes min_default the baseline, and a new scenario added without
+            # a paths list gets the same treatment rather than being silently dropped.
+            PATTERNS=$(echo "$SCENARIO_PATHS" | jq -r --arg n "$name" '.[$n][]?') \
+              || keep_everything "cannot read the paths list for $name"
+            if [[ -z "$PATTERNS" ]]; then
+              echo "keeping $name: no paths list, so it is an always-on baseline"
               SELECTED+=("$name")
               continue
             fi
@@ -146,7 +196,6 @@ jobs:
               continue
             fi
             MATCHED=false
-            PATTERNS=$(echo "$SCENARIO_PATHS" | jq -r --arg n "$name" '.[$n][]? ')
             while IFS= read -r pat; do
               [[ -z "$pat" ]] && continue
               while IFS= read -r f; do
@@ -164,7 +213,10 @@ jobs:
             fi
           done
 
-          NEW_CONFIGS=$(printf '%s\n' "${SELECTED[@]}" | jq -R . | jq -s -c .)
+          [[ ${#SELECTED[@]} -gt 0 ]] || keep_everything "no scenario survived selection"
+
+          NEW_CONFIGS=$(printf '%s\n' "${SELECTED[@]}" | jq -R . | jq -s -c .) \
+            || keep_everything "cannot rebuild the configs array"
           echo "CONFIGS=$NEW_CONFIGS" >> "$GITHUB_ENV"
           echo "selected PR scenarios: $NEW_CONFIGS" >> "$GITHUB_STEP_SUMMARY"
 

--- a/.github/workflows/upgrade-tests.yml
+++ b/.github/workflows/upgrade-tests.yml
@@ -28,6 +28,7 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
+  contents: read
   id-token: write
   statuses: write
 
@@ -38,12 +39,17 @@ env:
   # PR runs test min + bi in parallel (semaphore is 2, so wall clock = bi_ha alone,
   # and two upgrade paths get covered). full stays nightly-only: it is the slowest
   # stack and its extra coverage (provisioned-RDS BI, istio strict) is not worth the
-  # PR wait. Dispatch runs take the inputs (defaults = the nightly shape).
+  # PR wait. Dispatch runs take the inputs (defaults = the nightly shape). This is the
+  # ceiling for a PR run; the "Select PR scenarios" step below narrows it further by
+  # dropping any non-baseline scenario whose matrix.yaml paths the relevant diff never
+  # touches. min_default has no paths entry, so it is never dropped.
   CONFIGS: ${{ github.event_name == 'pull_request' && '["min_default","bi_ha"]' || inputs.configs }}
   FROM_REF: ${{ github.event_name == 'pull_request' && 'auto:latest' || inputs.from-ref }}
   TO_REF: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || inputs.to-ref }}
   PR_REPO: ${{ github.event_name == 'pull_request' && github.repository || '' }}
   PR_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || '' }}
+  PR_BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || '' }}
+  PR_BASE_REF: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.ref || '' }}
   NAME_HINT: ${{ github.event_name == 'pull_request' && format('pr{0}', github.event.pull_request.number) || 'manual' }}
 
 jobs:
@@ -51,6 +57,117 @@ jobs:
     if: github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'run-upgrade-tests')
     runs-on: ubuntu-latest
     steps:
+      # Only PR runs need the repo: the scenario-selection step below diffs it. Dispatch
+      # runs take configs verbatim from the input and never touch git.
+      - name: Check out the repo
+        if: github.event_name == 'pull_request'
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+          fetch-tags: true
+          persist-credentials: false
+
+      # Narrows CONFIGS for a PR run so it doesn't pay for a scenario nothing relevant
+      # changed. min_default always survives (it carries no paths list). Every other PR
+      # scenario runs iff:
+      #   - the relevant diff touches one of its live/tests/matrix.yaml `paths:` globs, or
+      #   - the relevant diff touches the harness itself (live/tests/** or this workflow
+      #     file) — a harness change has to prove the WHOLE matrix still passes, or
+      #   - the PR carries the `harness-full` label (manual escape hatch).
+      #
+      # "Relevant diff" depends on what kind of PR this is. A normal PR: base...head of the
+      # PR (three-dot — merge-base to head, so unrelated master history that landed after
+      # the branch forked doesn't count). A release-please PR (branch release-please--*):
+      # the PR's own diff is just the changelog/manifest bump, so the diff that matters is
+      # everything the release will actually ship — last tag..current base-branch HEAD
+      # (two-dot, direct diff), covering every commit merged since the last release.
+      - name: Select PR scenarios
+        if: github.event_name == 'pull_request'
+        env:
+          HARNESS_FULL_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'harness-full') }}
+        run: |
+          set -euo pipefail
+
+          if [[ "$GITHUB_HEAD_REF" == release-please--* ]]; then
+            echo "release-please PR ($GITHUB_HEAD_REF): diff basis = last tag..${PR_BASE_REF} HEAD"
+            git fetch --quiet origin "$PR_BASE_REF"
+            BASE_TIP=$(git rev-parse FETCH_HEAD)
+            LAST_TAG=$(git describe --tags --abbrev=0 "$BASE_TIP")
+            echo "last tag: $LAST_TAG, base tip: $BASE_TIP"
+            CHANGED=$(git diff --name-only "$LAST_TAG" "$BASE_TIP")
+          else
+            echo "normal PR: diff basis = ${PR_BASE_SHA}...${PR_SHA}"
+            CHANGED=$(git diff --name-only "${PR_BASE_SHA}...${PR_SHA}")
+          fi
+
+          echo "relevant diff (${#CHANGED} bytes):"
+          echo "$CHANGED"
+
+          HARNESS_CHANGED=false
+          while IFS= read -r f; do
+            [[ -z "$f" ]] && continue
+            if [[ "$f" == live/tests/* || "$f" == .github/workflows/upgrade-tests.yml ]]; then
+              HARNESS_CHANGED=true
+              break
+            fi
+          done <<< "$CHANGED"
+
+          # live/tests/matrix.yaml is itself under live/tests/**, so any edit to the path
+          # map below is already covered by HARNESS_CHANGED and never needs its own entry.
+          SCENARIO_PATHS=$(python3 - <<'PY'
+          import json
+          try:
+              import yaml
+          except ImportError:
+              import subprocess, sys
+              subprocess.run([sys.executable, "-m", "pip", "install", "-q", "pyyaml"], check=True)
+              import yaml
+          with open("live/tests/matrix.yaml") as f:
+              data = yaml.safe_load(f)
+          print(json.dumps({c["name"]: c.get("paths", []) for c in data["configs"]}))
+          PY
+          )
+
+          SELECTED=()
+          for name in $(echo "$CONFIGS" | jq -r '.[]'); do
+            if [[ "$name" == "min_default" ]]; then
+              SELECTED+=("$name")
+              continue
+            fi
+            if [[ "$HARNESS_CHANGED" == true ]]; then
+              echo "keeping $name: harness changed"
+              SELECTED+=("$name")
+              continue
+            fi
+            if [[ "$HARNESS_FULL_LABEL" == "true" ]]; then
+              echo "keeping $name: harness-full label"
+              SELECTED+=("$name")
+              continue
+            fi
+            MATCHED=false
+            PATTERNS=$(echo "$SCENARIO_PATHS" | jq -r --arg n "$name" '.[$n][]? ')
+            while IFS= read -r pat; do
+              [[ -z "$pat" ]] && continue
+              while IFS= read -r f; do
+                [[ -z "$f" ]] && continue
+                if [[ "$f" == $pat ]]; then
+                  MATCHED=true
+                fi
+              done <<< "$CHANGED"
+            done <<< "$PATTERNS"
+            if [[ "$MATCHED" == true ]]; then
+              echo "keeping $name: diff matches its paths"
+              SELECTED+=("$name")
+            else
+              echo "dropping $name: no path match in the relevant diff"
+            fi
+          done
+
+          NEW_CONFIGS=$(printf '%s\n' "${SELECTED[@]}" | jq -R . | jq -s -c .)
+          echo "CONFIGS=$NEW_CONFIGS" >> "$GITHUB_ENV"
+          echo "selected PR scenarios: $NEW_CONFIGS" >> "$GITHUB_STEP_SUMMARY"
+
       # The submit heredoc expands these; refuse anything that could smuggle shell or
       # YAML through a dispatch input. PR-path values are a hex SHA and org/repo, which
       # pass these same shapes.

--- a/live/tests/matrix.yaml
+++ b/live/tests/matrix.yaml
@@ -66,15 +66,16 @@ versions:
     chart_version: "2.2.0"
 
 configs:
-  # PR scenario gating (.github/workflows/upgrade-tests.yml, submit job) reads the `paths:`
-  # list below per scenario: a scenario runs on a PR only if the relevant diff touches one of
-  # its globs. A config with NO `paths:` key (min_default) always runs — that is the baseline
-  # every PR pays for. This list is the single source of truth for "what counts as BI"; keep it
-  # in sync with what bi_ha's feature flags actually turn on in terraform/physical/bi.tf and
-  # terraform/logical/bi.tf. The gate also has two escapes that ignore this list entirely: any
-  # PR touching live/tests/** or the workflow file itself runs every PR scenario (a harness
-  # change has to prove the whole matrix still works), and the `harness-full` PR label forces
-  # the same. See live/tests/CLAUDE.md for the full rule.
+  # PR scenario gating (.github/workflows/upgrade-tests.yml, "Select PR scenarios" step) reads
+  # the `paths:` list below per scenario: a scenario runs on a PR only if the relevant diff
+  # touches one of its globs. A config with NO `paths:` key (min_default) always runs - that is
+  # the baseline every PR pays for, and it is why a new scenario added without a paths list
+  # runs everywhere until someone writes one. This list is the single source of truth for
+  # "what counts as BI"; keep it in sync with what bi_ha's feature flags actually turn on.
+  # The gate also has two escapes that ignore this list entirely: any PR touching live/tests/**
+  # or the workflow file itself runs every PR scenario (a harness change has to prove the whole
+  # matrix still works), and the `harness-full` PR label forces the same. The workflow step's
+  # own comments carry the rest of the rule, including the diff basis per PR type.
   - name: min_default
     env: min
     feature_flags:
@@ -123,9 +124,17 @@ configs:
     # the BI target database on either engine path (aws_db_instance dms_replica_database /
     # module.bi_aurora) and its parameter groups, the bi_* variables that steer them, the
     # logical-layer dms-start Job, and the bi/ env dirs the scenario's `env: bi` resolves to.
-    # variables.tf/main.tf/monitoring.tf are shared files (not BI-only), so a change anywhere
-    # in them over-triggers this scenario rather than risk missing a real bi_* toggle edit —
-    # cheap insurance since min_default still runs either way.
+    #
+    # The test for a file belonging here is not "is it named bi": it is "can breaking this
+    # be invisible to min_default". min_default runs with enable_bi false, so everything
+    # gated on enable_bi/dms_enabled is only ever proven by this scenario, including the
+    # physical outputs that hand DMS to the logical layer, the logical locals and Vault
+    # write that consume them, and the DMS IAM the dms-start Job assumes.
+    #
+    # variables.tf/main.tf/monitoring.tf/db.tf/eks.tf/aurora.tf/outputs.tf and the logical
+    # main.tf/vault.tf/flux.tf are shared files (not BI-only), so a change anywhere in them
+    # over-triggers this scenario rather than risk missing a real bi_* toggle edit - cheap
+    # insurance, since the alternative is finding out on the release PR.
     paths:
       - "terraform/physical/bi.tf"
       - "terraform/physical/static/dms_config.json"
@@ -133,10 +142,17 @@ configs:
       - "terraform/physical/util/dms_restart.py"
       - "terraform/physical/util/dms-stop.sh"
       - "terraform/physical/variables.tf"
-      - "terraform/physical/main.tf"
-      - "terraform/physical/monitoring.tf"
+      - "terraform/physical/main.tf"        # bi_uses_aurora + every bi_db_* local
+      - "terraform/physical/monitoring.tf"  # DMS alarm wiring
+      - "terraform/physical/outputs.tf"     # dms_task_arn, dms_replication_generation, bi_*
+      - "terraform/physical/db.tf"          # locals the DMS source endpoint reads
+      - "terraform/physical/eks.tf"         # dms:Start*/Describe* for the dms-start Job
+      - "terraform/physical/aurora.tf"      # bi_uses_aurora shares its final-snapshot suffix
       - "terraform/logical/bi.tf"
       - "terraform/logical/variables.tf"
+      - "terraform/logical/main.tf"         # db_bi_* locals + the BI credentials secret
+      - "terraform/logical/vault.tf"        # the BI database credentials write
+      - "terraform/logical/flux.tf"         # grafanaDbInit + the enable_bi precondition
       - "live/.skel/environments/bi/**"
       - "live/*/*/bi/**"
     feature_flags:

--- a/live/tests/matrix.yaml
+++ b/live/tests/matrix.yaml
@@ -66,6 +66,15 @@ versions:
     chart_version: "2.2.0"
 
 configs:
+  # PR scenario gating (.github/workflows/upgrade-tests.yml, submit job) reads the `paths:`
+  # list below per scenario: a scenario runs on a PR only if the relevant diff touches one of
+  # its globs. A config with NO `paths:` key (min_default) always runs — that is the baseline
+  # every PR pays for. This list is the single source of truth for "what counts as BI"; keep it
+  # in sync with what bi_ha's feature flags actually turn on in terraform/physical/bi.tf and
+  # terraform/logical/bi.tf. The gate also has two escapes that ignore this list entirely: any
+  # PR touching live/tests/** or the workflow file itself runs every PR scenario (a harness
+  # change has to prove the whole matrix still works), and the `harness-full` PR label forces
+  # the same. See live/tests/CLAUDE.md for the full rule.
   - name: min_default
     env: min
     feature_flags:
@@ -110,6 +119,26 @@ configs:
       # harness needs no explicit entry; leaving it unset works for local + CI.
   - name: bi_ha
     env: bi
+    # What this scenario actually exercises: DMS Serverless replication (physical/bi.tf),
+    # the BI target database on either engine path (aws_db_instance dms_replica_database /
+    # module.bi_aurora) and its parameter groups, the bi_* variables that steer them, the
+    # logical-layer dms-start Job, and the bi/ env dirs the scenario's `env: bi` resolves to.
+    # variables.tf/main.tf/monitoring.tf are shared files (not BI-only), so a change anywhere
+    # in them over-triggers this scenario rather than risk missing a real bi_* toggle edit —
+    # cheap insurance since min_default still runs either way.
+    paths:
+      - "terraform/physical/bi.tf"
+      - "terraform/physical/static/dms_config.json"
+      - "terraform/physical/static/dms_mapping.json"
+      - "terraform/physical/util/dms_restart.py"
+      - "terraform/physical/util/dms-stop.sh"
+      - "terraform/physical/variables.tf"
+      - "terraform/physical/main.tf"
+      - "terraform/physical/monitoring.tf"
+      - "terraform/logical/bi.tf"
+      - "terraform/logical/variables.tf"
+      - "live/.skel/environments/bi/**"
+      - "live/*/*/bi/**"
     feature_flags:
       enable_bi: true
       db_engine: aurora


### PR DESCRIPTION
## What
PRs paid for the slow `bi_ha` scenario every time, even when nothing BI-related
changed. `min_default` stays the always-on baseline; `bi_ha` now only runs on a PR
when the relevant diff touches its path map.

## Path map
Lives in `live/tests/matrix.yaml`, next to the `bi_ha` config (`paths:` key). The
test for belonging there is not "is it named bi", it is "can breaking this be
invisible to `min_default`". `min_default` runs with `enable_bi: false`, so
everything gated on `enable_bi`/`dms_enabled` is proven by `bi_ha` alone:

- `terraform/physical/bi.tf`, `static/dms_config.json`, `static/dms_mapping.json`,
  `util/dms_restart.py`, `util/dms-stop.sh`
- `terraform/physical/variables.tf`, `main.tf`, `monitoring.tf` - the `bi_*`
  variables, the `bi_uses_aurora`/`bi_db_*` locals, the DMS alarm wiring
- `terraform/physical/outputs.tf` - `dms_task_arn`, `dms_replication_generation`
  (the hash that forces a fresh dms-start Job), `bi_aurora_cluster_id`
- `terraform/physical/db.tf` - the locals the DMS source endpoint reads
- `terraform/physical/eks.tf` - the `dms:Start*`/`Describe*` the dms-start Job needs
- `terraform/physical/aurora.tf` - `bi_uses_aurora` shares its final-snapshot suffix
- `terraform/logical/bi.tf`, `variables.tf`, `main.tf` (`db_bi_*` locals + the BI
  credentials secret), `vault.tf` (the BI credentials write), `flux.tf`
  (`grafanaDbInit` + the `enable_bi` precondition)
- `live/.skel/environments/bi/**`, `live/*/*/bi/**`

Shared files over-trigger `bi_ha` rather than risk missing a real `bi_*` toggle
edit. Everything outside terraform (chart pins, docs, azure, `live/` scaffolding)
and most of terraform still skips it, which is where the saving comes from.

## Diff basis
The job checks out with a bare head SHA. That shape has two properties worth
stating, because both were reproduced failing against a checkout built the same way:

- It creates **no remote-tracking refs and fetches no tags**. `fetch-tags` only
  drops `--no-tags`, and a refspec with no destination follows nothing, so
  `git describe --tags` found nothing at all on a release-please branch.
- `pull_request.base.sha` is the base branch tip at event time, **not** the merge
  base, and it is not in the fetched history once the base branch moves ahead of
  the branch, so `git diff base...head` died on "Invalid symmetric difference
  expression".

So the step fetches the base branch and the tags itself, then:

- **Normal PR:** `merge-base(<base tip>, head)..head`.
- **Release-please PR** (branch `release-please--*`): the PR's own diff is just the
  changelog/manifest bump, so the gate diffs `<last tag>..<base branch HEAD>` -
  every commit that will actually ship, not just what the release branch touched.

Checked against this repo's history in a simulated runner checkout: last tag
`v8.12.1`, base tip `d4d7b1f`, diff includes `live/tests/**`, so the
harness-changed override fires and release PR #444 keeps the full PR set.

## Fail-safe direction
Narrowing is an optimisation; losing coverage on the PR that needed it is not an
acceptable failure mode. The step does not run under `set -e`. Every error path -
fetch, describe, merge-base, diff, `matrix.yaml` parse, `jq` - keeps the full PR
set and says why in the job summary. An empty diff takes the same branch, because
a PR that changed nothing means the diff basis is wrong. A step failure would have
been worse than useless: it aborts the job before it submits anything, and the
commit status the PR gates on is only written after the submit.

The always-on baseline is read from the **absence** of a `paths:` list rather than
the literal name `min_default`, so a scenario added without a path map runs
everywhere instead of being silently dropped.

## Overrides (always run the full PR set)
- The diff touches the harness itself (`live/tests/**` or this workflow file).
- The PR carries the **`harness-full`** label (created on the repo).

## Status reporting
No change needed. `bi_ha` is never "skipped" mid-run, it is just not submitted as a
child workflow when excluded from `configs`, so `harness-matrix`'s exit handler
(`post-status` in `20-matrix.yaml`) still fires once on `{{workflow.status}}` and
reports on whatever subset ran. A one-element `configs` is a normal `withParam`
fan-out. No pending-forever risk.

## Argo
No template changes. `harness-matrix`'s existing `configs` parameter is the whole
mechanism; this PR only changes what value the workflow sends. The template default
is still the full `min_default`/`bi_ha`/`full` list, so the nightly CronWorkflow
(which passes no `configs`) and a manual `argo submit --from
workflowtemplate/harness-matrix` are both unaffected. **No post-merge kubectl apply
needed.**

## Testing
- The selection logic run standalone under bash 5 against fixture diffs: unrelated
  file drops `bi_ha`; `bi.tf`, `outputs.tf`, `db.tf`, `eks.tf`, logical `main.tf`
  and `vault.tf`, and a `bi/` env dir all keep it; harness-changed and the label
  both force the full set; empty diff, malformed `configs` and a missing `jq` all
  fall back to the full set with rc 0.
- Both git paths run end to end against a checkout reproduced the way the job builds
  one (bare-SHA fetch, detached HEAD, no tracking refs): a normal PR whose base
  branch moved ahead now resolves the merge base, and a `release-please--*` branch
  now finds `v8.12.1`. Both used to exit 128.
- `go build`, `go vet`, `go test ./...` clean in `live/tests` (`matrix.yaml` is
  parsed non-strictly, so the new `paths:` key is ignored by the Go harness).
