### PR TITLE
fix(harness): retry a failed teardown instead of leaking the stack

### DIFF
--- a/live/tests/argo/10-scenario.yaml
+++ b/live/tests/argo/10-scenario.yaml
@@ -241,6 +241,54 @@ spec:
           limits: { memory: 128Mi }
 
     - name: teardown
+      # The shared phase template retries OnError only, which is right for provision and
+      # validate: their non-zero exit IS the verdict the run exists to produce, and
+      # rerunning it burns another hour to report the same thing. Teardown inverts that.
+      # A non-zero exit here is a failed cleanup, not an answer, and the stack it failed
+      # to destroy keeps its VPC against DDVtest's ceiling of 10 until a human notices.
+      # Seven leaked stacks over three days is what that costs. So the retry lives here,
+      # on the exit handler, rather than in the phase library where it would also start
+      # rerunning failed assertions.
+      #
+      # Always, not OnFailure: an exit(1) from terragrunt destroy and an evicted pod
+      # strand the same stack. Both are safe to repeat because teardown reloads the run
+      # manifest from S3 and destroy is convergent.
+      #
+      # Three attempts. The failures worth repeating are AWS-side and clear in minutes (ENI
+      # detach lag, DependencyViolation, an NLB still protected) after the harness has
+      # exhausted its own narrow internal retry. The ones that never clear (a state lock
+      # held by a dead process, expired credentials) fail in seconds, so burning three of
+      # those is cheap. Backoff starts at 2m rather than seconds because destroyModule
+      # already spent its internal retry budget on the fast-transient class before the
+      # phase exited; whatever is left needs AWS minutes.
+      #
+      # maxDuration is measured from the FIRST attempt's start, not per attempt, and it is
+      # NOT the real ceiling. The controller refuses to schedule a retry once the workflow
+      # deadline has passed, and that check has no exit-handler exemption, so
+      # activeDeadlineSeconds above (6h for the whole run) bounds this sequence in practice.
+      # A run that spends 5h in provision and validate leaves teardown about an hour of
+      # retry budget no matter what is written here. 4h is a ceiling for the case where
+      # teardown itself is the thing burning time, not a promise of four hours.
+      #
+      # Bounding it at all matters because the workflow holds harness-semaphore through the
+      # exit handler, so spinning on one of two slots starves the other run against a VPC
+      # ceiling of 10. If this node ends with "Max duration limit exceeded", the budget ran
+      # out on wall clock and the stack needs cleanup-orphans.sh, not another submit.
+      #
+      # This nests inside the shared phase template's own OnError retry
+      # (00-phase-templates.yaml), which covers a pod dying rather than a clean exit(1).
+      # That inner layer is capped at 5m from its first attempt, so in practice it only
+      # catches a pod that dies in the opening minutes; anything later falls through to
+      # this one. Deliberately left alone: widening it would revive OnError retries for
+      # provision and validate too, where a rerun costs 90 minutes to reprint the same
+      # verdict.
+      retryStrategy:
+        limit: '2'
+        retryPolicy: Always
+        backoff:
+          duration: '2m'
+          factor: '2'
+          maxDuration: '4h'
       steps:
         - - name: destroy
             templateRef:

--- a/live/tests/argo/10-scenario.yaml
+++ b/live/tests/argo/10-scenario.yaml
@@ -254,13 +254,20 @@ spec:
       # strand the same stack. Both are safe to repeat because teardown reloads the run
       # manifest from S3 and destroy is convergent.
       #
-      # Three attempts. The failures worth repeating are AWS-side and clear in minutes (ENI
-      # detach lag, DependencyViolation, an NLB still protected) after the harness has
-      # exhausted its own narrow internal retry. The ones that never clear (a state lock
-      # held by a dead process, expired credentials) fail in seconds, so burning three of
-      # those is cheap. Backoff starts at 2m rather than seconds because destroyModule
-      # already spent its internal retry budget on the fast-transient class before the
-      # phase exited; whatever is left needs AWS minutes.
+      # Up to three attempts, and read that as "up to". The failures worth repeating are
+      # AWS-side and clear in minutes (ENI detach lag, DependencyViolation, an NLB still
+      # protected) after the harness has exhausted its own narrow internal retry, so in the
+      # common case all three fit easily. The ones that never clear (a state lock held by a
+      # dead process, expired credentials) fail in seconds, so burning three of those is
+      # cheap. But a teardown that runs near its full 3h deadline gets two attempts, not
+      # three: the second finishes past the window below and the third is never scheduled.
+      # That is accepted rather than fixed by shortening the per-attempt deadline, because
+      # a destroy waiting on a slow RDS deletion is exactly the case where cutting the
+      # attempt short would create the orphan this retry exists to prevent.
+      #
+      # Backoff starts at 2m rather than seconds because destroyModule already spent its
+      # internal retry budget on the fast-transient class before the phase exited; whatever
+      # is left needs AWS minutes.
       #
       # maxDuration is measured from the FIRST attempt's start, not per attempt, and it is
       # NOT the real ceiling. The controller refuses to schedule a retry once the workflow

