### PR TITLE
test(harness): stop superseded matrix runs for the same PR at submission

### DIFF
--- a/.github/workflows/upgrade-tests.yml
+++ b/.github/workflows/upgrade-tests.yml
@@ -49,6 +49,10 @@ env:
   PR_REPO: ${{ github.event_name == 'pull_request' && github.repository || '' }}
   PR_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || '' }}
   PR_BASE_REF: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.ref || '' }}
+  # Supersession identity for the matrix's supersede step: it selects older runs by
+  # this label, never by parsing workflow names. Empty on dispatch runs, which never
+  # supersede anything.
+  PR_NUM: ${{ github.event_name == 'pull_request' && github.event.pull_request.number || '' }}
   NAME_HINT: ${{ github.event_name == 'pull_request' && format('pr{0}', github.event.pull_request.number) || 'manual' }}
 
 jobs:
@@ -256,6 +260,7 @@ jobs:
             namespace: argo
             labels:
               harness/trigger: ${{ github.event_name == 'pull_request' && 'pr' || 'manual' }}
+              harness/pr: '${PR_NUM}'
           spec:
             workflowTemplateRef:
               name: harness-matrix

--- a/.github/workflows/upgrade-tests.yml
+++ b/.github/workflows/upgrade-tests.yml
@@ -248,6 +248,78 @@ jobs:
       - name: Point kubectl at the ops cluster
         run: aws eks update-kubeconfig --name "$CLUSTER" --region "$REGION"
 
