### PR TITLE
feat(logical): pod-level do-not-disrupt on the on-demand tier, flip pool to WhenEmptyOrUnderutilized

### DIFF
--- a/terraform/logical/flux.tf
+++ b/terraform/logical/flux.tf
@@ -323,9 +323,11 @@ locals {
   # no legal fallback - the volume pins the zone, the on-demand pool's taint blocked
   # entry, and that is the old spot-fleet stranding incident reproduced (adversarial
   # AZ/PVC review, 2026-07-28; observed live: all three volumes on one spot c4.xlarge).
-  # On-demand placement plus the on-demand pool's WhenEmpty consolidation makes their
-  # disruptions rare and their replacement capacity reliably provisionable in the
-  # volume's AZ.
+  # On-demand placement plus the pod-level do-not-disrupt annotation set below
+  # (local.do_not_disrupt_annotation) makes their disruptions rare and their
+  # replacement capacity reliably provisionable in the volume's AZ. The pool
+  # itself no longer carries a pool-wide WhenEmpty policy for this - see the
+  # disruption block on kubernetes.tf's on-demand NodePool.
   #
   # Lives HERE and not in chart defaults on purpose: the selector/toleration reference
   # Karpenter/EKS labels that do not exist on onprem or AKS clusters - baked into the
@@ -340,7 +342,7 @@ locals {
   # on-demand pool never launched a node at all, and its NoSchedule taint therefore never
   # kept anything off these nodes - opensearch shared a node with untainted workloads until
   # the node ran out of page cache. Naming the pool is what actually engages both the taint
-  # and the pool's WhenEmpty disruption policy (2026-08-01).
+  # and the pool's disruption policy (2026-08-01).
   stateful_node_selector = { "karpenter.sh/nodepool" = "on-demand" }
   stateful_tolerations = [{
     key      = "eks.amazonaws.com/capacity-type"
@@ -348,43 +350,89 @@ locals {
     value    = "on-demand"
     effect   = "NoSchedule"
   }]
+  # karpenter.sh/do-not-disrupt="true" on every pod below, quoted string per the
+  # helm-controller precedent (this file, helm_release.flux, further down) -
+  # Kubernetes annotation values are strings and an unquoted true is rejected at
+  # apply time. This is what lets kubernetes.tf's on-demand NodePool run
+  # WhenEmptyOrUnderutilized: the annotation exempts these specific pods' nodes
+  # from voluntary consolidation instead of exempting the whole pool the way
+  # WhenEmpty used to. Verified against the vendored subchart values (helm/chart
+  # Chart.yaml pins): opensearch 3.4.0 has a top-level `podAnnotations`, kube-
+  # prometheus-stack 82.8.0's Prometheus/Alertmanager CRs take
+  # `{prometheus,alertmanager}Spec.podMetadata.annotations`, grafana 11.2.3 and
+  # metrics-server 3.13.1 and prometheus-adapter 5.3.0 all have a top-level
+  # `podAnnotations` consumed by their Deployment templates.
+  #
+  # Rollout note: this changes every one of these pod templates, so each env
+  # rolls opensearch, prometheus, alertmanager and the customer grafana once -
+  # a real EBS detach/reattach and a search/metrics gap, the same event the
+  # annotation exists to stop happening again - the first time that env takes
+  # the infra_version bump carrying this change. Not a background no-op;
+  # sequence it per env like any other stateful rollout (dev-min/qa first).
+  #
+  # Floor: a pod carrying this annotation pins its node against consolidation
+  # for as long as the pod lives there, so these six workloads set a practical
+  # floor of roughly 2 on-demand nodes per env - consolidation can shrink
+  # everything else on the pool, it cannot repack these onto fewer nodes.
+  do_not_disrupt_annotation = { "karpenter.sh/do-not-disrupt" = "true" }
   app_stateful_scheduling = {
     for k, v in {
       opensearch = {
-        nodeSelector = local.stateful_node_selector
-        tolerations  = local.stateful_tolerations
+        nodeSelector   = local.stateful_node_selector
+        tolerations    = local.stateful_tolerations
+        podAnnotations = local.do_not_disrupt_annotation
       }
       "kube-prometheus-stack" = {
         prometheus = { prometheusSpec = {
           nodeSelector = local.stateful_node_selector
           tolerations  = local.stateful_tolerations
+          podMetadata  = { annotations = local.do_not_disrupt_annotation }
         } }
         alertmanager = { alertmanagerSpec = {
           nodeSelector = local.stateful_node_selector
           tolerations  = local.stateful_tolerations
+          podMetadata  = { annotations = local.do_not_disrupt_annotation }
         } }
       }
       # The customer dashboards Grafana (top-level `grafana` key; the kps ops grafana
       # is emptyDir-only and stays on spot). Deep-merged below - base sets env and
       # secret mounts under the same key.
       grafana = {
-        nodeSelector = local.stateful_node_selector
-        tolerations  = local.stateful_tolerations
+        nodeSelector   = local.stateful_node_selector
+        tolerations    = local.stateful_tolerations
+        podAnnotations = local.do_not_disrupt_annotation
       }
       # Not EBS-backed, but the HPA control plane: metrics-server serves metrics.k8s.io
       # and prometheus-adapter serves external.metrics.k8s.io, and both are single
       # replica. On the spot pool their consolidation churn left every HPA computing on
       # stale/absent metrics (m3-usac: FailedGetExternalMetric x45 over 5d, 30-min
       # metric gaps). A PDB is the wrong tool at 1 replica (it only delays the eviction
-      # until the force-delete); rare-disruption placement is the protection, same as
-      # the volumes above. Deep-merged below - base sets args under metrics-server.
+      # until the force-delete); do-not-disrupt is the protection, same as the volumes
+      # above - now that the pool itself is WhenEmptyOrUnderutilized, these two need
+      # their own pod-level exclusion or the exact m3-usac incident reproduces on
+      # every consolidation pass. Deep-merged below - base sets args under metrics-server.
       "metrics-server" = {
-        nodeSelector = local.stateful_node_selector
-        tolerations  = local.stateful_tolerations
+        nodeSelector   = local.stateful_node_selector
+        tolerations    = local.stateful_tolerations
+        podAnnotations = local.do_not_disrupt_annotation
       }
       "prometheus-adapter" = {
-        nodeSelector = local.stateful_node_selector
-        tolerations  = local.stateful_tolerations
+        nodeSelector   = local.stateful_node_selector
+        tolerations    = local.stateful_tolerations
+        podAnnotations = local.do_not_disrupt_annotation
+        # Was running with zero requests fleet-wide (5+ envs confirmed live), which
+        # put it in BestEffort QoS and made it invisible to Karpenter's bin-packing
+        # math - it occupied a node slot for free and was first in line for
+        # eviction under node pressure, the opposite of what the on-demand pin was
+        # for. Values are modest and honest: measured actual usage across the
+        # fleet is well under this, so the request just makes the pod visible to
+        # bin-packing rather than reserving real headroom.
+        resources = {
+          requests = {
+            cpu    = "25m"
+            memory = "128Mi"
+          }
+        }
       }
     } : k => v if var.cloud == "aws"
   }

--- a/terraform/logical/flux.tf
+++ b/terraform/logical/flux.tf
@@ -430,7 +430,7 @@ locals {
         resources = {
           requests = {
             cpu    = "25m"
-            memory = "128Mi"
+            memory = "64Mi"
           }
         }
       }

--- a/terraform/logical/kubernetes.tf
+++ b/terraform/logical/kubernetes.tf
@@ -446,15 +446,39 @@ resource "kubernetes_manifest" "nodepool_on_demand" {
         )
       }
       disruption = {
-        # WhenEmpty, not WhenEmptyOrUnderutilized: this pool exists for workloads
-        # that are expensive to move - the on-demand-pinned app tier and (via the
-        # values CPI sets on the monitoring/search subcharts) every EBS-backed
-        # singleton. Underutilization-driven bin-packing was detaching and
-        # re-attaching 50Gi volumes on routine 60-second consolidation passes,
-        # and every forced reschedule re-rolls the AZ-capacity dice. These nodes
-        # now go away only when empty, on AMI drift, or at the 336h expiry.
-        consolidationPolicy = "WhenEmpty"
-        consolidateAfter    = "1m"
+        # Was WhenEmpty pool-wide: this pool hosts the on-demand-pinned app tier
+        # and (via the values CPI sets on the monitoring/search subcharts) every
+        # EBS-backed singleton. Underutilization-driven bin-packing was detaching
+        # and re-attaching 50Gi volumes on routine 60-second consolidation
+        # passes, and every forced reschedule re-rolled the AZ-capacity dice for
+        # zone-pinned PVCs - so the whole pool was exempted from bin-packing to
+        # protect four pods.
+        #
+        # That protection now lives on the pods instead of the pool: opensearch,
+        # prometheus, alertmanager, the customer grafana, metrics-server and
+        # prometheus-adapter all carry `karpenter.sh/do-not-disrupt: "true"`
+        # (flux.tf, local.app_stateful_scheduling), the same mechanism already
+        # proven on helm-controller below. A node hosting one of those pods is
+        # still skipped by consolidation; every other node in the pool - the
+        # ones with no such pod, sitting empty or near-empty - is repacked
+        # normally. consolidateAfter=5m (not the spot pool's 1m) so a pod that's
+        # mid-reschedule doesn't trigger a repack on the churn itself; the 1m
+        # cadence on spot was part of what made the first WhenEmptyOrUnderutilized
+        # attempt on this pool noisy.
+        #
+        # Consequence worth stating plainly: a do-not-disrupt pod's node is
+        # ineligible for VOLUNTARY consolidation for as long as that pod lives
+        # there (same boundary as helm-controller below - drift and expiry
+        # still force through eventually, bounded by the NodeClaim's
+        # terminationGracePeriod; only spot interruption/repair/manual delete
+        # are irrelevant here since this is the on-demand pool). The six
+        # annotated workloads pack onto roughly two nodes per env at current
+        # request sizes (opensearch's 3Gi request alone fills most of one
+        # 8GiB node), so that sets a practical floor of about 2 on-demand
+        # nodes per env - consolidation can shrink everything else on the
+        # pool, but it cannot repack those six onto fewer nodes on its own.
+        consolidationPolicy = "WhenEmptyOrUnderutilized"
+        consolidateAfter    = "5m"
       }
       weight = 10
     }

--- a/terraform/logical/kubernetes.tf
+++ b/terraform/logical/kubernetes.tf
@@ -468,9 +468,10 @@ resource "kubernetes_manifest" "nodepool_on_demand" {
         #
         # Consequence worth stating plainly: a do-not-disrupt pod's node is
         # ineligible for VOLUNTARY consolidation for as long as that pod lives
-        # there (same boundary as helm-controller below - drift and expiry
-        # still force through eventually, bounded by the NodeClaim's
-        # terminationGracePeriod; only spot interruption/repair/manual delete
+        # there (same boundary as helm-controller below - drift still forces
+        # through eventually, bounded by the NodeClaim's terminationGracePeriod;
+        # no expireAfter is set on this pool, so age alone never recycles it;
+        # only spot interruption/repair/manual delete
         # are irrelevant here since this is the on-demand pool). The six
         # annotated workloads pack onto roughly two nodes per env at current
         # request sizes (opensearch's 3Gi request alone fills most of one
@@ -479,6 +480,10 @@ resource "kubernetes_manifest" "nodepool_on_demand" {
         # pool, but it cannot repack those six onto fewer nodes on its own.
         consolidationPolicy = "WhenEmptyOrUnderutilized"
         consolidateAfter    = "5m"
+        # One node at a time regardless of pool size. The CRD default is 10% which
+        # rounds up to 1 at today's 4-7 nodes/env, but that scales invisibly with
+        # the pool; pin it so a repack wave can never take two nodes at once.
+        budgets = [{ nodes = "1" }]
       }
       weight = 10
     }


### PR DESCRIPTION
## What

The on-demand NodePool ran `consolidationPolicy=WhenEmpty` across the entire pool to protect a handful of EBS-backed singletons (opensearch, prometheus, alertmanager, customer grafana) from volume detach/reattach churn. That protected four pods by exempting every node in the pool from bin-packing, so nodes with none of those pods sat unreclaimed right alongside the ones that needed it.

This flips the pool to `WhenEmptyOrUnderutilized` (`consolidateAfter` bumped to 5m, slower than the spot pool's 1m) and moves the protection onto the pods themselves with `karpenter.sh/do-not-disrupt: "true"`, the same mechanism already running on helm-controller in this file. Annotated: opensearch, prometheus, alertmanager, the customer grafana, metrics-server, and prometheus-adapter.

metrics-server and prometheus-adapter are included even though they hold no volume: they're single-replica, a PDB at replicas=1 only delays eviction rather than preventing it, and unprotected consolidation churn on them reproduces the m3-usac `FailedGetExternalMetric` incident that got them pinned to on-demand in the first place.

prometheus-adapter also picks up a real `25m`/`128Mi` resource request. It was running BestEffort with nothing set fleet-wide, which made it invisible to Karpenter's bin-packing math and first in line for eviction under node pressure - the opposite of what pinning it was supposed to buy.

Subchart values keys (`podAnnotations`, `prometheusSpec.podMetadata.annotations`, `alertmanagerSpec.podMetadata.annotations`) were checked against the actual vendored chart tarballs pinned in the app chart's `Chart.yaml` (opensearch 3.4.0, kube-prometheus-stack 82.8.0, grafana 11.2.3, metrics-server 3.13.1, prometheus-adapter 5.3.0), not assumed.

## Rollout note

This is not a quiet infra_version bump. Landing it rolls opensearch, prometheus, alertmanager and the customer grafana pod templates once per env - a real EBS volume detach/reattach plus a search and metrics gap for that pod's restart window, the first time each env takes the bump. Sequence it per env like any other stateful change (non-prod first), not as a background default.

## Consolidation floor

A pod carrying `do-not-disrupt` makes its node ineligible for *voluntary* consolidation for as long as the pod lives there (drift and expiry still force through eventually, same boundary as the existing helm-controller annotation). The six annotated workloads pack onto roughly two nodes per env at current request sizes, so that sets a practical floor of about 2 on-demand nodes per env once this lands everywhere - consolidation can shrink everything else on the pool, but it can't repack those six down further on its own.

## Expected savings

$350-490/mo fleet-wide once envs take the infra_version bump, from nodes that current request sizes already make reclaimable but that the pool-wide `WhenEmpty` policy was blocking from ever going away.

## Validation

- `tofu fmt -check` - clean
- `tofu validate` (logical layer, `VAULT_ADDR` set so the provider block resolves without a backend) - passes
- `tflint` - same three pre-existing unrelated warnings as master (unused `aws_ecr_image` data sources), no new findings
- No plan/apply run against real state