--- a/live/tests/argo/README.md
+++ b/live/tests/argo/README.md
@@ -60,6 +60,16 @@ spot reclaim, node replacement), which re-entrancy makes safe to repeat. A non-z
 from the harness is a real verdict; retrying it would burn another hour and report the same
 thing.
 
+**Teardown is the exception, and carries its own retry.** OnError is correct for provision
+and validate because their exit code IS the verdict. It is wrong for teardown: a non-zero
+exit there is a failed cleanup, not an answer, and the stack it failed to destroy sits on
+DDVtest's books against a ceiling of 10 VPCs until a human notices. So the `teardown` step
+in `10-scenario.yaml` carries its own `retryPolicy: Always`, on the exit-handler template
+rather than the shared one, so provision and validate are untouched. The budget is bounded
+on purpose (three attempts, wall-clock capped): the workflow holds `harness-semaphore`
+through the whole exit handler, so an unbounded retry on one run would starve the other
+slot instead of just leaking a VPC.
+
 **Teardown is an exit handler.** A final step does not run when an earlier step fails,
 which is precisely when teardown matters. And because teardown reads the manifest from S3,
 cleanup is not tied to the process that created the stack: this pod, a retry, or the Phase 4
@@ -85,5 +95,8 @@ measurements.
 - **The recovery scenario.** `cmd/harness` exposes `provision/upgrade/validate/teardown`
   with `--scenario upgrade|fresh`; `RunRecovery` has no phase equivalent, so the `recover`
   and `recover_source` configs stay on `run.sh` until the CLI grows a phase for them.
-- **Cron and PR triggers**, and the backstop janitor. Those are Phase 4. Everything here is
-  submit-driven so far.
+- **The backstop janitor.** Retry exhaustion (or a failure mode retry can't fix, like a
+  half-provisioned upgrade destroying against the wrong ref) still ends in an orphan with
+  nothing sweeping it. `cleanup-orphans.sh` is the right foundation but is not schedulable
+  as written: no staleness gate on the DynamoDB lock release, no self-mutex, needs an
+  interactive SSO session. That is Phase 4.


### PR DESCRIPTION
## The failure

Seven test stacks leaked into the test account over three days and exhausted its 10-VPC
quota. Every run after that failed at provision with `VpcLimitExceeded`, including the
nightly. Traced on `harness-bi-ha-454kh`:

```
destroy(0)   Failed   main: Error (exit code 1)
destroy      Failed   Max duration limit exceeded
```

## Why

`00-phase-templates.yaml` defines one shared `run` template used by every phase, carrying
`retryPolicy: OnError` with `backoff.maxDuration: 5m`.

**OnError is correct there and this PR does not change it.** For provision and validate a
non-zero exit is the verdict the run exists to produce, and rerunning burns an hour to
reprint it. The comment in that file argues it well.

The defect is that teardown inherits it. A non-zero exit from teardown is not a verdict, it
is a failed cleanup, and the stack it failed to destroy holds a VPC until a human notices.
Nothing sweeps it afterward, because the backstop janitor is still Phase 4.

## The change

A `retryStrategy` on the `teardown` exit-handler template in `10-scenario.yaml`. Provision
and validate are untouched because their code path is untouched.

- `retryPolicy: Always` rather than `OnFailure`: an `exit 1` and an evicted pod strand the
  same stack. `Teardown()` reloads the run manifest from S3 on every call and destroys
  convergently, so repeating it is safe.
- Three attempts, backoff starting at 2m: `destroyModule` has already spent its internal
  retry budget on the fast-transient class before the phase exits, so what remains needs
  AWS minutes, not seconds.
- Bounded on purpose. The workflow holds `harness-semaphore` through the exit handler, so
  an unbounded retry starves the other of two slots against a 10-VPC ceiling.

## What the comment is careful about

`maxDuration` is **not** the real ceiling. The controller will not schedule a retry once the
workflow deadline has passed, and that check has no exit-handler exemption, so
`activeDeadlineSeconds` (6h for the whole run) bounds this in practice. A run that spends 5h
upstream leaves teardown roughly an hour of retry budget regardless. The comment says so
rather than implying a guarantee the mechanism does not provide.

## Deliberately not included

- **Raising the shared template's `maxDuration` from 5m.** It is measured from the first
  attempt's start, so at 5m the OnError retry is effectively unreachable for any phase.
  Real, but fixing it revives OnError retries for provision and validate, and this file
  documents an unverified `archiveLogs` canary whose failure marks a node `Errored`. That
  would turn one failed log upload into three 90-minute provision reruns, each holding a
  semaphore slot. Wrong change to bundle into this one.
- **Reordering `AppliedRef` before the apply in `phases.go`.** A failed apply leaves real
  resources while the manifest still records the previous ref, so teardown can destroy
  against the wrong code. Also real, also out of scope here, and `Upgrade()` has the same
  bug so a fix touching only `Provision()` would be half a fix.

Both deserve their own PRs.

## Verification

`argo lint --offline live/tests/argo/` passes. The retry semantics were traced against the
v4.0.8 controller source rather than assumed, which is where the `maxDuration`-vs-workflow-
deadline interaction above came from.