### PR TITLE
fix(harness): track the current chart, floor 2.7.2 for v8.14.0

### DIFF
--- a/live/tests/matrix.yaml
+++ b/live/tests/matrix.yaml
@@ -18,16 +18,29 @@ defaults:
 version_defaults:
   image_tag: "3625f3c7a3fe9bd3fb87b03a23a4cbb683d44ded.11"   # what mpc-dev-min-logical runs; .8 was three builds stale
   nextjs_tag: "2.23.0"
-  chart_version: "2.6.0"  # Track the current chart so a run validates the pairing a real deploy
-                           # would get. The floor moved to 2.6.0 for CPI >= 8.12: the grafana_primary
-                           # DB bootstrap left bi.tf for the chart's grafana-db-init hook, and the
-                           # dashboards Grafana's password secret is now chart-rendered
-                           # (dozuki-grafana-db); an older chart on a newer CPI leaves both missing.
-                           # (Earlier floor for the same reason: 1.18.0 / v7.17.0 - NLB TGBs #278,
-                           # frontegg DB-create + ztunnel PodMonitor #277.) Hook templates are gated
-                           # on values only newer CPI passes, so this chart stays safe on older
-                           # baseline refs. Bump this when the chart releases, or the harness
-                           # quietly tests a pairing nobody actually runs.
+  chart_version: "2.10.0"  # Track the CURRENT chart so a run validates the pairing a real deploy
+                           # would get. This sits ahead of the fleet (2.8.x today) on purpose: the
+                           # harness exists to find a bad pairing before an env does, so it tracks
+                           # the newest published chart rather than the one already rolled out.
+                           #
+                           # HARD FLOOR 2.7.2 as of CPI v8.14.0. v8.14.0 carries #441
+                           # (3d619d5), which drops vault_kv_secret_v2.smtp via
+                           # removed{destroy=false}. That leaves an EXISTING env's Vault value
+                           # alone but never creates one for a NEW env, and a chart below 2.7.2
+                           # reads that path with bare dot access, so the whole
+                           # dozuki-infra-credentials ExternalSecret aborts (db_host, db_user,
+                           # cache, sentry, not just smtp), app pods never start, and Envoy
+                           # answers 503 forever while terraform reports success. helm #221
+                           # (50a6ab8, first in chart-v2.7.2) tolerates the absent path. Being
+                           # pinned at 2.6.0 is what made every v8.14.0 provision fail.
+                           #
+                           # Earlier floors, same shape: 2.6.0 for CPI >= 8.12 (grafana_primary DB
+                           # bootstrap moved from bi.tf to the chart's grafana-db-init hook, and
+                           # the dashboards Grafana password became chart-rendered); 1.18.0 /
+                           # v7.17.0 (NLB TGBs #278, frontegg DB-create + ztunnel PodMonitor #277).
+                           # Hook templates are gated on values only newer CPI passes, so this
+                           # chart stays safe on older baseline refs. Bump this when the chart
+                           # releases, or the harness quietly tests a pairing nobody runs.
   image_repository: "069174876992.dkr.ecr.us-east-1.amazonaws.com"
 
 # Per-ref OVERRIDES — only keys that DIFFER from version_defaults need to be here.


### PR DESCRIPTION
## The failure

Every harness run on v8.14.0 fails provision validation with a 503 that never clears:

```
provision failed: provision validation: endpoint https://<stack>.dozuki.cloud
not healthy after 120 attempts: status 503
```

Terraform reports success first (`Apply complete! Resources: 66 added`), so this looks like
an app problem rather than a version problem.

## It is a clean version boundary, not a flake

Note that the provision phase deploys `from-ref = auto:latest`, **not** the workflow's
`to-ref` parameter. `auto:latest` flipped from v8.13.0 to v8.14.0 between 00:38Z and 00:58Z
on 2026-08-05:

| run | provisioned | result |
|---|---|---|
| `min-default-hq7c2` | v8.13.0 | validated |
| `min-default-2zr7x` | **v8.14.0** | 503 x120 |
| `bi-ha-j58s7` | **v8.14.0** | 503 x120 |

Every v8.13.0 provision that cleared the VPC quota was green. Zero v8.14.0 provisions have
succeeded, in any config, including `min_default`, the lightest one in the matrix.

## Root cause

v8.14.0 carries #441 (`3d619d5`), which replaces `vault_kv_secret_v2.smtp` with
`removed { destroy = false }`.

That commit's safety argument is that it "only forgets Terraform state, it does not touch
Vault". True for an **existing** env. For a **new** one there is no prior value to leave
alone, so `secret/<customer>/<env>/smtp` is simply never created.

A chart below 2.7.2 reads that path with bare dot access, and its own template comment says
"absent is not blank ... or the sync errors". So the entire `dozuki-infra-credentials`
ExternalSecret aborts, taking `db_host`, `db_user`, cache and sentry with it, not just SMTP.
App pods cannot start, and Envoy answers 503 "no healthy upstream" indefinitely. Terraform
still reports success because `kubectl_manifest.dozuki_helmrelease` returns in 0s.

helm #221 (`50a6ab8`, first released in **chart-v2.7.2**) tolerates the absent path. The
harness was pinned at 2.6.0, below that floor, so it could not provision at all.

**Blast radius beyond the harness: any fresh install on v8.14.0 with a chart below 2.7.2
fails the same way.** Existing envs are unaffected, which is why nothing else caught this.

## Why 2.10.0 rather than the fleet's 2.8.x

The harness exists to find a bad pairing before an env does, so it tracks the newest
published chart rather than the one already rolled out. The file's own comment already said
to bump on every chart release "or the harness quietly tests a pairing nobody actually
runs", which is what happened here.

## Not included, worth its own PR

`validateStack` calls `CheckEndpoints` **before** `AwaitHelmReleaseReady` and returns on
failure, so the Flux verdict is never collected. `AwaitHelmReleaseReady` was added
specifically so a broken install "fails in seconds with Flux's own message", but it sits
below the 60-minute HTTP poll and never runs. That is why this failure was opaque rather
than why it happened, so it is a separate fix.

## Verification

`matrix.yaml` parses, `go build ./...` and `go test ./harness/...` pass. Not yet exercised
against a real run; the nightly will be the proof.