### PR TITLE
fix(logical): stop istiod replicas colocating on one node

### DIFF
--- a/terraform/logical/istio.tf
+++ b/terraform/logical/istio.tf
@@ -98,10 +98,22 @@ resource "helm_release" "istiod" {
       # on the custom pools it untaints.
       nodeSelector = { "karpenter.sh/nodepool" = "system" }
       tolerations  = [{ key = "CriticalAddonsOnly", operator = "Exists" }]
+      # DoNotSchedule, not ScheduleAnyway: soft spread let Karpenter pack both
+      # autoscaleMin=2 replicas onto one node (confirmed live on dev-min and
+      # gov-parker), which under STRICT mTLS takes the untaint controller and
+      # the mesh CA down together on that single node's loss - on gov the SCP
+      # denies ec2:TerminateInstances, so recovery there is a manual NodeClaim
+      # delete. This does not deadlock the built-in system pool: unlike the
+      # custom spot/on-demand pools above, the system pool carries no
+      # cni.istio.io/not-ready startupTaint (that taint is added by this repo
+      # only to the pools it defines, kubernetes.tf), so a Pending 2nd replica
+      # is bog-standard Karpenter scale-from-zero - it gets a fresh node with
+      # nothing blocking the schedule. Verified by rendering this chart+values
+      # with helm template: the constraint lands on the Deployment as written.
       topologySpreadConstraints = [{
         maxSkew           = 1
         topologyKey       = "kubernetes.io/hostname"
-        whenUnsatisfiable = "ScheduleAnyway"
+        whenUnsatisfiable = "DoNotSchedule"
         labelSelector     = { matchLabels = { app = "istiod" } }
       }]
       # Chart defaults are 500m/2Gi requests. Observed usage across 5 healthy

--- a/terraform/logical/istio.tf
+++ b/terraform/logical/istio.tf
@@ -98,20 +98,27 @@ resource "helm_release" "istiod" {
       # on the custom pools it untaints.
       nodeSelector = { "karpenter.sh/nodepool" = "system" }
       tolerations  = [{ key = "CriticalAddonsOnly", operator = "Exists" }]
-      # DoNotSchedule, not ScheduleAnyway: soft spread let Karpenter pack both
-      # autoscaleMin=2 replicas onto one node (confirmed live on dev-min and
-      # gov-parker), which under STRICT mTLS takes the untaint controller and
-      # the mesh CA down together on that single node's loss - on gov the SCP
-      # denies ec2:TerminateInstances, so recovery there is a manual NodeClaim
-      # delete. This does not deadlock the built-in system pool: unlike the
-      # custom spot/on-demand pools above, the system pool carries no
-      # cni.istio.io/not-ready startupTaint (that taint is added by this repo
-      # only to the pools it defines, kubernetes.tf), so a Pending 2nd replica
-      # is bog-standard Karpenter scale-from-zero - it gets a fresh node with
-      # nothing blocking the schedule. Verified by rendering this chart+values
-      # with helm template: the constraint lands on the Deployment as written.
+      # DoNotSchedule + minDomains 2, not ScheduleAnyway: on a one-node system
+      # pool (dev-min, m3-qa, m3-usac, m3-emea today) the nodeSelector above
+      # restricts eligible domains to that single node, so with the default
+      # minDomains=1 the observed-domain count already meets the floor - the
+      # global minimum used for skew is just that one node's own count, skew
+      # is always 0, and ANY number of istiod pods there satisfies maxSkew 1.
+      # ScheduleAnyway never had a second node to prefer; it wasn't a
+      # preference Karpenter was overriding. minDomains 2 (GA since k8s 1.30,
+      # fleet runs 1.35.6) makes Pod Topology Spread treat a missing second
+      # domain as 0 pods, so the second replica goes Pending until Karpenter
+      # provisions a second system node - ordinary scale-from-zero, since the
+      # system pool carries none of the custom pools' cni.istio.io/not-ready
+      # startupTaint (that taint is only added to the pools this repo defines,
+      # kubernetes.tf). Under STRICT mTLS this matters because one node
+      # hosting both replicas is a single point of failure for the untaint
+      # controller and the mesh CA together; on gov the SCP denies
+      # ec2:TerminateInstances, so recovery from a stuck node there is a
+      # manual NodeClaim delete.
       topologySpreadConstraints = [{
         maxSkew           = 1
+        minDomains        = 2
         topologyKey       = "kubernetes.io/hostname"
         whenUnsatisfiable = "DoNotSchedule"
         labelSelector     = { matchLabels = { app = "istiod" } }


### PR DESCRIPTION
## Problem

istiod's topology spread constraint (`pilot.topologySpreadConstraints`, terraform/logical/istio.tf) used `whenUnsatisfiable: ScheduleAnyway` (a soft preference) and, on a system pool with exactly one node, that preference had nothing to prefer over - both `autoscaleMin=2` replicas land there today. Confirmed live: every one-system-node env (dev-min, m3-qa, m3-usac, m3-emea) has both istiod pods colocated on a single node right now; the two-node envs (gca, apac, latam) already spread on their own without help from this constraint.

Under STRICT mTLS, losing that one node takes down the untaint controller (`taint.enabled`, which un-taints fresh custom-pool nodes) and the mesh cert authority together. On gov the account SCP denies `ec2:TerminateInstances`, so recovery from a stuck/degraded node is a manual NodeClaim delete, not a simple instance replace. sharedgov's system pool currently has zero nodes and would start at exactly one - the case this fix closes.

## Fix

Two changes to the same `topologySpreadConstraints` entry:

1. `whenUnsatisfiable: ScheduleAnyway` → `DoNotSchedule`.
2. Add `minDomains: 2` (GA since Kubernetes 1.30; the fleet runs 1.35.6).

`DoNotSchedule` alone is not sufficient and was the first thing tried here - worth spelling out why, since it's not obvious. With `nodeAffinityPolicy: Honor` (the default), the `pilot.nodeSelector` above restricts eligible topology domains to system-pool nodes. On a pool with one node there is exactly one eligible domain. `minDomains` defaults to 1, so the observed-domain count (1) already meets that floor - Pod Topology Spread computes the "global minimum" as that one domain's own pod count, so skew is always 0 no matter how many istiod pods land there. `DoNotSchedule` was never being violated; there was no second domain to compare against.

`minDomains: 2` changes that: when the actual domain count (1) is below `minDomains` (2), Pod Topology Spread treats the missing domain as having 0 matching pods. Now scheduling a second replica into the same single domain produces skew 2, which exceeds `maxSkew: 1` and is rejected under `DoNotSchedule` - the second replica goes Pending until Karpenter provisions a second system node. That's what actually produces a second domain to spread across.

Considered a 2-node floor on the system NodePool instead - rejected, it's an always-on cost with no offsetting benefit once the spread constraint genuinely enforces spread.

The chart's PDB (`global.defaultPodDisruptionBudget.enabled = true`, `minAvailable: 1`) was already set in this file before this change - no PDB gap to close here.

## Bootstrap safety (why the Pending replica doesn't deadlock)

istiod runs on the **built-in EKS Auto Mode system pool** (`compute_config.node_pools = ["system"]` in terraform/physical/eks.tf), not one of the custom Karpenter pools this repo defines. The `cni.istio.io/not-ready` startupTaint that could plausibly cause a chicken-and-egg deadlock is only applied by this repo to the custom `spot`/`on-demand` NodePools in terraform/logical/kubernetes.tf - the system pool carries no such taint. So the Pending second replica triggers ordinary Karpenter scale-from-zero: it provisions a fresh system node and schedules there, same as any other Pending pod on that pool. dev-min's system NodePool has no `spec.limits` set, so nothing in this repo caps that scale-out.

## Rollout behavior on existing STRICT envs

The rendered Deployment strategy is `maxSurge: 100%` / `maxUnavailable: 25%`. At `replicas: 2` that's surge 2 / unavailable 0: a rolling update creates 2 new pods before removing any old one. On a one-node system env, the surge pods can't both satisfy the new spread constraint on that single existing domain, so they park Pending until Karpenter adds a second system node - transiently 3 system nodes until consolidation reclaims one, but the 2 old replicas keep serving the whole time. The PDB (`minAvailable: 1`) gates *eviction*, not the surge/create side of a rolling update, so nothing wedges. Worst case here is a slower-than-usual rollout on one-node envs, not an outage.

## Scope and rollout

- Applies uniformly to every env through the shared `terraform/logical/istio.tf` - inert (mesh not installed / `local.mesh_installed = false`) wherever the mesh is off.
- The seven envs already at STRICT are equally exposed to this bug today; applying this reschedules/adds istiod capacity, not an outage - istiod is control plane only in ambient (config push, cert rotation), not on the data path; ztunnel keeps serving existing mTLS sessions through it regardless.
- Should land before parker and sharedgov take their STRICT rungs (infra-live #232 / #233 reference this PR).
- **Open verification item:** gov-parker's current system-pool node count could not be confirmed for this PR (the `govcloudparkerhannafan` SSO session had expired). Working assumption is one node today, same as dev-min/m3-qa/m3-usac/m3-emea - if so, this fix is exactly what fixes gov-parker's live colocation, and that should be reconfirmed once the run applies there.

## Precedent

Same shape of fix as the envoy gateway proxy colocation outage, closed by the proxy PDB + topology spread work in the dozuki chart (`chart/templates/gateway/envoy-proxy-pdb.yaml`, `chart/values.yaml` `gateway.proxy.spread`/`pdb`). That fix paired a topology spread with `maxUnavailable: 1` since the proxy's on-demand toleration widens its schedulable set past its 2-node spot pool; istiod doesn't carry an analogous toleration trick, so `DoNotSchedule` + `minDomains: 2` is the direct equivalent for a control-plane component that must not share a node with its own replica, on pools as small as one node.

## Validation

- `tofu init -backend=false` + `tofu validate` in `terraform/logical`: clean (only the pre-existing, accepted `vault_kv_secret_v2` deprecation warning).
- `tofu fmt -check` on the changed file: no diff.
- Rendered the istiod chart (`helm template istiod istio/istiod --version 1.30.3`) with the same values this file produces (`pilot.topologySpreadConstraints` with `maxSkew: 1`, `minDomains: 2`, `whenUnsatisfiable: DoNotSchedule`, `autoscaleMin: 2`, the system nodeSelector/toleration): confirmed `minDomains: 2` lands on the Deployment pod spec exactly as configured, the existing `global.defaultPodDisruptionBudget.enabled: true` still renders a `minAvailable: 1` PDB, and the Deployment's rolling-update strategy is `maxSurge: 100%` / `maxUnavailable: 25%` as described above.
- Pre-commit hooks (terraform fmt, tflint, terraform-docs) passed on both commits.