### PR TITLE
fix(dms): set an explicit timeout on the dms_restart lambda

### DIFF
--- a/terraform/physical/monitoring.tf
+++ b/terraform/physical/monitoring.tf
@@ -833,6 +833,16 @@ resource "aws_lambda_function" "dms_restart" {
   runtime       = "python3.12"
   architectures = ["arm64"]
   role          = aws_iam_role.lambda_execution[0].arn
+  # This was never set, so the function ran on AWS's 3s default while doing a
+  # FilterLogEvents plus a StartReplication on a cold arm64 start. Real invocations
+  # land at 2.7-2.9s and one has already been killed outright ("Status: timeout",
+  # 3000.00 ms), recovered only because Lambda retried the async invocation. That
+  # rescue is not guaranteed: once the async retries are spent, a restart lost this
+  # way is silent, and the replication sits failed against the 48h deprovision clock
+  # with nothing but the CRITICAL state-change alert to say so. 30s matches
+  # sns_to_slack above; Lambda bills duration actually used, so a higher ceiling
+  # costs nothing on the normal 2s path.
+  timeout = 30
 
   source_code_hash = data.archive_file.dms_restart_lambda[0].output_base64sha256
 


### PR DESCRIPTION
The `dms_restart` Lambda never set a `timeout`, so it ran on AWS's 3-second default while doing a `FilterLogEvents` plus a `StartReplication` on a cold arm64 start.

That is not theoretical headroom. Real invocations land at 2765-2931 ms, and one has already been killed outright:

```
REPORT RequestId: ...
Duration: 3000.00 ms
Billed Duration: 3000 ms
Memory Size: 128 MB
Status: timeout
```

It recovered only because SNS retried the invocation.

A restart lost this way is silent. The replication stays failed against the 48h deprovision deadline, after which recovery is no longer a start call but a Terraform apply, and the only signal is the CRITICAL state-change alert that had already fired for the original failure.

`30` matches `sns_to_slack` in the same file, which has always set it. This one looks like a simple omission. Lambda bills the duration actually used, so the higher ceiling costs nothing on the normal ~2s path.

## Scope

This PR originally carried a `resume-processing` before `reload-target` recovery ladder. Multi-model review found four MAJOR defects in it, including a suppression-marker bug that produced an alternating `reload -> suppress -> reload` loop, and a conflict with the documented invariant at `bi.tf:197` that a repointed (empty) target must be reloaded rather than resumed. That work is dropped; the findings are preserved in the review comment below.

The root cause it was chasing is better fixed at the DMS layer: `RecoverableErrorCount` is pinned to `0` in `static/dms_config.json`, which disables DMS's own retry of a lost target connection. AWS's default is `-1` (nine retries for exactly that failure). That change is tracked separately.

What remains here is the one independently verified, self-contained bug.