### PR TITLE
fix(physical): DR bucket backfill on creation, replication metrics + alarm, DR-region access logs

### DIFF
--- a/terraform/physical/README.md
+++ b/terraform/physical/README.md
@@ -69,7 +69,6 @@
 | [aws_cloudwatch_metric_alarm.bi_dms_capacity_saturated](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
 | [aws_cloudwatch_metric_alarm.bi_dms_cpu_saturated](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
 | [aws_cloudwatch_metric_alarm.dr_replication_deadman](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
-| [aws_cloudwatch_metric_alarm.dr_replication_failed](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
 | [aws_cloudwatch_metric_alarm.dr_s3_replication_failed](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
 | [aws_cloudwatch_metric_alarm.dr_s3_replication_latency](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
 | [aws_cloudwatch_metric_alarm.nlb_healthy_hosts_critical](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
@@ -153,6 +152,7 @@
 | [aws_s3_bucket_cors_configuration.guide_documents](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_cors_configuration) | resource |
 | [aws_s3_bucket_cors_configuration.guide_images](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_cors_configuration) | resource |
 | [aws_s3_bucket_lifecycle_configuration.dr_guide_buckets](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_lifecycle_configuration) | resource |
+| [aws_s3_bucket_lifecycle_configuration.dr_logging_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_lifecycle_configuration) | resource |
 | [aws_s3_bucket_lifecycle_configuration.guide_buckets](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_lifecycle_configuration) | resource |
 | [aws_s3_bucket_lifecycle_configuration.logging_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_lifecycle_configuration) | resource |
 | [aws_s3_bucket_logging.dr_guide_buckets](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_logging) | resource |
@@ -171,6 +171,7 @@
 | [aws_s3_bucket_replication_configuration.dr](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_replication_configuration) | resource |
 | [aws_s3_bucket_replication_configuration.replication](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_replication_configuration) | resource |
 | [aws_s3_bucket_server_side_encryption_configuration.dr_guide_buckets](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_server_side_encryption_configuration) | resource |
+| [aws_s3_bucket_server_side_encryption_configuration.dr_logging_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_server_side_encryption_configuration) | resource |
 | [aws_s3_bucket_server_side_encryption_configuration.guide_buckets_encryption](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_server_side_encryption_configuration) | resource |
 | [aws_s3_bucket_server_side_encryption_configuration.logging_bucket_encryption](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_server_side_encryption_configuration) | resource |
 | [aws_s3_bucket_versioning.dr_guide_buckets](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_versioning) | resource |

--- a/terraform/physical/README.md
+++ b/terraform/physical/README.md
@@ -171,7 +171,6 @@
 | [aws_s3_bucket_replication_configuration.dr](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_replication_configuration) | resource |
 | [aws_s3_bucket_replication_configuration.replication](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_replication_configuration) | resource |
 | [aws_s3_bucket_server_side_encryption_configuration.dr_guide_buckets](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_server_side_encryption_configuration) | resource |
-| [aws_s3_bucket_server_side_encryption_configuration.dr_logging_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_server_side_encryption_configuration) | resource |
 | [aws_s3_bucket_server_side_encryption_configuration.guide_buckets_encryption](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_server_side_encryption_configuration) | resource |
 | [aws_s3_bucket_server_side_encryption_configuration.logging_bucket_encryption](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_server_side_encryption_configuration) | resource |
 | [aws_s3_bucket_versioning.dr_guide_buckets](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_versioning) | resource |

--- a/terraform/physical/README.md
+++ b/terraform/physical/README.md
@@ -69,6 +69,7 @@
 | [aws_cloudwatch_metric_alarm.bi_dms_capacity_saturated](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
 | [aws_cloudwatch_metric_alarm.bi_dms_cpu_saturated](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
 | [aws_cloudwatch_metric_alarm.dr_replication_deadman](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
+| [aws_cloudwatch_metric_alarm.dr_replication_failed](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
 | [aws_cloudwatch_metric_alarm.dr_s3_replication_failed](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
 | [aws_cloudwatch_metric_alarm.dr_s3_replication_latency](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
 | [aws_cloudwatch_metric_alarm.nlb_healthy_hosts_critical](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
@@ -145,6 +146,7 @@
 | [aws_route53_zone.mimir_private](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_zone) | resource |
 | [aws_route53_zone.vault_private](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_zone) | resource |
 | [aws_s3_bucket.dr_guide_buckets](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
+| [aws_s3_bucket.dr_logging_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
 | [aws_s3_bucket.guide_buckets](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
 | [aws_s3_bucket.logging_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
 | [aws_s3_bucket_acl.logging_bucket_acl](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_acl) | resource |
@@ -153,14 +155,17 @@
 | [aws_s3_bucket_lifecycle_configuration.dr_guide_buckets](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_lifecycle_configuration) | resource |
 | [aws_s3_bucket_lifecycle_configuration.guide_buckets](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_lifecycle_configuration) | resource |
 | [aws_s3_bucket_lifecycle_configuration.logging_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_lifecycle_configuration) | resource |
+| [aws_s3_bucket_logging.dr_guide_buckets](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_logging) | resource |
 | [aws_s3_bucket_logging.guide_buckets_logging](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_logging) | resource |
 | [aws_s3_bucket_ownership_controls.dr_guide_pdf_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_ownership_controls) | resource |
 | [aws_s3_bucket_ownership_controls.guide_pdf_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_ownership_controls) | resource |
 | [aws_s3_bucket_ownership_controls.logging_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_ownership_controls) | resource |
 | [aws_s3_bucket_policy.dr_guide_buckets](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |
+| [aws_s3_bucket_policy.dr_logging_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |
 | [aws_s3_bucket_policy.guide_buckets](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |
 | [aws_s3_bucket_policy.logging_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |
 | [aws_s3_bucket_public_access_block.dr_guide_buckets](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block) | resource |
+| [aws_s3_bucket_public_access_block.dr_logging_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block) | resource |
 | [aws_s3_bucket_public_access_block.guide_buckets_acl_block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block) | resource |
 | [aws_s3_bucket_public_access_block.logging_bucket_acl_block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block) | resource |
 | [aws_s3_bucket_replication_configuration.dr](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_replication_configuration) | resource |
@@ -169,6 +174,7 @@
 | [aws_s3_bucket_server_side_encryption_configuration.guide_buckets_encryption](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_server_side_encryption_configuration) | resource |
 | [aws_s3_bucket_server_side_encryption_configuration.logging_bucket_encryption](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_server_side_encryption_configuration) | resource |
 | [aws_s3_bucket_versioning.dr_guide_buckets](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_versioning) | resource |
+| [aws_s3_bucket_versioning.dr_logging_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_versioning) | resource |
 | [aws_s3_bucket_versioning.guide_buckets_versioning](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_versioning) | resource |
 | [aws_s3_bucket_versioning.logging_bucket_versioning_block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_versioning) | resource |
 | [aws_secretsmanager_secret.aurora_migration_credentials](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret) | resource |
@@ -204,6 +210,7 @@
 | [null_resource.create_dms_access_for_tasks_role](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [null_resource.create_dms_cloudwatch_role](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [null_resource.create_dms_vpc_role](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
+| [null_resource.dr_replication_job_init](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [null_resource.s3_replication_job_init](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [random_id.aurora_final_snapshot](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
 | [random_password.aurora](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
@@ -216,6 +223,7 @@
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_iam_policy_document.cluster_access](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.dr_guide_buckets_ssl_only](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.dr_logging_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.dr_s3_replication](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.dr_s3_replication_assume](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.eks_worker](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |

--- a/terraform/physical/dr.tf
+++ b/terraform/physical/dr.tf
@@ -651,19 +651,12 @@ resource "aws_s3_bucket_versioning" "dr_logging_bucket" {
   }
 }
 
-resource "aws_s3_bucket_server_side_encryption_configuration" "dr_logging_bucket" {
-  count    = local.dr_enabled ? 1 : 0
-  provider = aws.dr
-
-  bucket = aws_s3_bucket.dr_logging_bucket[0].id
-  rule {
-    apply_server_side_encryption_by_default {
-      kms_master_key_id = aws_kms_key.dr_s3[0].arn
-      sse_algorithm     = "aws:kms"
-    }
-    bucket_key_enabled = true
-  }
-}
+# Deliberately NO SSE-KMS on this bucket, do not "fix" it: AWS requires an
+# access-log destination to use SSE-S3. With SSE-KMS default encryption the
+# log-delivery service principal cannot use the key (it is not an IAM
+# principal the key's root-delegation policy can reach) and AWS warns logs
+# may arrive encrypted with a key you cannot access - the delivery just
+# silently never works. SSE-S3 (the bucket default) is the supported path.
 
 # Same hygiene the primary logging bucket carries: without it a versioned
 # bucket receiving one log record per replicated PUT keeps every noncurrent

--- a/terraform/physical/dr.tf
+++ b/terraform/physical/dr.tf
@@ -365,8 +365,16 @@ data "aws_iam_policy_document" "dr_s3_replication_assume" {
     effect  = "Allow"
     actions = ["sts:AssumeRole"]
     principals {
-      type        = "Service"
-      identifiers = ["s3.amazonaws.com"]
+      type = "Service"
+      # Live CRR assumes this role as s3; Batch Replication assumes it as
+      # batchoperations.s3. Without the second principal every backfill job
+      # submits fine and then fails async on sts:AssumeRole with 0 tasks run
+      # while the apply stays green. Same pair the migration role carries
+      # (s3.tf), partition-aware for the same reason.
+      identifiers = [
+        "s3.${data.aws_partition.current.dns_suffix}",
+        "batchoperations.s3.${data.aws_partition.current.dns_suffix}",
+      ]
     }
   }
 }
@@ -399,10 +407,21 @@ data "aws_iam_policy_document" "dr_s3_replication" {
   }
 
   # Batch job task reports land in the primary-region logging bucket.
+  # PutObject only: the manifest is S3-generated (never read back by this
+  # role), so read access to the fleet's access logs stays off this role.
   statement {
     effect    = "Allow"
-    actions   = ["s3:GetObject", "s3:GetObjectVersion", "s3:PutObject"]
+    actions   = ["s3:PutObject"]
     resources = ["${aws_s3_bucket.logging_bucket.arn}/*"]
+  }
+
+  # The logging bucket defaults to SSE-KMS on the primary S3 key, so the
+  # report write also needs to generate a data key there. Without this the
+  # backfill replicates fine but the completion report never appears.
+  statement {
+    effect    = "Allow"
+    actions   = ["kms:Encrypt", "kms:GenerateDataKey"]
+    resources = distinct(compact([local.s3_kms_key_id, var.s3_kms_key_id]))
   }
 
   statement {
@@ -509,16 +528,18 @@ resource "null_resource" "dr_replication_job_init" {
     aws_s3_bucket_replication_configuration.dr,
   ]
 
+  # Triggers are ONLY the data identity of the pair. A re-fire re-replicates
+  # the whole corpus (the generated manifest has no ObjectReplicationStatuses
+  # filter), so operational parameters must never force one. In particular
+  # aws_profile is empty on Spacelift and set on a local terragrunt run, so
+  # keying on it would re-copy tens of millions of objects every time the two
+  # alternate. Everything the command needs beyond the pair identity is
+  # referenced directly below (legal in creation-time provisioners) so a
+  # change to it never replaces this resource. bucket_prefix means a recreated
+  # DR bucket gets a NEW name, so dr_bucket does change when it matters.
   triggers = {
-    aws_account      = data.aws_caller_identity.current.account_id
-    aws_profile      = var.aws_profile
-    aws_partition    = data.aws_partition.current.partition
-    logging_bucket   = aws_s3_bucket.logging_bucket.arn
-    source_bucket    = aws_s3_bucket.guide_buckets[each.key].bucket
-    replication_role = aws_iam_role.dr_s3_replication[0].arn
-    # Ties the trigger set to the DR bucket's identity so the job re-fires only
-    # if the destination is ever recreated, never on routine applies.
-    dr_bucket = each.value.id
+    source_bucket = aws_s3_bucket.guide_buckets[each.key].bucket
+    dr_bucket     = each.value.id
   }
 
   provisioner "local-exec" {
@@ -527,45 +548,20 @@ resource "null_resource" "dr_replication_job_init" {
     environment = {
       AWS_REGION = data.aws_region.current.region
     }
-    command = "/usr/bin/env bash ./util/create-s3-batch.sh ${self.triggers["logging_bucket"]} ${self.triggers["source_bucket"]} ${self.triggers["replication_role"]} ${self.triggers["aws_account"]} ${self.triggers["aws_partition"]} ${self.triggers["aws_profile"]}"
+    # The leading sleep is for replication-config propagation, a different
+    # wait than the script's IAM sleep: AWS advises waiting a few minutes
+    # after adding or updating a replication configuration before creating a
+    # Batch Replication job with an S3-generated manifest, or the manifest
+    # can come up short against the unpropagated config.
+    command = "sleep 270 && /usr/bin/env bash ./util/create-s3-batch.sh \"${aws_s3_bucket.logging_bucket.arn}\" \"${self.triggers["source_bucket"]}\" \"${aws_iam_role.dr_s3_replication[0].arn}\" \"${data.aws_caller_identity.current.account_id}\" \"${data.aws_partition.current.partition}\" \"${var.aws_profile}\""
   }
 }
 
-# Failed replication operations do not retry forever; once S3 gives up the
-# object silently never reaches DR. Requires the metrics block on the
-# replication rule - before that block existed this metric did not exist, so
-# no alarm was possible. Emitted in the SOURCE region, so this uses the
-# primary-region provider and the standard SNS topic.
-resource "aws_cloudwatch_metric_alarm" "dr_replication_failed" {
-  for_each = aws_s3_bucket.dr_guide_buckets
-
-  alarm_name        = "${local.identifier}-dr-replication-failed-${each.key}"
-  alarm_description = "S3 replication to DR is failing: ${aws_s3_bucket.guide_buckets[each.key].bucket} -> ${each.value.bucket}. Failed operations are NOT retried indefinitely. Diagnose (role policy, KMS, destination), then re-drive the gap with a Batch Replication job (util/create-s3-batch.sh)."
-
-  namespace           = "AWS/S3"
-  metric_name         = "OperationsFailedReplication"
-  statistic           = "Sum"
-  period              = 300
-  evaluation_periods  = 1
-  threshold           = 0
-  comparison_operator = "GreaterThanThreshold"
-
-  # The metric emits datapoints only while there is replication traffic;
-  # absence means "nothing to replicate", not "healthy", so missing data must
-  # not page. Absence-of-parity detection is a separate concern (central
-  # metrics), not expressible as a per-stack CloudWatch alarm without lying.
-  treat_missing_data = "notBreaching"
-
-  dimensions = {
-    SourceBucket      = aws_s3_bucket.guide_buckets[each.key].bucket
-    DestinationBucket = each.value.bucket
-    RuleId            = "dr-${each.key}"
-  }
-
-  alarm_actions = [module.sns.topic_arn]
-  ok_actions    = [module.sns.topic_arn]
-  tags          = local.tags
-}
+# The OperationsFailedReplication alarm for these pairs already exists
+# (monitoring.tf dr_s3_replication_failed) and is in the right region: that is
+# the one replication metric published in the SOURCE region. It has been inert
+# since 2026-06 only because the metrics block above did not exist; enabling
+# metrics is what turns it on. Do not add a second alarm here.
 
 # S3 server access logging can only target a bucket in the SAME region as the
 # source, so the primary logging bucket can never receive the DR buckets' logs
@@ -575,8 +571,8 @@ resource "aws_cloudwatch_metric_alarm" "dr_replication_failed" {
 # Policy-based log delivery only (no ACLs): these buckets are new enough to
 # stay on the BucketOwnerEnforced default.
 #
-// No logging on the logging bucket, same as the primary one - that way lies
-// recursion.
+# No logging on the logging bucket, same as the primary one - that way lies
+# recursion.
 #tfsec:ignore:aws-s3-enable-bucket-logging
 resource "aws_s3_bucket" "dr_logging_bucket" {
   count    = local.dr_enabled ? 1 : 0
@@ -661,6 +657,45 @@ resource "aws_s3_bucket_versioning" "dr_logging_bucket" {
   }
 }
 
+resource "aws_s3_bucket_server_side_encryption_configuration" "dr_logging_bucket" {
+  count    = local.dr_enabled ? 1 : 0
+  provider = aws.dr
+
+  bucket = aws_s3_bucket.dr_logging_bucket[0].id
+  rule {
+    apply_server_side_encryption_by_default {
+      kms_master_key_id = aws_kms_key.dr_s3[0].arn
+      sse_algorithm     = "aws:kms"
+    }
+    bucket_key_enabled = true
+  }
+}
+
+# Same hygiene the primary logging bucket carries: without it a versioned
+# bucket receiving one log record per replicated PUT keeps every noncurrent
+# version forever.
+resource "aws_s3_bucket_lifecycle_configuration" "dr_logging_bucket" {
+  count    = local.dr_enabled ? 1 : 0
+  provider = aws.dr
+
+  bucket = aws_s3_bucket.dr_logging_bucket[0].id
+
+  rule {
+    id     = "finops-hygiene"
+    status = "Enabled"
+
+    filter {}
+
+    abort_incomplete_multipart_upload {
+      days_after_initiation = 7
+    }
+
+    noncurrent_version_expiration {
+      noncurrent_days = 30
+    }
+  }
+}
+
 resource "aws_s3_bucket_logging" "dr_guide_buckets" {
   for_each = aws_s3_bucket.dr_guide_buckets
   provider = aws.dr
@@ -669,4 +704,10 @@ resource "aws_s3_bucket_logging" "dr_guide_buckets" {
 
   target_bucket = aws_s3_bucket.dr_logging_bucket[0].bucket
   target_prefix = "${each.key}/"
+
+  # No implicit graph edge exists to the target bucket's policy, and with
+  # BucketOwnerEnforced (no ACLs) that policy is the ONLY thing authorising
+  # log delivery - without this edge the first apply can enable logging
+  # before delivery is grantable.
+  depends_on = [aws_s3_bucket_policy.dr_logging_bucket]
 }

--- a/terraform/physical/dr.tf
+++ b/terraform/physical/dr.tf
@@ -409,19 +409,13 @@ data "aws_iam_policy_document" "dr_s3_replication" {
   # Batch job task reports land in the primary-region logging bucket.
   # PutObject only: the manifest is S3-generated (never read back by this
   # role), so read access to the fleet's access logs stays off this role.
+  # No KMS grant needed for the report despite the bucket's SSE-KMS default:
+  # AWS writes completion reports with SSE-S3 explicitly, which overrides
+  # the bucket default.
   statement {
     effect    = "Allow"
     actions   = ["s3:PutObject"]
     resources = ["${aws_s3_bucket.logging_bucket.arn}/*"]
-  }
-
-  # The logging bucket defaults to SSE-KMS on the primary S3 key, so the
-  # report write also needs to generate a data key there. Without this the
-  # backfill replicates fine but the completion report never appears.
-  statement {
-    effect    = "Allow"
-    actions   = ["kms:Encrypt", "kms:GenerateDataKey"]
-    resources = distinct(compact([local.s3_kms_key_id, var.s3_kms_key_id]))
   }
 
   statement {

--- a/terraform/physical/dr.tf
+++ b/terraform/physical/dr.tf
@@ -381,15 +381,28 @@ resource "aws_iam_role" "dr_s3_replication" {
 data "aws_iam_policy_document" "dr_s3_replication" {
   count = local.dr_enabled ? 1 : 0
 
+  # PutInventoryConfiguration and InitiateReplication are for the Batch
+  # Replication backfill (null_resource.dr_replication_job_init): the job's
+  # generated manifest is built via an inventory report, and each task calls
+  # InitiateReplication as this role. Same permission set the migration path
+  # needed (s3.tf), where their absence failed every job AccessDenied with 0
+  # tasks run while the apply stayed green.
   statement {
     effect    = "Allow"
-    actions   = ["s3:GetReplicationConfiguration", "s3:ListBucket"]
+    actions   = ["s3:GetReplicationConfiguration", "s3:ListBucket", "s3:PutInventoryConfiguration"]
     resources = [for b in aws_s3_bucket.guide_buckets : b.arn]
   }
   statement {
     effect    = "Allow"
-    actions   = ["s3:GetObjectVersionForReplication", "s3:GetObjectVersionAcl", "s3:GetObjectVersionTagging"]
+    actions   = ["s3:GetObjectVersionForReplication", "s3:GetObjectVersionAcl", "s3:GetObjectVersionTagging", "s3:InitiateReplication", "s3:GetObject"]
     resources = [for b in aws_s3_bucket.guide_buckets : "${b.arn}/*"]
+  }
+
+  # Batch job task reports land in the primary-region logging bucket.
+  statement {
+    effect    = "Allow"
+    actions   = ["s3:GetObject", "s3:GetObjectVersion", "s3:PutObject"]
+    resources = ["${aws_s3_bucket.logging_bucket.arn}/*"]
   }
 
   statement {
@@ -453,6 +466,16 @@ resource "aws_s3_bucket_replication_configuration" "dr" {
       encryption_configuration {
         replica_kms_key_id = aws_kms_key.dr_s3[0].arn
       }
+
+      # Without this block S3 publishes NONE of the four replication metrics
+      # (OperationsFailedReplication, OperationsPendingReplication,
+      # BytesPendingReplication, ReplicationLatency), so no alarm or parity
+      # check is even possible - which is how the fleet ran empty DR buckets
+      # for weeks with every dashboard green. Metrics only, no replication_time:
+      # RTC's contractual 15-minute SLA bills $0.015/GB and nothing requires it.
+      metrics {
+        status = "Enabled"
+      }
     }
   }
 
@@ -461,4 +484,189 @@ resource "aws_s3_bucket_replication_configuration" "dr" {
     aws_s3_bucket_versioning.guide_buckets_versioning,
     aws_s3_bucket_versioning.dr_guide_buckets,
   ]
+}
+
+# Live CRR only carries writes made AFTER the replication rule exists; S3 never
+# retroactively copies what a bucket already holds, and the only supported way
+# to close that gap is a Batch Replication job. Every DR-enabled env stood up
+# before 2026-08 shipped correctly wired but EMPTY destination buckets because
+# that job never ran (found in production: tens of millions of objects with no
+# DR copy across every pair of one fleet). Same fire-once pattern as s3.tf's
+# s3_replication_job_init: the job submits when the DR bucket first exists, and
+# on already-deployed stacks it runs once when this resource first enters
+# state, which is exactly the fleet backfill. The job is async; progress and
+# the task report land under batch-replication-report/ in the logging bucket.
+resource "null_resource" "dr_replication_job_init" {
+  for_each = aws_s3_bucket.dr_guide_buckets
+
+  # The job is authorised by the POLICY, not the role, and S3ReplicateObject
+  # requires the source bucket to already carry its replication config: without
+  # both of these the job submits fine and then fails async (AccessDenied
+  # preparing the manifest / no eligible objects) while the apply stays green.
+  # Same ordering bug the migration path hit on the sharedgov build.
+  depends_on = [
+    aws_iam_role_policy_attachment.dr_s3_replication,
+    aws_s3_bucket_replication_configuration.dr,
+  ]
+
+  triggers = {
+    aws_account      = data.aws_caller_identity.current.account_id
+    aws_profile      = var.aws_profile
+    aws_partition    = data.aws_partition.current.partition
+    logging_bucket   = aws_s3_bucket.logging_bucket.arn
+    source_bucket    = aws_s3_bucket.guide_buckets[each.key].bucket
+    replication_role = aws_iam_role.dr_s3_replication[0].arn
+    # Ties the trigger set to the DR bucket's identity so the job re-fires only
+    # if the destination is ever recreated, never on routine applies.
+    dr_bucket = each.value.id
+  }
+
+  provisioner "local-exec" {
+    # Spacelift workers don't inherit a default region; without this the aws
+    # CLI calls inside the script fail with NoRegion.
+    environment = {
+      AWS_REGION = data.aws_region.current.region
+    }
+    command = "/usr/bin/env bash ./util/create-s3-batch.sh ${self.triggers["logging_bucket"]} ${self.triggers["source_bucket"]} ${self.triggers["replication_role"]} ${self.triggers["aws_account"]} ${self.triggers["aws_partition"]} ${self.triggers["aws_profile"]}"
+  }
+}
+
+# Failed replication operations do not retry forever; once S3 gives up the
+# object silently never reaches DR. Requires the metrics block on the
+# replication rule - before that block existed this metric did not exist, so
+# no alarm was possible. Emitted in the SOURCE region, so this uses the
+# primary-region provider and the standard SNS topic.
+resource "aws_cloudwatch_metric_alarm" "dr_replication_failed" {
+  for_each = aws_s3_bucket.dr_guide_buckets
+
+  alarm_name        = "${local.identifier}-dr-replication-failed-${each.key}"
+  alarm_description = "S3 replication to DR is failing: ${aws_s3_bucket.guide_buckets[each.key].bucket} -> ${each.value.bucket}. Failed operations are NOT retried indefinitely. Diagnose (role policy, KMS, destination), then re-drive the gap with a Batch Replication job (util/create-s3-batch.sh)."
+
+  namespace           = "AWS/S3"
+  metric_name         = "OperationsFailedReplication"
+  statistic           = "Sum"
+  period              = 300
+  evaluation_periods  = 1
+  threshold           = 0
+  comparison_operator = "GreaterThanThreshold"
+
+  # The metric emits datapoints only while there is replication traffic;
+  # absence means "nothing to replicate", not "healthy", so missing data must
+  # not page. Absence-of-parity detection is a separate concern (central
+  # metrics), not expressible as a per-stack CloudWatch alarm without lying.
+  treat_missing_data = "notBreaching"
+
+  dimensions = {
+    SourceBucket      = aws_s3_bucket.guide_buckets[each.key].bucket
+    DestinationBucket = each.value.bucket
+    RuleId            = "dr-${each.key}"
+  }
+
+  alarm_actions = [module.sns.topic_arn]
+  ok_actions    = [module.sns.topic_arn]
+  tags          = local.tags
+}
+
+# S3 server access logging can only target a bucket in the SAME region as the
+# source, so the primary logging bucket can never receive the DR buckets' logs
+# and until this bucket existed the DR side produced no access logs at all.
+# The primary log buckets are deliberately NOT replicated: access logs are
+# audit trail, not customer content - each region logs locally instead.
+# Policy-based log delivery only (no ACLs): these buckets are new enough to
+# stay on the BucketOwnerEnforced default.
+#
+// No logging on the logging bucket, same as the primary one - that way lies
+// recursion.
+#tfsec:ignore:aws-s3-enable-bucket-logging
+resource "aws_s3_bucket" "dr_logging_bucket" {
+  count    = local.dr_enabled ? 1 : 0
+  provider = aws.dr
+
+  bucket_prefix = "${local.identifier}-log-dr-"
+  force_destroy = !var.protect_resources
+  tags          = local.tags
+
+  lifecycle {
+    ignore_changes = [bucket, bucket_prefix]
+  }
+}
+
+resource "aws_s3_bucket_policy" "dr_logging_bucket" {
+  count    = local.dr_enabled ? 1 : 0
+  provider = aws.dr
+
+  bucket = aws_s3_bucket.dr_logging_bucket[0].id
+  policy = data.aws_iam_policy_document.dr_logging_bucket[0].json
+}
+
+data "aws_iam_policy_document" "dr_logging_bucket" {
+  count = local.dr_enabled ? 1 : 0
+
+  statement {
+    principals {
+      type        = "Service"
+      identifiers = ["logging.s3.amazonaws.com"]
+    }
+
+    actions = ["s3:PutObject"]
+
+    resources = [
+      aws_s3_bucket.dr_logging_bucket[0].arn,
+      "${aws_s3_bucket.dr_logging_bucket[0].arn}/*",
+    ]
+  }
+
+  # S3.5: reject plaintext requests, same as every other bucket here.
+  statement {
+    sid     = "DenyInsecureTransport"
+    effect  = "Deny"
+    actions = ["s3:*"]
+
+    resources = [
+      aws_s3_bucket.dr_logging_bucket[0].arn,
+      "${aws_s3_bucket.dr_logging_bucket[0].arn}/*",
+    ]
+
+    condition {
+      test     = "Bool"
+      variable = "aws:SecureTransport"
+      values   = ["false"]
+    }
+
+    principals {
+      type        = "*"
+      identifiers = ["*"]
+    }
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "dr_logging_bucket" {
+  count    = local.dr_enabled ? 1 : 0
+  provider = aws.dr
+
+  bucket                  = aws_s3_bucket.dr_logging_bucket[0].id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_versioning" "dr_logging_bucket" {
+  count    = local.dr_enabled ? 1 : 0
+  provider = aws.dr
+
+  bucket = aws_s3_bucket.dr_logging_bucket[0].id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_logging" "dr_guide_buckets" {
+  for_each = aws_s3_bucket.dr_guide_buckets
+  provider = aws.dr
+
+  bucket = each.value.id
+
+  target_bucket = aws_s3_bucket.dr_logging_bucket[0].bucket
+  target_prefix = "${each.key}/"
 }

--- a/terraform/physical/monitoring.tf
+++ b/terraform/physical/monitoring.tf
@@ -834,6 +834,14 @@ resource "aws_lambda_permission" "dms_restart_permission" {
 # --- DR replication health (count-gated on enable_dr) --- #
 
 # S3 CRR: pending bytes growing unboundedly means replication is failing/stuck.
+#
+# KNOWN NON-FUNCTIONAL: ReplicationLatency (like BytesPendingReplication and
+# OperationsPendingReplication, but unlike OperationsFailedReplication) is
+# published in the DESTINATION bucket's region, and this alarm lives in the
+# primary region, so it never sees a datapoint and notBreaching keeps it
+# silently OK. Moving it needs a DR-region notification path (the dr_paging
+# topic only exists when Aurora DR is on), so it stays here, documented,
+# until the central-metrics parity work covers cross-region signals.
 resource "aws_cloudwatch_metric_alarm" "dr_s3_replication_latency" {
   for_each = var.enable_dr ? aws_s3_bucket.guide_buckets : {}
 
@@ -860,11 +868,18 @@ resource "aws_cloudwatch_metric_alarm" "dr_s3_replication_latency" {
   tags = local.tags
 }
 
+# Dormant from 2026-06 until the replication rules gained their metrics block
+# (dr.tf): the metric did not exist before that, so this alarm had nothing to
+# watch. OperationsFailedReplication is the one replication metric published
+# in the SOURCE region, so unlike the latency alarm above this one is in the
+# right place, and it also counts Batch Replication task failures (though not
+# a job that never runs at all - the rollout runbook's describe-job check
+# covers that).
 resource "aws_cloudwatch_metric_alarm" "dr_s3_replication_failed" {
   for_each = var.enable_dr ? aws_s3_bucket.guide_buckets : {}
 
   alarm_name          = "${local.identifier}-dr-s3-replication-failed-${each.key}"
-  alarm_description   = "S3 DR replication operations failing for ${local.identifier} ${each.key} bucket"
+  alarm_description   = "S3 DR replication to ${aws_s3_bucket.dr_guide_buckets[each.key].id} is failing for ${local.identifier} ${each.key}. Failed operations are NOT retried indefinitely. Diagnose (role trust/policy, KMS, destination), read the batch-replication-report CSVs in the logging bucket, then re-drive the gap with a Batch Replication job (util/create-s3-batch.sh)."
   namespace           = "AWS/S3"
   metric_name         = "OperationsFailedReplication"
   statistic           = "Sum"


### PR DESCRIPTION
S3 cross-region replication only carries writes made after the rule exists; it never copies what a bucket already holds. The only supported way to close that gap is an S3 Batch Replication job, run out of band. Nothing in the module did that, so DR-enabled stacks came up with correctly wired but empty destination buckets, and with no replication metrics enabled there was no signal to catch it. Found during a production DR audit; every pair on the audited fleet was affected.

Changes, all in `terraform/physical/dr.tf`:

- **Backfill on DR creation.** A `null_resource` per DR pair calls the existing `util/create-s3-batch.sh` (same fire-once pattern as `s3_replication_job_init`, including the `depends_on` ordering lesson from the sharedgov build). Triggers are tied to the DR bucket id, so it fires when the destination is first created and never on routine applies. On stacks that already have DR, the resource entering state runs the job once, which is exactly the missing backfill.
- **Replication metrics on every rule** (metrics only, no RTC and its $0.015/GB SLA). Before this the four `AWS/S3` replication metrics did not exist at all.
- **Alarm on `OperationsFailedReplication > 0`** per pair, wired to the standard SNS topic. `treat_missing_data = notBreaching` because the metric only emits while there is replication traffic.
- **IAM for the batch job**: `s3:PutInventoryConfiguration`, `s3:InitiateReplication`, `s3:GetObject` on sources plus report-write on the logging bucket. Without these the job submits fine and fails async with 0 tasks while the apply stays green.
- **DR-region access-log bucket.** Server access logging cannot cross regions, so the DR buckets produced no logs at all. One log bucket in the DR region, policy-based delivery, TLS-only, public access blocked; the four DR buckets log into it. Primary log buckets are deliberately not replicated.

Deliberately unchanged: the DR lifecycle rule (the day-0 Intelligent-Tiering transition and the 30-day noncurrent expiry are documented FinOps intent, and the version history lives in the primary's Deep Archive tier).

Rollout note: on existing DR-enabled stacks the first apply after this lands submits one Batch Replication job per content bucket (cost scales with corpus size). Physical stacks gate at UNCONFIRMED, so each env's backfill fires only on its confirmed apply.