+      # Runs BEFORE the new matrix is created, which is what makes it safe: every
+      # matrix carrying this PR's label is older than the run about to exist, by
+      # construction. No self-exclusion, no name parsing, no timestamp tiebreak.
+      # It also keeps the patch verb on the submitter's own RBAC identity
+      # (30-submitter-rbac.yaml) instead of the shared argo-workflow SA that
+      # Terraform-running phase pods use.
+      #
+      # Stop, never Terminate: Stop still runs the scenario teardown exit handler,
+      # and the workflow-level semaphore is held until that teardown finishes, so a
+      # superseded stack is always destroyed before a waiting child takes its slot.
+      # The harness/superseded marker rides the SAME patch as the stop, so the
+      # notify handler can never observe the stop without the marker.
+      #
+      # Fail-open on every path: a broken supersede must never block the submission
+      # it precedes. Worst case is the pre-change status quo (stale runs drain on
+      # their own). Children are swept only for parents whose patch SUCCEEDED - a
+      # marked child under an unmarked parent would let the parent post a stale red
+      # verdict with no suppression, which is worse than leaving both running.
+      - name: Stop superseded matrix runs for this PR
+        if: github.event_name == 'pull_request'
+        continue-on-error: true
+        run: |
+          set -uo pipefail
+          KC="kubectl -n argo --request-timeout=10s"
+          MARK='{"metadata":{"labels":{"harness/superseded":"true"}},"spec":{"shutdown":"Stop"}}'
+          STALE=$($KC get workflows -l "harness/trigger=pr,harness/pr=${PR_NUM}" -o json \
+            | jq -r '.items[].metadata.name') || { echo "cannot list matrices; skipping supersede"; exit 0; }
+          if [ -z "$STALE" ]; then
+            echo "no prior matrix for pr ${PR_NUM}"; exit 0
+          fi
+          # Parents first, and only successfully patched parents feed the child
+          # sweep (a partial state where children stop but the parent survives
+          # unmarked defeats the suppression invariant).
+          PATCHED=""
+          while IFS= read -r wf; do
+            [ -z "$wf" ] && continue
+            ok=false
+            for attempt in 1 2 3; do
+              if $KC patch workflow "$wf" --type merge -p "$MARK"; then ok=true; break; fi
+              sleep 2
+            done
+            if [ "$ok" = true ]; then
+              echo "superseded ${wf}"
+              PATCHED="${PATCHED}${wf}"$'\n'
+            else
+              echo "warn: could not mark ${wf}; leaving its children untouched"
+            fi
+          done <<< "$STALE"
+          [ -z "$PATCHED" ] && exit 0
+          # All three passes ALWAYS run: an empty listing is what a submit-child
+          # pod mid-create looks like, so breaking early would strand exactly the
+          # late child the extra passes exist for. Already-stopping children are
+          # excluded so they are not re-patched every pass.
+          for attempt in 1 2 3; do
+            while IFS= read -r wf; do
+              [ -z "$wf" ] && continue
+              CHILDREN=$($KC get workflows -l "harness/parent=${wf}" -o json \
+                | jq -r '.items[]
+                         | select((.status.phase // "Pending") | IN("Pending", "Running"))
+                         | select(.spec.shutdown == null)
+                         | .metadata.name') || { echo "warn: cannot list children of ${wf}"; continue; }
+              while IFS= read -r child; do
+                [ -z "$child" ] && continue
+                echo "  stopping child ${child} (pass ${attempt})"
+                $KC patch workflow "$child" --type merge -p "$MARK" \
+                  || echo "warn: failed to patch child ${child}"
+              done <<< "$CHILDREN"
+            done <<< "$PATCHED"
+            [ "$attempt" -lt 3 ] && sleep 5
+          done
+          exit 0
+
       - name: Submit the harness matrix workflow
         id: submit
         run: |

--- a/.github/workflows/upgrade-tests.yml
+++ b/.github/workflows/upgrade-tests.yml
@@ -251,6 +251,15 @@ jobs:
       # Runs BEFORE the new matrix is created, which is what makes it safe: every
       # matrix carrying this PR's label is older than the run about to exist, by
       # construction. No self-exclusion, no name parsing, no timestamp tiebreak.
+      # "By construction" leans on the workflow-level concurrency block above
+      # (group per PR, cancel-in-progress: false): it serializes whole runs per
+      # PR, so no other run can create a matrix between this supersede and the
+      # create below. TestSupersedeInvariantsSubmitterSide asserts that block
+      # stays; changing it invalidates this step's ordering guarantee.
+      #
+      # One window this ordering opens: if the create below fails after the stop
+      # here, the PR briefly has old runs stopped and no new one. That failure is
+      # loud (the job goes red on the PR) and a re-run resubmits; not worth code.
       # It also keeps the patch verb on the submitter's own RBAC identity
       # (30-submitter-rbac.yaml) instead of the shared argo-workflow SA that
       # Terraform-running phase pods use.

--- a/live/tests/argo/20-matrix.yaml
+++ b/live/tests/argo/20-matrix.yaml
@@ -10,9 +10,20 @@
 #   argo submit -n argo --from workflowtemplate/harness-matrix \
 #     -p configs='["min_default"]' -p to-ref=<sha>
 ---
-# The workflow service account can run pods but cannot create Workflows; the argo-workflows
-# chart's workflow RBAC does not cover that. Without this the fan-out fails with a
-# forbidden error on the first child.
+# Dedicated identity for the matrix orchestrator. The Role below carries create (the
+# fan-out) and now patch (the supersede step); binding it to the shared argo-workflow
+# SA would hand both to every scenario/phase/notify pod too, including ones running
+# Terraform against real stacks. Scenario children keep argo-workflow, which retains
+# only the chart's executor role - they never needed workflow verbs.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: harness-matrix
+  namespace: argo
+---
+# The matrix's pods cannot create Workflows via the argo-workflows chart's workflow
+# RBAC alone; without create the fan-out fails with a forbidden error on the first
+# child.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -38,7 +49,24 @@ roleRef:
   name: harness-submit-children
 subjects:
   - kind: ServiceAccount
-    name: argo-workflow
+    name: harness-matrix
+    namespace: argo
+---
+# Every workflow pod needs the argo-workflows chart's executor role
+# (workflowtaskresults create/patch); the chart binds it to argo-workflow only, so
+# the dedicated SA gets its own binding to the same chart-managed Role.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: harness-matrix-executor
+  namespace: argo
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: argo-workflows-workflow
+subjects:
+  - kind: ServiceAccount
+    name: harness-matrix
     namespace: argo
 ---
 apiVersion: argoproj.io/v1alpha1
@@ -48,7 +76,7 @@ metadata:
   namespace: argo
 spec:
   entrypoint: matrix
-  serviceAccountName: argo-workflow
+  serviceAccountName: harness-matrix
   # The matrix blocks on its children (successCondition below), so the exit handler
   # sees the aggregate verdict: commit status back to the PR when pr-sha is set, and a
   # Slack post either way. Both the cron and PR entry points get this for free.
@@ -113,6 +141,14 @@ spec:
       steps:
         - - name: supersede
             template: supersede-older
+            # The script body is fail-open, but pod-level failures (deadline kill on
+            # a hung API call, image pull, eviction) are outside its reach - without
+            # continueOn any of those would fail this step, halt the step-group, and
+            # leave the PR with no harness run plus a false failure status. This
+            # step must be incapable of harming the run it precedes.
+            continueOn:
+              failed: true
+              error: true
         - - name: scenario
             template: submit-child
             # Every config in parallel. The children queue on the semaphore, so this does
@@ -145,42 +181,85 @@ spec:
       script:
         image: '{{workflow.parameters.image}}'
         command: [/bin/bash]
+        # Parameters arrive via env, never by textual substitution into the shell
+        # source: a value carrying a quote in a direct template submission (the GH
+        # path regex-validates, direct submits do not) cannot break out of quoting.
+        env:
+          - name: SELF
+            value: '{{workflow.name}}'
+          - name: PR_SHA
+            value: '{{workflow.parameters.pr-sha}}'
+        resources:
+          requests: { cpu: 50m, memory: 64Mi }
+          limits: { memory: 128Mi }
         source: |
           set -uo pipefail
-          SELF='{{workflow.name}}'
-          PR_SHA='{{workflow.parameters.pr-sha}}'
+          KC="kubectl -n argo --request-timeout=10s"
           if [ -z "$PR_SHA" ]; then
             echo "not a PR run; nothing to supersede"; exit 0
           fi
-          # harness-pr456-xh2gz -> harness-pr456-; generateName suffixes carry no dashes.
-          PREFIX="${SELF%-*}-"
-          SELF_TS=$(kubectl -n argo get workflow "$SELF" \
-            -o jsonpath='{.metadata.creationTimestamp}') || { echo "cannot read own timestamp"; exit 0; }
-          STALE=$(kubectl -n argo get workflows -l 'harness/trigger=pr' -o json \
-            | jq -r --arg p "$PREFIX" --arg self "$SELF" --arg ts "$SELF_TS" \
+          # Identity is contractual, not conventional: the name must be the GH
+          # submitter's shape AND the harness/pr label must be present, or nothing
+          # is selected. No name-prefix parsing.
+          if ! [[ "$SELF" =~ ^harness-pr[0-9]+-[^-]+$ ]]; then
+            echo "name '$SELF' is not harness-pr<N>-<suffix>; skipping supersede"; exit 0
+          fi
+          ME=$($KC get workflow "$SELF" -o json) || { echo "cannot read own workflow"; exit 0; }
+          PR_NUM=$(jq -r '.metadata.labels."harness/pr" // empty' <<<"$ME")
+          SELF_TS=$(jq -r '.metadata.creationTimestamp // empty' <<<"$ME")
+          if [ -z "$PR_NUM" ] || [ -z "$SELF_TS" ]; then
+            echo "own harness/pr label or timestamp missing; skipping supersede"; exit 0
+          fi
+          # Older same-PR matrices in ANY phase: a Failed parent can still own
+          # running children, so the child sweep below must see it. Timestamp ties
+          # are left alone on purpose - generateName suffixes do not encode
+          # creation order, so any name tiebreak could stop the NEWER run.
+          STALE=$($KC get workflows -l "harness/trigger=pr,harness/pr=${PR_NUM}" -o json \
+            | jq -r --arg self "$SELF" --arg ts "$SELF_TS" \
               '.items[]
                | select(.metadata.name != $self)
-               | select(.metadata.name | startswith($p))
                | select(.metadata.creationTimestamp < $ts)
-               | select((.status.phase // "Pending") | IN("Pending", "Running"))
-               | .metadata.name') || { echo "cannot list workflows"; exit 0; }
+               | .metadata.name') || { echo "cannot list matrices"; exit 0; }
           if [ -z "$STALE" ]; then
-            echo "no older running matrix for ${PREFIX}*"; exit 0
+            echo "no older matrix for pr ${PR_NUM}"; exit 0
           fi
-          for wf in $STALE; do
+          # One atomic PATCH sets the superseded marker AND the graceful stop, so
+          # the notify exit handler can never observe the stop without the marker
+          # (post-status suppresses its failure noise on that label).
+          MARK='{"metadata":{"labels":{"harness/superseded":"true"}},"spec":{"shutdown":"Stop"}}'
+          # Parents FIRST: quiesce child scheduling before sweeping, else a child
+          # created after our listing could linger unseen. Stop on a terminal
+          # parent is a no-op; the marker still lands for its notify handler.
+          while IFS= read -r wf; do
+            [ -z "$wf" ] && continue
             echo "superseding ${wf}"
-            kubectl -n argo get workflows -l "harness/parent=${wf}" -o json \
-              | jq -r '.items[]
-                       | select((.status.phase // "Pending") | IN("Pending", "Running"))
-                       | .metadata.name' \
-              | while read -r child; do
-                  [ -z "$child" ] && continue
-                  echo "  stopping child ${child}"
-                  kubectl -n argo patch workflow "$child" --type merge \
-                    -p '{"spec":{"shutdown":"Stop"}}' || true
-                done
-            kubectl -n argo patch workflow "$wf" --type merge \
-              -p '{"spec":{"shutdown":"Stop"}}' || true
+            $KC patch workflow "$wf" --type merge -p "$MARK" \
+              || echo "warn: failed to patch parent ${wf}"
+          done <<< "$STALE"
+          # Bounded child sweep: children are ownerless by design, so stop them
+          # directly; retries catch ones created in the window before their parent
+          # quiesced. Only children not already shutting down count as active -
+          # a stopped child stays Running through its teardown and must not keep
+          # the loop spinning.
+          for attempt in 1 2 3; do
+            ACTIVE=0
+            while IFS= read -r wf; do
+              [ -z "$wf" ] && continue
+              CHILDREN=$($KC get workflows -l "harness/parent=${wf}" -o json \
+                | jq -r '.items[]
+                         | select((.status.phase // "Pending") | IN("Pending", "Running"))
+                         | select(.spec.shutdown == null)
+                         | .metadata.name') || { echo "warn: cannot list children of ${wf}"; continue; }
+              while IFS= read -r child; do
+                [ -z "$child" ] && continue
+                ACTIVE=1
+                echo "  stopping child ${child} (attempt ${attempt})"
+                $KC patch workflow "$child" --type merge -p "$MARK" \
+                  || echo "warn: failed to patch child ${child}"
+              done <<< "$CHILDREN"
+            done <<< "$STALE"
+            [ "$ACTIVE" = 0 ] && break
+            sleep 5
           done
           exit 0
 
@@ -249,6 +328,17 @@ spec:
         args:
           - |
             set -uo pipefail
+            # A superseded run (stopped by a newer submission for the same PR) must
+            # not post its red verdict anywhere: not a status on its old sha, not a
+            # PR comment, not Slack. The marker label rides the SAME atomic PATCH as
+            # the stop, so it is always visible by the time this handler runs. A
+            # stopped workflow renders phase Failed ("Stopped with strategy 'Stop'"),
+            # so the label - not the phase - is the only reliable discriminator.
+            SUPERSEDED=$(kubectl -n argo --request-timeout=10s get workflow '{{workflow.name}}' -o json 2>/dev/null \
+              | jq -r '.metadata.labels."harness/superseded" // empty')
+            if [ "$SUPERSEDED" = "true" ]; then
+              echo "superseded run; skipping status, comment and slack"; exit 0
+            fi
             export VAULT_ADDR='{{workflow.parameters.vault-addr}}'
             export AWS_REGION=us-east-1
             vault login -method=aws role=deployer region=us-east-1 >/dev/null || { echo "vault login failed"; exit 0; }

--- a/live/tests/argo/20-matrix.yaml
+++ b/live/tests/argo/20-matrix.yaml
@@ -211,8 +211,12 @@ spec:
             # Retried, then FAIL-OPEN: on a persistent lookup failure the handler
             # posts anyway. Failing closed would leave a NORMAL run's verdict
             # unposted - the status set to pending at submission would hang the PR
-            # head forever, which is worse than a rare stale-red on a superseded
-            # (dead) sha.
+            # head forever. Accepted residual, eyes open: on a SAME-sha
+            # resubmission (rerun/reopen) both runs share one status context, so a
+            # stale red that slips through can block the merge gate until the new
+            # run finishes - a bounded delay that clears itself, never a wrong
+            # green, and it needs the supersede patch AND this lookup to both fail
+            # persistently. Low probability, bounded impact, fail-safe direction.
             check_superseded() {
               local out
               for _attempt in 1 2 3; do

--- a/live/tests/argo/20-matrix.yaml
+++ b/live/tests/argo/20-matrix.yaml
@@ -23,7 +23,9 @@ rules:
     resources: ['workflows']
     # get/list/watch are what the resource template polls with to decide the child's
     # outcome; without them it can create a child and then never learn it finished.
-    verbs: ['create', 'get', 'list', 'watch']
+    # patch is what the supersede step uses to set shutdown: Stop on older runs for
+    # the same PR; it grants no delete, so history is never removable this way.
+    verbs: ['create', 'get', 'list', 'watch', 'patch']
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -109,6 +111,8 @@ spec:
   templates:
     - name: matrix
       steps:
+        - - name: supersede
+            template: supersede-older
         - - name: scenario
             template: submit-child
             # Every config in parallel. The children queue on the semaphore, so this does
@@ -119,6 +123,66 @@ spec:
               parameters:
                 - name: config
                   value: '{{item}}'
+
+    # Stop superseded runs for the same PR before this one takes any capacity. A
+    # release-please force-push resubmits the matrix while the previous submission may
+    # be mid-provision, and its children then hold the harness semaphore for hours
+    # testing a sha that is no longer the PR head. The children's staleness gate only
+    # protects QUEUED runs (it fires at admission); anything already past it runs to
+    # completion. This closes that gap: stop every OLDER matrix sharing this name
+    # prefix (harness-pr<N>-) plus its children.
+    #
+    # Stop, never terminate: Stop still runs the scenario's teardown exit handler, and
+    # the workflow-level semaphore is held until the whole workflow (teardown included)
+    # finishes, so a superseded stack is fully destroyed before a waiting child can
+    # take its slot. Per-run state isolation (run-id = workflow name) means an apply
+    # interrupted by the Stop can only ever affect its own stack, and the orphan
+    # janitor remains the backstop if a destroy fails. Best-effort by design: every
+    # failure path exits 0, because correctness never depends on this step - it only
+    # reclaims capacity earlier than the runs would release it themselves.
+    - name: supersede-older
+      activeDeadlineSeconds: 120
+      script:
+        image: '{{workflow.parameters.image}}'
+        command: [/bin/bash]
+        source: |
+          set -uo pipefail
+          SELF='{{workflow.name}}'
+          PR_SHA='{{workflow.parameters.pr-sha}}'
+          if [ -z "$PR_SHA" ]; then
+            echo "not a PR run; nothing to supersede"; exit 0
+          fi
+          # harness-pr456-xh2gz -> harness-pr456-; generateName suffixes carry no dashes.
+          PREFIX="${SELF%-*}-"
+          SELF_TS=$(kubectl -n argo get workflow "$SELF" \
+            -o jsonpath='{.metadata.creationTimestamp}') || { echo "cannot read own timestamp"; exit 0; }
+          STALE=$(kubectl -n argo get workflows -l 'harness/trigger=pr' -o json \
+            | jq -r --arg p "$PREFIX" --arg self "$SELF" --arg ts "$SELF_TS" \
+              '.items[]
+               | select(.metadata.name != $self)
+               | select(.metadata.name | startswith($p))
+               | select(.metadata.creationTimestamp < $ts)
+               | select((.status.phase // "Pending") | IN("Pending", "Running"))
+               | .metadata.name') || { echo "cannot list workflows"; exit 0; }
+          if [ -z "$STALE" ]; then
+            echo "no older running matrix for ${PREFIX}*"; exit 0
+          fi
+          for wf in $STALE; do
+            echo "superseding ${wf}"
+            kubectl -n argo get workflows -l "harness/parent=${wf}" -o json \
+              | jq -r '.items[]
+                       | select((.status.phase // "Pending") | IN("Pending", "Running"))
+                       | .metadata.name' \
+              | while read -r child; do
+                  [ -z "$child" ] && continue
+                  echo "  stopping child ${child}"
+                  kubectl -n argo patch workflow "$child" --type merge \
+                    -p '{"spec":{"shutdown":"Stop"}}' || true
+                done
+            kubectl -n argo patch workflow "$wf" --type merge \
+              -p '{"spec":{"shutdown":"Stop"}}' || true
+          done
+          exit 0
 
     - name: submit-child
       inputs:

--- a/live/tests/argo/20-matrix.yaml
+++ b/live/tests/argo/20-matrix.yaml
@@ -20,10 +20,12 @@
 # ServiceAccount other than argo-workflow/the restricted default - fine while the gate
 # warns, a template that can never re-apply once it enforces - and EKS Pod Identity is
 # associated with argo-workflow only, so a new SA's post-status pod would fail its
-# vault login silently and leave the PR status pending forever. Isolating the write
-# verbs from the Terraform-running phase pods is still worth doing, but it takes an
-# infra-tf change (admission allowlist + pod identity association) applied in lockstep,
-# not a unilateral SA swap here.
+# vault login silently and leave the PR status pending forever.
+#
+# Deliberately NO patch verb here. Supersession (stopping older same-PR matrices)
+# lives in the GitHub submitter job (.github/workflows/upgrade-tests.yml), whose own
+# harness-pr-submitter Role carries patch - it binds only the GitHub OIDC identity,
+# so no workload pod (Terraform phases included) can stop or relabel a workflow.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -37,9 +39,7 @@ rules:
     # The janitor cron (50-janitor-cron.yaml) also runs as argo-workflow and depends
     # on this same get/list for its ownership listing - removing reads here sends the
     # janitor dark, not loudly.
-    # patch is what the supersede step uses to set shutdown: Stop on older runs for
-    # the same PR; it grants no delete, so history is never removable this way.
-    verbs: ['create', 'get', 'list', 'watch', 'patch']
+    verbs: ['create', 'get', 'list', 'watch']
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -125,16 +125,6 @@ spec:
   templates:
     - name: matrix
       steps:
-        - - name: supersede
-            template: supersede-older
-            # The script body is fail-open, but pod-level failures (deadline kill on
-            # a hung API call, image pull, eviction) are outside its reach - without
-            # continueOn any of those would fail this step, halt the step-group, and
-            # leave the PR with no harness run plus a false failure status. This
-            # step must be incapable of harming the run it precedes.
-            continueOn:
-              failed: true
-              error: true
         - - name: scenario
             template: submit-child
             # Every config in parallel. The children queue on the semaphore, so this does
@@ -145,114 +135,6 @@ spec:
               parameters:
                 - name: config
                   value: '{{item}}'
-
-    # Stop superseded runs for the same PR before this one takes any capacity. A
-    # release-please force-push resubmits the matrix while the previous submission may
-    # be mid-provision, and its children then hold the harness semaphore for hours
-    # testing a sha that is no longer the PR head. The children's staleness gate only
-    # protects QUEUED runs (it fires at admission); anything already past it runs to
-    # completion. This closes that gap: stop every OLDER matrix sharing this name
-    # prefix (harness-pr<N>-) plus its children.
-    #
-    # Stop, never terminate: Stop still runs the scenario's teardown exit handler, and
-    # the workflow-level semaphore is held until the whole workflow (teardown included)
-    # finishes, so a superseded stack is fully destroyed before a waiting child can
-    # take its slot. Per-run state isolation (run-id = workflow name) means an apply
-    # interrupted by the Stop can only ever affect its own stack, and the orphan
-    # janitor remains the backstop if a destroy fails. Best-effort by design: every
-    # failure path exits 0, because correctness never depends on this step - it only
-    # reclaims capacity earlier than the runs would release it themselves.
-    - name: supersede-older
-      # 300, not 120: the observed worst case is five stale matrices (PR #456), and the
-      # bounded sweep's ceiling is 3 attempts x (N parents x 10s request timeout) + two
-      # 5s sleeps - already past 120s at N=5 with a slow API server. continueOn keeps a
-      # deadline kill from failing the run, but the kill leaves children unstopped with
-      # no retry, so the budget errs long instead.
-      activeDeadlineSeconds: 300
-      script:
-        image: '{{workflow.parameters.image}}'
-        command: [/bin/bash]
-        # Parameters arrive via env, never by textual substitution into the shell
-        # source: a value carrying a quote in a direct template submission (the GH
-        # path regex-validates, direct submits do not) cannot break out of quoting.
-        env:
-          - name: SELF
-            value: '{{workflow.name}}'
-          - name: PR_SHA
-            value: '{{workflow.parameters.pr-sha}}'
-        resources:
-          requests: { cpu: 50m, memory: 64Mi }
-          limits: { memory: 128Mi }
-        source: |
-          set -uo pipefail
-          KC="kubectl -n argo --request-timeout=10s"
-          if [ -z "$PR_SHA" ]; then
-            echo "not a PR run; nothing to supersede"; exit 0
-          fi
-          # Identity is contractual, not conventional: the name must be the GH
-          # submitter's shape AND the harness/pr label must be present, or nothing
-          # is selected. No name-prefix parsing.
-          if ! [[ "$SELF" =~ ^harness-pr[0-9]+-[^-]+$ ]]; then
-            echo "name '$SELF' is not harness-pr<N>-<suffix>; skipping supersede"; exit 0
-          fi
-          ME=$($KC get workflow "$SELF" -o json) || { echo "cannot read own workflow"; exit 0; }
-          PR_NUM=$(jq -r '.metadata.labels."harness/pr" // empty' <<<"$ME")
-          SELF_TS=$(jq -r '.metadata.creationTimestamp // empty' <<<"$ME")
-          if [ -z "$PR_NUM" ] || [ -z "$SELF_TS" ]; then
-            echo "own harness/pr label or timestamp missing; skipping supersede"; exit 0
-          fi
-          # Older same-PR matrices in ANY phase: a Failed parent can still own
-          # running children, so the child sweep below must see it. Timestamp ties
-          # are left alone on purpose - generateName suffixes do not encode
-          # creation order, so any name tiebreak could stop the NEWER run.
-          STALE=$($KC get workflows -l "harness/trigger=pr,harness/pr=${PR_NUM}" -o json \
-            | jq -r --arg self "$SELF" --arg ts "$SELF_TS" \
-              '.items[]
-               | select(.metadata.name != $self)
-               | select(.metadata.creationTimestamp < $ts)
-               | .metadata.name') || { echo "cannot list matrices"; exit 0; }
-          if [ -z "$STALE" ]; then
-            echo "no older matrix for pr ${PR_NUM}"; exit 0
-          fi
-          # One atomic PATCH sets the superseded marker AND the graceful stop, so
-          # the notify exit handler can never observe the stop without the marker
-          # (post-status suppresses its failure noise on that label).
-          MARK='{"metadata":{"labels":{"harness/superseded":"true"}},"spec":{"shutdown":"Stop"}}'
-          # Parents FIRST: quiesce child scheduling before sweeping, else a child
-          # created after our listing could linger unseen. Stop on a terminal
-          # parent is a no-op; the marker still lands for its notify handler.
-          while IFS= read -r wf; do
-            [ -z "$wf" ] && continue
-            echo "superseding ${wf}"
-            $KC patch workflow "$wf" --type merge -p "$MARK" \
-              || echo "warn: failed to patch parent ${wf}"
-          done <<< "$STALE"
-          # Bounded child sweep: children are ownerless by design, so stop them
-          # directly; the later passes catch ones created in the window before their
-          # parent quiesced. All three passes ALWAYS run - an empty listing is not
-          # proof of quiescence, it is exactly what a submit-child pod mid-create
-          # looks like, so breaking on empty would strand precisely the late child
-          # the extra passes exist for. Only children not already shutting down are
-          # patched - a stopped child stays Running through its teardown and must
-          # not be re-patched every pass.
-          for attempt in 1 2 3; do
-            while IFS= read -r wf; do
-              [ -z "$wf" ] && continue
-              CHILDREN=$($KC get workflows -l "harness/parent=${wf}" -o json \
-                | jq -r '.items[]
-                         | select((.status.phase // "Pending") | IN("Pending", "Running"))
-                         | select(.spec.shutdown == null)
-                         | .metadata.name') || { echo "warn: cannot list children of ${wf}"; continue; }
-              while IFS= read -r child; do
-                [ -z "$child" ] && continue
-                echo "  stopping child ${child} (attempt ${attempt})"
-                $KC patch workflow "$child" --type merge -p "$MARK" \
-                  || echo "warn: failed to patch child ${child}"
-              done <<< "$CHILDREN"
-            done <<< "$STALE"
-            [ "$attempt" -lt 3 ] && sleep 5
-          done
-          exit 0
 
     - name: submit-child
       inputs:
@@ -325,8 +207,25 @@ spec:
             # the stop, so it is always visible by the time this handler runs. A
             # stopped workflow renders phase Failed ("Stopped with strategy 'Stop'"),
             # so the label - not the phase - is the only reliable discriminator.
-            SUPERSEDED=$(kubectl -n argo --request-timeout=10s get workflow '{{workflow.name}}' -o json 2>/dev/null \
-              | jq -r '.metadata.labels."harness/superseded" // empty')
+            #
+            # Retried, then FAIL-OPEN: on a persistent lookup failure the handler
+            # posts anyway. Failing closed would leave a NORMAL run's verdict
+            # unposted - the status set to pending at submission would hang the PR
+            # head forever, which is worse than a rare stale-red on a superseded
+            # (dead) sha.
+            check_superseded() {
+              local out
+              for _attempt in 1 2 3; do
+                if out=$(kubectl -n argo --request-timeout=10s get workflow '{{workflow.name}}' -o json 2>/dev/null); then
+                  jq -r '.metadata.labels."harness/superseded" // empty' <<<"$out"
+                  return 0
+                fi
+                sleep 2
+              done
+              echo "warn: could not read own workflow after 3 attempts; posting anyway (fail-open)" >&2
+              echo ""
+            }
+            SUPERSEDED=$(check_superseded)
             if [ "$SUPERSEDED" = "true" ]; then
               echo "superseded run; skipping status, comment and slack"; exit 0
             fi
@@ -375,6 +274,16 @@ spec:
                   }]' 2>/dev/null) || CHILD_JSON='[]'
             fi
             [ -z "$CHILD_JSON" ] && CHILD_JSON='[]'
+
+            # Second look right before the external posts: vault login and evidence
+            # collection above take minutes, and a supersession patch landing in
+            # that window would otherwise go unseen. Narrows the check-then-post
+            # race to seconds; the residual (superseded while the curl is in
+            # flight) is accepted - such a run finished its scenario naturally.
+            SUPERSEDED=$(check_superseded)
+            if [ "$SUPERSEDED" = "true" ]; then
+              echo "superseded during evidence collection; skipping status, comment and slack"; exit 0
+            fi
 
             if [ -n '{{workflow.parameters.pr-sha}}' ] && [ -n "$GH_TOKEN" ]; then
               curl -sf -X POST \

--- a/live/tests/argo/20-matrix.yaml
+++ b/live/tests/argo/20-matrix.yaml
@@ -10,20 +10,20 @@
 #   argo submit -n argo --from workflowtemplate/harness-matrix \
 #     -p configs='["min_default"]' -p to-ref=<sha>
 ---
-# Dedicated identity for the matrix orchestrator. The Role below carries create (the
-# fan-out) and now patch (the supersede step); binding it to the shared argo-workflow
-# SA would hand both to every scenario/phase/notify pod too, including ones running
-# Terraform against real stacks. Scenario children keep argo-workflow, which retains
-# only the chart's executor role - they never needed workflow verbs.
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: harness-matrix
-  namespace: argo
----
-# The matrix's pods cannot create Workflows via the argo-workflows chart's workflow
-# RBAC alone; without create the fan-out fails with a forbidden error on the first
-# child.
+# The workflow service account can run pods but cannot create Workflows; the argo-workflows
+# chart's workflow RBAC does not cover that. Without this the fan-out fails with a
+# forbidden error on the first child.
+#
+# Everything here stays on the shared argo-workflow SA on purpose. A dedicated matrix
+# SA was designed and rejected: the argo-privilege-gate admission policy
+# (infra-tf/modules/argo-ops-cluster/admission.tf) forbids any template from naming a
+# ServiceAccount other than argo-workflow/the restricted default - fine while the gate
+# warns, a template that can never re-apply once it enforces - and EKS Pod Identity is
+# associated with argo-workflow only, so a new SA's post-status pod would fail its
+# vault login silently and leave the PR status pending forever. Isolating the write
+# verbs from the Terraform-running phase pods is still worth doing, but it takes an
+# infra-tf change (admission allowlist + pod identity association) applied in lockstep,
+# not a unilateral SA swap here.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -34,6 +34,9 @@ rules:
     resources: ['workflows']
     # get/list/watch are what the resource template polls with to decide the child's
     # outcome; without them it can create a child and then never learn it finished.
+    # The janitor cron (50-janitor-cron.yaml) also runs as argo-workflow and depends
+    # on this same get/list for its ownership listing - removing reads here sends the
+    # janitor dark, not loudly.
     # patch is what the supersede step uses to set shutdown: Stop on older runs for
     # the same PR; it grants no delete, so history is never removable this way.
     verbs: ['create', 'get', 'list', 'watch', 'patch']
@@ -49,24 +52,7 @@ roleRef:
   name: harness-submit-children
 subjects:
   - kind: ServiceAccount
-    name: harness-matrix
-    namespace: argo
----
-# Every workflow pod needs the argo-workflows chart's executor role
-# (workflowtaskresults create/patch); the chart binds it to argo-workflow only, so
-# the dedicated SA gets its own binding to the same chart-managed Role.
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: harness-matrix-executor
-  namespace: argo
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: argo-workflows-workflow
-subjects:
-  - kind: ServiceAccount
-    name: harness-matrix
+    name: argo-workflow
     namespace: argo
 ---
 apiVersion: argoproj.io/v1alpha1
@@ -76,7 +62,7 @@ metadata:
   namespace: argo
 spec:
   entrypoint: matrix
-  serviceAccountName: harness-matrix
+  serviceAccountName: argo-workflow
   # The matrix blocks on its children (successCondition below), so the exit handler
   # sees the aggregate verdict: commit status back to the PR when pr-sha is set, and a
   # Slack post either way. Both the cron and PR entry points get this for free.
@@ -177,7 +163,12 @@ spec:
     # failure path exits 0, because correctness never depends on this step - it only
     # reclaims capacity earlier than the runs would release it themselves.
     - name: supersede-older
-      activeDeadlineSeconds: 120
+      # 300, not 120: the observed worst case is five stale matrices (PR #456), and the
+      # bounded sweep's ceiling is 3 attempts x (N parents x 10s request timeout) + two
+      # 5s sleeps - already past 120s at N=5 with a slow API server. continueOn keeps a
+      # deadline kill from failing the run, but the kill leaves children unstopped with
+      # no retry, so the budget errs long instead.
+      activeDeadlineSeconds: 300
       script:
         image: '{{workflow.parameters.image}}'
         command: [/bin/bash]
@@ -237,12 +228,14 @@ spec:
               || echo "warn: failed to patch parent ${wf}"
           done <<< "$STALE"
           # Bounded child sweep: children are ownerless by design, so stop them
-          # directly; retries catch ones created in the window before their parent
-          # quiesced. Only children not already shutting down count as active -
-          # a stopped child stays Running through its teardown and must not keep
-          # the loop spinning.
+          # directly; the later passes catch ones created in the window before their
+          # parent quiesced. All three passes ALWAYS run - an empty listing is not
+          # proof of quiescence, it is exactly what a submit-child pod mid-create
+          # looks like, so breaking on empty would strand precisely the late child
+          # the extra passes exist for. Only children not already shutting down are
+          # patched - a stopped child stays Running through its teardown and must
+          # not be re-patched every pass.
           for attempt in 1 2 3; do
-            ACTIVE=0
             while IFS= read -r wf; do
               [ -z "$wf" ] && continue
               CHILDREN=$($KC get workflows -l "harness/parent=${wf}" -o json \
@@ -252,14 +245,12 @@ spec:
                          | .metadata.name') || { echo "warn: cannot list children of ${wf}"; continue; }
               while IFS= read -r child; do
                 [ -z "$child" ] && continue
-                ACTIVE=1
                 echo "  stopping child ${child} (attempt ${attempt})"
                 $KC patch workflow "$child" --type merge -p "$MARK" \
                   || echo "warn: failed to patch child ${child}"
               done <<< "$CHILDREN"
             done <<< "$STALE"
-            [ "$ACTIVE" = 0 ] && break
-            sleep 5
+            [ "$attempt" -lt 3 ] && sleep 5
           done
           exit 0
 

--- a/live/tests/argo/30-submitter-rbac.yaml
+++ b/live/tests/argo/30-submitter-rbac.yaml
@@ -10,7 +10,12 @@ metadata:
 rules:
   - apiGroups: ['argoproj.io']
     resources: ['workflows']
-    verbs: ['create', 'get', 'list']
+    # patch belongs HERE, not on the shared argo-workflow SA: the submitter job
+    # stops superseded same-PR matrices (shutdown: Stop + harness/superseded)
+    # before creating the new one, and this Role binds only the GitHub OIDC
+    # identity - no workload pod (Terraform phases included) can patch a
+    # workflow. No delete: history is never removable this way.
+    verbs: ['create', 'get', 'list', 'patch']
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/live/tests/harness/matrix_invariants_test.go
+++ b/live/tests/harness/matrix_invariants_test.go
@@ -131,65 +131,85 @@ func TestJanitorCronMatchesTheGoConstants(t *testing.T) {
 	}
 }
 
-// TestSupersedeStepInvariants locks the shape of the supersede-older step in
-// argo/20-matrix.yaml. Each assertion is a property the consensus review of the
-// change identified as load-bearing; losing any of them silently reintroduces a
-// failure mode that was observed live.
-func TestSupersedeStepInvariants(t *testing.T) {
+// TestSupersedeInvariantsSubmitterSide locks the shape of the supersede step in
+// .github/workflows/upgrade-tests.yml. Supersession runs in the SUBMITTER (before
+// the new matrix is created, under the harness-pr-submitter identity), not in the
+// matrix template - that placement is what removes the patch verb from workload
+// pods and makes every same-PR matrix older than the run being submitted by
+// construction. Each assertion is a property the consensus review identified as
+// load-bearing.
+func TestSupersedeInvariantsSubmitterSide(t *testing.T) {
+	b, err := os.ReadFile("../../../.github/workflows/upgrade-tests.yml")
+	if err != nil {
+		t.Fatalf("read upgrade-tests.yml: %v", err)
+	}
+	y := string(b)
+
+	// The supersede step must run BEFORE the matrix is created: ordering is the
+	// substitute for self-exclusion and timestamp tiebreaks.
+	supersede := strings.Index(y, "Stop superseded matrix runs for this PR")
+	submit := strings.Index(y, "Submit the harness matrix workflow")
+	if supersede == -1 {
+		t.Fatal("the supersede step is gone from the submitter")
+	}
+	if submit != -1 && supersede > submit {
+		t.Error("supersede no longer runs before the matrix is created; ordering is its only self-exclusion")
+	}
+
+	// A broken supersede must never block the submission it precedes.
+	region := y[supersede:submit]
+	if !strings.Contains(region, "continue-on-error: true") {
+		t.Error("supersede lost continue-on-error; a failure would block the PR's harness run")
+	}
+
+	// Graceful stop only: Terminate skips the teardown exit handler and would
+	// leak live stacks. The superseded marker must ride the same patch.
+	if strings.Contains(region, "Terminate") {
+		t.Error("supersede uses Terminate; teardown exit handlers would be skipped")
+	}
+	if !strings.Contains(region, `"shutdown":"Stop"`) {
+		t.Error("supersede no longer patches shutdown: Stop")
+	}
+	if !strings.Contains(region, `"harness/superseded":"true"`) {
+		t.Error("supersede no longer sets the harness/superseded marker; post-status would post false failures for stopped runs")
+	}
+
+	// Identity is the label contract, never name parsing.
+	if !strings.Contains(region, "harness/trigger=pr,harness/pr=") {
+		t.Error("supersede no longer selects by the harness/pr label contract")
+	}
+
+	// Children are swept only under successfully patched parents: a marked child
+	// beneath an unmarked parent lets the parent post a stale red verdict with no
+	// suppression.
+	if !strings.Contains(region, "PATCHED") {
+		t.Error("supersede lost its PATCHED set; children of a failed parent patch would be stopped while the parent survives unmarked")
+	}
+
+	// Bounded API calls; a hung API server must not hang the submit job.
+	if !strings.Contains(region, "--request-timeout=10s") {
+		t.Error("supersede's kubectl calls lost their request timeout")
+	}
+}
+
+// TestPostStatusSuppressionInvariants: the matrix's notify handler must suppress
+// all external posts for a superseded run, re-check after the slow evidence
+// window, and fail OPEN (a normal run's verdict must always post - the pending
+// status from submission would otherwise hang the PR head forever).
+func TestPostStatusSuppressionInvariants(t *testing.T) {
 	b, err := os.ReadFile("../argo/20-matrix.yaml")
 	if err != nil {
 		t.Fatalf("read 20-matrix.yaml: %v", err)
 	}
 	y := string(b)
-
-	// The step must exist and must run before the fan-out. Compare the step
-	// entries (template: refs), not "name:" strings - a scenario PARAMETER
-	// definition appears earlier in the file.
-	supersede := strings.Index(y, "template: supersede-older")
-	fanout := strings.Index(y, "template: submit-child")
-	if supersede == -1 {
-		t.Fatal("supersede step is gone from the matrix")
-	}
-	if fanout != -1 && supersede > fanout {
-		t.Error("supersede no longer runs before the scenario fan-out")
-	}
-
-	// Pod-level failures (deadline kill, image pull, eviction) must never block
-	// the fan-out: the step is capacity hygiene, not a gate.
-	if !strings.Contains(y, "continueOn:") {
-		t.Error("supersede lost its continueOn; a pod-level failure would block the fan-out and post a false failure to the PR head")
-	}
-
-	// Graceful stop only: Terminate skips the teardown exit handler and would
-	// leak live stacks.
-	if strings.Contains(y, `"shutdown":"Terminate"`) || strings.Contains(y, "shutdown: Terminate") {
-		t.Error("supersede uses Terminate; teardown exit handlers would be skipped")
-	}
-	if !strings.Contains(y, `"shutdown":"Stop"`) {
-		t.Error("supersede no longer patches shutdown: Stop")
-	}
-
-	// The superseded marker must ride the same patch as the stop, and identity
-	// must come from the label contract, never name parsing.
-	if !strings.Contains(y, `"harness/superseded":"true"`) {
-		t.Error("supersede no longer sets the harness/superseded marker; post-status would post false failures for stopped runs")
-	}
-	if !strings.Contains(y, "harness/trigger=pr,harness/pr=") {
-		t.Error("supersede no longer selects by the harness/pr label contract")
-	}
-	if !strings.Contains(y, `.metadata.name != $self`) {
-		t.Error("supersede lost its self-exclusion")
-	}
-
-	// Every kubectl call is bounded; a hung API server must not eat the
-	// activeDeadline and fail the pod.
-	if !strings.Contains(y, "--request-timeout=10s") {
-		t.Error("supersede's kubectl calls lost their request timeout")
-	}
-
-	// post-status must suppress notifications for superseded runs.
-	if !strings.Contains(y, "harness/superseded") || !strings.Contains(y, "superseded run; skipping") {
+	if !strings.Contains(y, "superseded run; skipping") {
 		t.Error("post-status no longer suppresses notifications for superseded runs")
+	}
+	if !strings.Contains(y, "superseded during evidence collection") {
+		t.Error("post-status lost its pre-post re-check; the vault/evidence window would hide a supersession patch")
+	}
+	if !strings.Contains(y, "posting anyway (fail-open)") {
+		t.Error("post-status lost its fail-open path; a kubectl blip would silently swallow a NORMAL run's verdict")
 	}
 }
 
@@ -232,13 +252,28 @@ func TestMatrixRBACContract(t *testing.T) {
 		t.Fatal("harness-submit-children Role is gone; the janitor's workflow listing 403s and the fan-out cannot create children")
 	}
 	region := y[role:]
-	for _, verb := range []string{"'get'", "'list'", "'watch'", "'create'", "'patch'"} {
+	for _, verb := range []string{"'get'", "'list'", "'watch'", "'create'"} {
 		if !strings.Contains(region, verb) {
 			t.Errorf("harness-submit-children lost verb %s", verb)
 		}
 	}
+	// patch must NOT be on the shared workload SA's Role: it belongs to the GitHub
+	// submitter's identity only (30-submitter-rbac.yaml). A patch verb here hands
+	// every Terraform-running phase pod the ability to stop or relabel any
+	// workflow in the namespace.
+	if strings.Contains(region, "'patch'") {
+		t.Error("harness-submit-children regained patch; supersession must stay on harness-pr-submitter, off workload pods")
+	}
 	if !strings.Contains(region, "name: argo-workflow") {
 		t.Error("harness-submit-children no longer binds argo-workflow; the janitor cron and the matrix both lose access")
+	}
+
+	sub, err := os.ReadFile("../argo/30-submitter-rbac.yaml")
+	if err != nil {
+		t.Fatalf("read 30-submitter-rbac.yaml: %v", err)
+	}
+	if !strings.Contains(string(sub), "'patch'") {
+		t.Error("harness-pr-submitter lost patch; the submitter cannot stop superseded runs")
 	}
 	// Every serviceAccountName in the file - workflow-level or per-template - must
 	// be argo-workflow. Checking occurrences rather than one literal catches the

--- a/live/tests/harness/matrix_invariants_test.go
+++ b/live/tests/harness/matrix_invariants_test.go
@@ -152,8 +152,24 @@ func TestSupersedeInvariantsSubmitterSide(t *testing.T) {
 	if supersede == -1 {
 		t.Fatal("the supersede step is gone from the submitter")
 	}
-	if submit != -1 && supersede > submit {
-		t.Error("supersede no longer runs before the matrix is created; ordering is its only self-exclusion")
+	if submit == -1 {
+		t.Fatal("the submit step is gone from the submitter")
+	}
+	if supersede > submit {
+		// Fatal, not Error: the region slice below is meaningless when the order
+		// inverts, and slicing it would panic and take the whole binary down.
+		t.Fatal("supersede no longer runs before the matrix is created; ordering is its only self-exclusion")
+	}
+
+	// The ordering guarantee is only real because the workflow serializes runs
+	// per PR: with cancel-in-progress or a changed group key, another run could
+	// create a matrix between this run's supersede and its create, and nothing
+	// else (no self-exclusion, no tiebreak) would catch it.
+	if !strings.Contains(y, "group: upgrade-tests-${{ github.event.pull_request.number || github.run_id }}") {
+		t.Error("the per-PR concurrency group changed; supersede-before-create is no longer serialized")
+	}
+	if !strings.Contains(y, "cancel-in-progress: false") {
+		t.Error("cancel-in-progress is no longer false; a cancelled run can leave its matrix orphaned and unsuppressed")
 	}
 
 	// A broken supersede must never block the submission it precedes.

--- a/live/tests/harness/matrix_invariants_test.go
+++ b/live/tests/harness/matrix_invariants_test.go
@@ -240,8 +240,25 @@ func TestMatrixRBACContract(t *testing.T) {
 	if !strings.Contains(region, "name: argo-workflow") {
 		t.Error("harness-submit-children no longer binds argo-workflow; the janitor cron and the matrix both lose access")
 	}
-	if !strings.Contains(y, "serviceAccountName: argo-workflow") ||
-		strings.Contains(y, "kind: ServiceAccount\nmetadata:\n  name: harness-") {
-		t.Error("a template names a non-argo-workflow ServiceAccount; the admission gate rejects it on enforce and pod identity never attaches")
+	// Every serviceAccountName in the file - workflow-level or per-template - must
+	// be argo-workflow. Checking occurrences rather than one literal catches the
+	// likelier regression: a single step template quietly naming its own SA.
+	saCount := 0
+	for _, line := range strings.Split(y, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if name, ok := strings.CutPrefix(trimmed, "serviceAccountName:"); ok {
+			saCount++
+			if strings.TrimSpace(name) != "argo-workflow" {
+				t.Errorf("a template names ServiceAccount %q; the admission gate rejects it on enforce and pod identity never attaches", strings.TrimSpace(name))
+			}
+		}
+	}
+	if saCount == 0 {
+		t.Error("no serviceAccountName found; the matrix would fall to the restricted default and lose its workflow RBAC")
+	}
+	// An unindented kind: line is a top-level object declaration; the indented
+	// "- kind: ServiceAccount" inside a RoleBinding's subjects list is fine.
+	if strings.HasPrefix(y, "kind: ServiceAccount\n") || strings.Contains(y, "\nkind: ServiceAccount\n") {
+		t.Error("20-matrix.yaml defines a ServiceAccount object; only argo-workflow is admitted and pod-identity-backed")
 	}
 }

--- a/live/tests/harness/matrix_invariants_test.go
+++ b/live/tests/harness/matrix_invariants_test.go
@@ -130,3 +130,65 @@ func TestJanitorCronMatchesTheGoConstants(t *testing.T) {
 		t.Error(`the notify script no longer excludes sweep_result "destroyed" from the alarm set; a clean destroy would render under a "teardown FAILED" headline (Sweep leaves State=orphan on purpose)`)
 	}
 }
+
+// TestSupersedeStepInvariants locks the shape of the supersede-older step in
+// argo/20-matrix.yaml. Each assertion is a property the consensus review of the
+// change identified as load-bearing; losing any of them silently reintroduces a
+// failure mode that was observed live.
+func TestSupersedeStepInvariants(t *testing.T) {
+	b, err := os.ReadFile("../argo/20-matrix.yaml")
+	if err != nil {
+		t.Fatalf("read 20-matrix.yaml: %v", err)
+	}
+	y := string(b)
+
+	// The step must exist and must run before the fan-out. Compare the step
+	// entries (template: refs), not "name:" strings - a scenario PARAMETER
+	// definition appears earlier in the file.
+	supersede := strings.Index(y, "template: supersede-older")
+	fanout := strings.Index(y, "template: submit-child")
+	if supersede == -1 {
+		t.Fatal("supersede step is gone from the matrix")
+	}
+	if fanout != -1 && supersede > fanout {
+		t.Error("supersede no longer runs before the scenario fan-out")
+	}
+
+	// Pod-level failures (deadline kill, image pull, eviction) must never block
+	// the fan-out: the step is capacity hygiene, not a gate.
+	if !strings.Contains(y, "continueOn:") {
+		t.Error("supersede lost its continueOn; a pod-level failure would block the fan-out and post a false failure to the PR head")
+	}
+
+	// Graceful stop only: Terminate skips the teardown exit handler and would
+	// leak live stacks.
+	if strings.Contains(y, `"shutdown":"Terminate"`) || strings.Contains(y, "shutdown: Terminate") {
+		t.Error("supersede uses Terminate; teardown exit handlers would be skipped")
+	}
+	if !strings.Contains(y, `"shutdown":"Stop"`) {
+		t.Error("supersede no longer patches shutdown: Stop")
+	}
+
+	// The superseded marker must ride the same patch as the stop, and identity
+	// must come from the label contract, never name parsing.
+	if !strings.Contains(y, `"harness/superseded":"true"`) {
+		t.Error("supersede no longer sets the harness/superseded marker; post-status would post false failures for stopped runs")
+	}
+	if !strings.Contains(y, "harness/trigger=pr,harness/pr=") {
+		t.Error("supersede no longer selects by the harness/pr label contract")
+	}
+	if !strings.Contains(y, `.metadata.name != $self`) {
+		t.Error("supersede lost its self-exclusion")
+	}
+
+	// Every kubectl call is bounded; a hung API server must not eat the
+	// activeDeadline and fail the pod.
+	if !strings.Contains(y, "--request-timeout=10s") {
+		t.Error("supersede's kubectl calls lost their request timeout")
+	}
+
+	// post-status must suppress notifications for superseded runs.
+	if !strings.Contains(y, "harness/superseded") || !strings.Contains(y, "superseded run; skipping") {
+		t.Error("post-status no longer suppresses notifications for superseded runs")
+	}
+}

--- a/live/tests/harness/matrix_invariants_test.go
+++ b/live/tests/harness/matrix_invariants_test.go
@@ -192,3 +192,56 @@ func TestSupersedeStepInvariants(t *testing.T) {
 		t.Error("post-status no longer suppresses notifications for superseded runs")
 	}
 }
+
+// TestSupersedeLabelContractEmitterSide guards the half of the label contract the
+// matrix cannot see: the GitHub submitter must keep emitting the harness/pr label,
+// or the supersede script takes its "own harness/pr label missing" branch and
+// no-ops forever - silently, which is exactly the pre-PR behavior.
+func TestSupersedeLabelContractEmitterSide(t *testing.T) {
+	b, err := os.ReadFile("../../../.github/workflows/upgrade-tests.yml")
+	if err != nil {
+		t.Fatalf("read upgrade-tests.yml: %v", err)
+	}
+	y := string(b)
+	if !strings.Contains(y, "PR_NUM:") {
+		t.Error("upgrade-tests.yml no longer defines PR_NUM; the submitted matrix loses its supersession identity")
+	}
+	if !strings.Contains(y, "harness/pr: '${PR_NUM}'") {
+		t.Error("upgrade-tests.yml no longer stamps harness/pr on the submitted matrix; supersede selects nothing")
+	}
+}
+
+// TestMatrixRBACContract locks two facts a reshuffle can silently break. First,
+// the janitor cron runs as argo-workflow and pipes `kubectl get workflows` into
+// its ownership check; losing that binding's reads does not fail loudly, it makes
+// the janitor abort on its G2 empty-body check every night while the cron looks
+// green. Second, no template here may name a ServiceAccount other than
+// argo-workflow: the argo-privilege-gate admission policy forbids it, and EKS Pod
+// Identity is associated with argo-workflow only - a dedicated SA passes today's
+// Warn-mode gate, then can never re-apply once the gate enforces, and its
+// post-status pod has no AWS identity to log into Vault with.
+func TestMatrixRBACContract(t *testing.T) {
+	b, err := os.ReadFile("../argo/20-matrix.yaml")
+	if err != nil {
+		t.Fatalf("read 20-matrix.yaml: %v", err)
+	}
+	y := string(b)
+
+	role := strings.Index(y, "name: harness-submit-children")
+	if role == -1 {
+		t.Fatal("harness-submit-children Role is gone; the janitor's workflow listing 403s and the fan-out cannot create children")
+	}
+	region := y[role:]
+	for _, verb := range []string{"'get'", "'list'", "'watch'", "'create'", "'patch'"} {
+		if !strings.Contains(region, verb) {
+			t.Errorf("harness-submit-children lost verb %s", verb)
+		}
+	}
+	if !strings.Contains(region, "name: argo-workflow") {
+		t.Error("harness-submit-children no longer binds argo-workflow; the janitor cron and the matrix both lose access")
+	}
+	if !strings.Contains(y, "serviceAccountName: argo-workflow") ||
+		strings.Contains(y, "kind: ServiceAccount\nmetadata:\n  name: harness-") {
+		t.Error("a template names a non-argo-workflow ServiceAccount; the admission gate rejects it on enforce and pod identity never attaches")
+	}
+}


### PR DESCRIPTION
Seen live on the 8.15.0 release PR (#456): three master pushes in one afternoon left four matrix runs for the same PR, with both harness semaphore slots held by children testing superseded shas while the real head's children sat queued. The staleness gate only fires at child admission, so runs already past it burned slots for hours.

Supersession runs in the GitHub submit job, BEFORE the new matrix is created: stop every matrix carrying this PR's harness/pr label (children swept only under parents whose patch succeeded), then create the new run. Running it pre-creation is what makes it safe - everything selected is older by construction, so there is no self-exclusion, no name parsing, and no timestamp tiebreak. Stop rather than terminate so the scenario teardown exit handler still runs, and the workflow-level semaphore is held through that teardown, so a superseded stack is always fully destroyed before a waiting child takes its slot. The harness/superseded marker rides the same patch as the stop; the matrix's notify handler suppresses the commit status, PR comment and Slack post for marked runs (retried lookup, fail-open, re-checked after evidence collection).

Security note: the patch verb lands ONLY on harness-pr-submitter, the Role bound to the GitHub OIDC identity - the shared argo-workflow SA (Terraform phase pods included) gains nothing. An earlier revision granted patch to the shared SA; the panel review rejected that, and an invariant test now locks it out.

Rollout notes:
- Matrices submitted before this merges lack the harness/pr label and cannot be superseded; they drain naturally (one-time gap, accepted).
- Superseded shas keep their pending commit status forever; cosmetic, branch protection evaluates the current head.
- After merge the templates need a hand apply per live/tests/argo/README.md: kubectl --context argo-ops -n argo apply -f live/tests/argo/

Reviewed by a 4-seat consensus panel plus the senior reviewer across three rounds; findings and adjudications are in the review thread.