### PR TITLE
feat: connect harness cleanup to resource reaper

### DIFF
--- a/live/root.hcl
+++ b/live/root.hcl
@@ -53,6 +53,7 @@ locals {
           StackPath   = "${path_relative_to_include()}"
           Repo        = "CloudPrem-Infra"
           %{if local.delete_after != ""}deleteAfter = "${local.delete_after}"%{endif}
+          %{if local.delete_after != ""}"reaper:engine" = "harness"%{endif}
         }
       }
   EOF

--- a/live/tests/argo/00-phase-templates.yaml
+++ b/live/tests/argo/00-phase-templates.yaml
@@ -38,12 +38,22 @@ data:
   # shared Vault channelId (that one points at #spacelift-alerts and other
   # consumers read it). Channel IDs are not secrets; config lives here.
   slack_channel: 'C0BMGD1KE8Z'
-  # Phase 4 janitor mode. 'report' detects and posts, deletes nothing. Flipping to
-  # 'sweep' is a deliberate, reviewable, one-word commit - and the janitor CLI defaults
-  # to dry run independently (--sweep=false), so BOTH have to say sweep before anything
-  # is destroyed. Watch several days of reports, including one with a real orphan in it,
-  # before flipping this.
-  janitor_mode: 'report'
+  # Resource Reaper is the only control plane for cleanup decisions. The janitor scan
+  # publishes normalized findings but is permanently report-only; the separate worker
+  # can consume one signed/durable Reaper action only after the rollout flag is enabled.
+  reaper_report_bucket: 'resource-reaper-reports-076248559428'
+  reaper_action_queue_url: 'https://sqs.us-east-1.amazonaws.com/076248559428/resource-reaper-harness-actions.fifo'
+  reaper_result_queue_url: 'https://sqs.us-east-1.amazonaws.com/076248559428/resource-reaper-harness-results.fifo'
+  reaper_control_table: 'resource-reaper-control'
+  # Marks the report and every cleanup unit as shadow evidence for parity analysis,
+  # including empty reports. This is not an authority gate: infra-tf
+  # harness_actions_enabled and the independent local reaper_actions_enabled switch
+  # both remain false during shadowing.
+  reaper_shadow: 'true'
+  reaper_actions_enabled: 'false'
+  # Temporary shadow-parity switch. Task 10 removes the direct Slack template and this
+  # key after the consolidated #mpc-alerts report is proven authoritative.
+  reaper_direct_slack_enabled: 'true'
 ---
 # DDVtest has a hard ceiling of 10 VPCs per region and each test stack is about one VPC
 # (recovery is two). A nightly matrix plus a couple of PR runs will exhaust it mid-apply,

--- a/live/tests/argo/50-janitor-cron.yaml
+++ b/live/tests/argo/50-janitor-cron.yaml
@@ -18,18 +18,10 @@
 # cycle rather than skip one candidate if it is ever tripped. See harness/janitor.go for
 # the full predicate.
 #
-# DEFAULT IS DRY RUN, on two levels: the janitor CLI's own --sweep defaults to false
-# (janitor.go, and Sweep() itself now refuses to run at all when it is not explicitly
-# true), and this workflow only ever passes --sweep=true when the `mode` parameter
-# resolves to 'sweep' - whose DEFAULT comes from the janitor_mode key in harness-config
-# (committed as 'report'). That default is a scheduled cron run's only path here, so the
-# nightly cycle never sweeps until a human commits janitor_mode: sweep. It is not a
-# second switch a submitter cannot also flip in the same breath, though: `argo submit
-# --from workflowtemplate/harness-janitor -p mode=sweep` overrides the parameter at
-# submission time same as any other Argo parameter, independent of what janitor_mode
-# is committed as - so a manual sweep run is one explicit `-p mode=sweep`, not two
-# separate approvals. Watch several days of reports, including one with a real orphan
-# in it, before committing janitor_mode: sweep or running one by hand.
+# This daily workflow is permanently report-only. It publishes normalized findings to
+# Resource Reaper, which owns every approval, hold, and destructive action. The separate
+# harness-reaper-worker below is the only destructive Argo entry point, and it can act
+# only on one durable FIFO request after a final fresh scan and control-plane veto.
 ---
 apiVersion: argoproj.io/v1alpha1
 kind: WorkflowTemplate
@@ -47,11 +39,6 @@ spec:
   # nothing.
   arguments:
     parameters:
-      - name: mode
-        valueFrom:
-          configMapKeyRef:
-            name: harness-config
-            key: janitor_mode
       # One destroy per cycle. Leaks are rare and each one is evidence a teardown failed
       # somewhere - the report is what tells a human that, not a bigger sweep budget.
       # Raise this deliberately, never reflexively.
@@ -71,37 +58,28 @@ spec:
         valueFrom: { configMapKeyRef: { name: harness-config, key: vault_addr } }
       - name: slack-channel
         valueFrom: { configMapKeyRef: { name: harness-config, key: slack_channel } }
-  # Report mode finishes in minutes (a handful of S3 listings + tag lookups). Sweep mode
-  # can run MULTIPLE Teardown calls in-process now (harness/janitor.go Sweep bounds
-  # attempts by wall clock, not by count, since one Teardown's own historical worst case
-  # ran ~90 minutes with only the Aurora tail left before a deadline killed it -
-  # 10-scenario.yaml's own teardown deadline is 10800s for exactly that reason - and two
-  # slow failures plus one slow success used to be able to exceed this pod's deadline
-  # with nothing to stop it). 12600 is THE authoritative number: harness.go's
-  # JanitorPodActiveDeadlineSeconds constant must equal this literal exactly (its own
-  # comment points back here), and Sweep's wall-clock budget (DefaultSweepBudget) is
-  # derived from that constant minus a fixed setup margin, not tuned here separately.
-  # If this number ever changes, change JanitorPodActiveDeadlineSeconds in
-  # harness/janitor.go FIRST and copy the new literal here - the derivation then
-  # updates Sweep's budget automatically, so there is exactly one number to keep in
-  # sync by hand, not two.
-  activeDeadlineSeconds: 12600
+      - name: reaper-report-bucket
+        valueFrom: { configMapKeyRef: { name: harness-config, key: reaper_report_bucket } }
+      - name: reaper-shadow
+        valueFrom: { configMapKeyRef: { name: harness-config, key: reaper_shadow } }
+      - name: reaper-direct-slack-enabled
+        valueFrom: { configMapKeyRef: { name: harness-config, key: reaper_direct_slack_enabled } }
+      - name: reaper-action-queue-url
+        valueFrom: { configMapKeyRef: { name: harness-config, key: reaper_action_queue_url } }
+      - name: reaper-result-queue-url
+        valueFrom: { configMapKeyRef: { name: harness-config, key: reaper_result_queue_url } }
+      - name: reaper-control-table
+        valueFrom: { configMapKeyRef: { name: harness-config, key: reaper_control_table } }
   ttlStrategy:
     secondsAfterSuccess: 86400
     secondsAfterFailure: 259200
-  podMetadata:
-    annotations:
-      # A sweep destroy killed halfway strands the very stack this workflow exists to
-      # clean up - the same reasoning as harness-scenario, doubly so here.
-      karpenter.sh/do-not-disrupt: 'true'
-  volumeClaimTemplates:
-    - metadata:
-        name: workspace
-      spec:
-        accessModes: ['ReadWriteOnce']
-        resources:
-          requests:
-            storage: 10Gi
+  # Scan and action execution each use the repository only within one pod. An
+  # ephemeral workspace avoids provisioning a 10Gi EBS PVC on every five-minute
+  # empty queue check.
+  volumes:
+    - name: workspace
+      emptyDir:
+        sizeLimit: 10Gi
   templates:
     - name: janitor
       steps:
@@ -119,6 +97,7 @@ spec:
               error: true
         - - name: notify
             template: post-report
+            when: "'{{workflow.parameters.reaper-direct-slack-enabled}}' == 'true'"
             # A notification failure must never fail the cycle - the report already
             # reached the pod log and the JSON artifact either way.
             continueOn:
@@ -149,6 +128,9 @@ spec:
                   value: '{{steps.scan.status}}'
 
     - name: scan
+      # Reserve ten minutes inside the 2,400-second workflow deadline for pod
+      # startup plus the failure-notification and verification steps.
+      activeDeadlineSeconds: 1800
       outputs:
         parameters:
           - name: report
@@ -161,8 +143,10 @@ spec:
         args:
           - |
             set -uo pipefail
-            SWEEP_FLAG=--sweep=false
-            [ '{{workflow.parameters.mode}}' = sweep ] && SWEEP_FLAG=--sweep=true
+            REAPER_FLAGS=(--reaper-report-bucket '{{workflow.parameters.reaper-report-bucket}}')
+            if [ '{{workflow.parameters.reaper-shadow}}' = true ]; then
+              REAPER_FLAGS+=(--reaper-shadow)
+            fi
 
             # The ownership check is only as good as this list, so it is piped in rather
             # than fetched by the Go binary: the exact proven pattern `harness evidence`
@@ -187,7 +171,7 @@ spec:
               --repo-dir /workspace/repo \
               --self-workflow '{{workflow.name}}' \
               --max-sweeps '{{workflow.parameters.max-sweeps}}' \
-              --json "${SWEEP_FLAG}" < /tmp/wf.json | tee /tmp/out.txt
+              --json --sweep=false "${REAPER_FLAGS[@]}" < /tmp/wf.json | tee /tmp/out.txt
             RC=${PIPESTATUS[0]}
             # runJanitor's last stdout line is the JSON report (--json); everything
             # before it is the human-readable table, in both report and sweep mode.
@@ -209,8 +193,10 @@ spec:
           requests:
             cpu: '1'
             memory: '4Gi'
+            ephemeral-storage: 10Gi
           limits:
             memory: '6Gi'
+            ephemeral-storage: 12Gi
 
     # Finding an orphan means a teardown FAILED somewhere. The point of this step is that
     # the underlying bug gets seen by a human, not that the mess quietly disappears.
@@ -415,7 +401,7 @@ spec:
           - name: SCAN_STATUS
             value: '{{inputs.parameters.scan-status}}'
           - name: MODE
-            value: '{{workflow.parameters.mode}}'
+            value: report
           - name: VAULT_ADDR
             value: '{{workflow.parameters.vault-addr}}'
           - name: SLACK_CHANNEL
@@ -457,6 +443,122 @@ spec:
             memory: 64Mi
           limits:
             memory: 128Mi
+
+    - name: consume-one
+      steps:
+        - - name: queue-check
+            template: queue-check
+        - - name: execute
+            template: execute
+            when: "'{{steps.queue-check.outputs.parameters.available}}' == 'true'"
+
+    # Avoid cloning the repository and acquiring Vault credentials when the action
+    # switch is disabled or the FIFO is empty. GetQueueAttributes does not receive or
+    # hide a message; the heavy executor remains the sole consumer.
+    - name: queue-check
+      activeDeadlineSeconds: 120
+      outputs:
+        parameters:
+          - name: available
+            valueFrom:
+              path: /tmp/reaper-action-available
+      container:
+        image: '{{workflow.parameters.image}}'
+        command: ['/bin/bash', '-c']
+        args:
+          - |
+            set -euo pipefail
+            if [ "${REAPER_ACTIONS_ENABLED}" != true ]; then
+              echo false > /tmp/reaper-action-available
+              exit 0
+            fi
+            CREDS="$(aws sts assume-role \
+              --region '{{workflow.parameters.region}}' \
+              --role-arn '{{workflow.parameters.assume-role-arn}}' \
+              --role-session-name reaper-queue-check)"
+            export AWS_ACCESS_KEY_ID="$(jq -r .Credentials.AccessKeyId <<<"$CREDS")"
+            export AWS_SECRET_ACCESS_KEY="$(jq -r .Credentials.SecretAccessKey <<<"$CREDS")"
+            export AWS_SESSION_TOKEN="$(jq -r .Credentials.SessionToken <<<"$CREDS")"
+            COUNT="$(aws sqs get-queue-attributes \
+              --region '{{workflow.parameters.region}}' \
+              --queue-url '{{workflow.parameters.reaper-action-queue-url}}' \
+              --attribute-names ApproximateNumberOfMessages \
+              --query 'Attributes.ApproximateNumberOfMessages' \
+              --output text)"
+            if [ "${COUNT:-0}" -gt 0 ]; then
+              echo true > /tmp/reaper-action-available
+            else
+              echo false > /tmp/reaper-action-available
+            fi
+        env:
+          # Read directly from the ConfigMap, not a workflow parameter. Submitters
+          # may choose this template's entrypoint but cannot override this rollout gate.
+          - name: REAPER_ACTIONS_ENABLED
+            valueFrom:
+              configMapKeyRef:
+                name: harness-config
+                key: reaper_actions_enabled
+        resources:
+          requests:
+            cpu: 100m
+            memory: 256Mi
+          limits:
+            memory: 256Mi
+
+    - name: execute
+      # Coupled safety contract: SQS visibility is 13,500 seconds, leaving a
+      # 15-minute margin beyond this executor deadline.
+      activeDeadlineSeconds: 12600
+      metadata:
+        annotations:
+          karpenter.sh/do-not-disrupt: 'true'
+      container:
+        image: '{{workflow.parameters.image}}'
+        command: ['/bin/bash', '-c']
+        args:
+          - |
+            set -uo pipefail
+            kubectl -n argo get workflows -o json > /tmp/wf.json || : > /tmp/wf.json
+            /usr/local/bin/docker-entrypoint.sh reaper-worker \
+              --action-queue-url '{{workflow.parameters.reaper-action-queue-url}}' \
+              --result-queue-url '{{workflow.parameters.reaper-result-queue-url}}' \
+              --control-table '{{workflow.parameters.reaper-control-table}}' \
+              --account-id '{{workflow.parameters.ddvtest-account-id}}' \
+              --region '{{workflow.parameters.region}}' \
+              --dr-region '{{workflow.parameters.dr-region}}' \
+              --profile ddvtest \
+              --repo-dir /workspace/repo \
+              --actions-enabled="${REAPER_ACTIONS_ENABLED}" \
+              --self-workflow '{{workflow.name}}' < /tmp/wf.json
+        env:
+          - name: HARNESS_RUN_LABEL
+            value: '{{workflow.name}}'
+          - name: HARNESS_REPO_DIR
+            value: /workspace/repo
+          - name: HARNESS_ASSUME_ROLE_ARN
+            value: '{{workflow.parameters.assume-role-arn}}'
+          - name: VAULT_ADDR
+            value: '{{workflow.parameters.vault-addr}}'
+          - name: VAULT_AWS_ROLE
+            value: deployer
+          # Defense in depth against direct submission of the execute entrypoint:
+          # the Go worker exits before workflow parsing, AWS, or SQS when this is false.
+          - name: REAPER_ACTIONS_ENABLED
+            valueFrom:
+              configMapKeyRef:
+                name: harness-config
+                key: reaper_actions_enabled
+        volumeMounts:
+          - name: workspace
+            mountPath: /workspace
+        resources:
+          requests:
+            cpu: '1'
+            memory: '4Gi'
+            ephemeral-storage: 10Gi
+          limits:
+            memory: '6Gi'
+            ephemeral-storage: 12Gi
 ---
 apiVersion: argoproj.io/v1alpha1
 kind: CronWorkflow
@@ -479,12 +581,46 @@ spec:
   # stale listing. Forbid means Argo refuses to start a second janitor cycle while one
   # is still running, rather than trusting a lockfile that does not exist.
   concurrencyPolicy: Forbid
-  startingDeadlineSeconds: 3600
+  startingDeadlineSeconds: 600
   successfulJobsHistoryLimit: 7
   failedJobsHistoryLimit: 7
   workflowMetadata:
     labels:
       harness/trigger: janitor
   workflowSpec:
+    # Even the latest accepted 09:10 start must finish by 09:50, leaving ten
+    # minutes before Resource Reaper's 10:00 consolidated deadline.
+    activeDeadlineSeconds: 2400
+    workflowTemplateRef:
+      name: harness-janitor
+
+---
+apiVersion: argoproj.io/v1alpha1
+kind: CronWorkflow
+metadata:
+  name: harness-reaper-worker
+  namespace: argo
+spec:
+  # Keep shadow mode genuinely inert. Task 10 unsuspends this in the same reviewed
+  # change that enables reaper_actions_enabled; the in-pod and Go gates remain.
+  suspend: true
+  schedules:
+    - '*/5 * * * *'
+  timezone: America/New_York
+  # This is the deployment-level fence that prevents a lost SQS receipt from starting
+  # another executor while the original Workflow (and possibly its destroy) still runs.
+  concurrencyPolicy: Forbid
+  startingDeadlineSeconds: 300
+  successfulJobsHistoryLimit: 7
+  failedJobsHistoryLimit: 7
+  workflowMetadata:
+    labels:
+      harness/trigger: reaper-worker
+  workflowSpec:
+    entrypoint: consume-one
+    # Reserve thirty minutes for the queue-check, image pull, node provisioning, and
+    # pod scheduling so the destructive execute leaf still receives its full
+    # 12,600-second deadline even on a cold node.
+    activeDeadlineSeconds: 14400
     workflowTemplateRef:
       name: harness-janitor

--- a/live/tests/argo/README.md
+++ b/live/tests/argo/README.md
@@ -9,7 +9,7 @@ drives the identical `harness <phase>` subcommands, so the two paths stay compar
 10-scenario.yaml          harness-scenario: one config end to end, teardown as an exit handler
 20-matrix.yaml            harness-matrix: fans out over configs, submits one child workflow each
 40-nightly-cron.yaml      the nightly clock for harness-matrix
-50-janitor-cron.yaml      harness-janitor: the Phase 4 orphan sweeper (dry-run by default)
+50-janitor-cron.yaml      report-only janitor + Resource Reaper controlled action worker
 ```
 
 Apply:
@@ -83,9 +83,15 @@ a destroy that fails transiently. Neither covers a destroy that fails for a reas
 fixes - a state lock held by a dead process, expired credentials, a pod killed between apply
 and the manifest write. Those abandon a stack permanently: seven of them leaking over three
 days exhausted DDVtest's 10-VPC ceiling and took the nightly down with VpcLimitExceeded.
-`harness-janitor` (`50-janitor-cron.yaml`) runs nightly, never matches on a name, and
-defaults to a dry-run report - see `harness/janitor.go` for the full predicate and
-`harness/janitor_test.go` for its test coverage.
+`harness-janitor` (`50-janitor-cron.yaml`) runs nightly, never matches on a name, always
+uses `--sweep=false`, and publishes Engine Report v1 to Resource Reaper. The separate
+`harness-reaper-worker` is installed suspended during shadow validation. Once enabled,
+it checks its FIFO every five minutes and starts the heavy executor
+only when actions are enabled and a message exists. That executor consumes at most one
+durable Reaper action, repeats the full scan/version/ownership checks, and installs a
+final control-plane veto immediately before the existing selected sweep path. There is
+no Argo parameter that bypasses Reaper. See `harness/janitor.go` and
+`harness/reaper_worker.go` for the enforced predicates and their test coverage.
 
 **A sweep cleans more than the terragrunt destroy.** `PhaseParams.Teardown` runs the same
 destroy every phase pod's exit handler runs, but a sweep also carries the out-of-band

--- a/live/tests/cmd/harness/main.go
+++ b/live/tests/cmd/harness/main.go
@@ -28,6 +28,7 @@ const usage = `usage: harness <provision|upgrade|validate|teardown|evidence|jani
              writes the CHILD_JSON array on stdout; needs neither --run-id nor --config)
   janitor:   --account-id --region --dr-region --self-workflow [--sweep] [--max-sweeps]
              [--max-sweep-failures] [--sweep-budget]
+             [--reaper-report-bucket <bucket>] [--reaper-shadow]
              (Phase 4 orphan sweeper; reads a WorkflowList json on stdin, defaults to a
              dry-run report; needs neither --run-id nor --config)`
 
@@ -251,6 +252,8 @@ func runJanitor(rest []string, stdin io.Reader, stdout, stderr io.Writer) int {
 		maxSweepFail = fs.Int("max-sweep-failures", 2, "cap on FAILED destroy attempts in one cycle, independent of --max-sweeps (bounds total attempts against the pod deadline; see janitor.go Sweep)")
 		sweepBudget  = fs.Duration("sweep-budget", 0, "wall-clock budget for starting new Sweep destroy attempts in one cycle; <= 0 derives it from harness.JanitorPodActiveDeadlineSeconds (see janitor.go DefaultSweepBudget) rather than a second independent number")
 		jsonOut      = fs.Bool("json", false, "also print the report as JSON on the last stdout line")
+		reaperBucket = fs.String("reaper-report-bucket", "", "publish Engine Report v1 to this Resource Reaper report bucket")
+		reaperShadow = fs.Bool("reaper-shadow", false, "publish Resource Reaper reports without consuming cleanup actions")
 	)
 	if err := fs.Parse(rest); err != nil {
 		return 2
@@ -261,6 +264,10 @@ func runJanitor(rest []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	}
 	if *selfWorkflow == "" {
 		fmt.Fprintln(stderr, "error: --self-workflow is required — the ownership check must be able to prove it is looking at a real workflow list\n"+usage)
+		return 2
+	}
+	if *reaperShadow && *reaperBucket == "" {
+		fmt.Fprintln(stderr, "error: --reaper-shadow requires --reaper-report-bucket")
 		return 2
 	}
 	if *maxSweeps < 1 {
@@ -375,23 +382,19 @@ func runJanitor(rest []string, stdin io.Reader, stdout, stderr io.Writer) int {
 		ProcessStart: processStart,
 	}
 
-	// emitJSON prints the report as the last stdout line when --json is set. Every exit
-	// path from here on goes through it, including the mid-sweep safety abort: the Argo
-	// scan step's `tail -1 > report.json` contract (50-janitor-cron.yaml) treats the
-	// last stdout line as the report, and an abort is exactly the cycle whose report a
-	// human needs. Before this, the abort path returned before the print and the notify
-	// step got the outputs default '{}' - no candidates, no reason, nothing to read.
-	emitJSON := func(rep *harness.Report, code int) int {
-		if !*jsonOut || rep == nil {
-			return code
-		}
-		out, jerr := json.Marshal(rep)
-		if jerr != nil {
-			fmt.Fprintf(stderr, "janitor: marshal report: %v\n", jerr)
-			return 1
-		}
-		fmt.Fprintln(stdout, string(out))
-		return code
+	// Every exit path after Scan uses finish. It publishes the normalized report first,
+	// then keeps the legacy janitor JSON as the last stdout line for Argo's existing
+	// `tail -1 > report.json` artifact contract. A publish failure therefore turns the
+	// step red only after the original report remains available to the notify step.
+	var reaperWriter harness.EngineReportWriter
+	if *reaperBucket != "" {
+		reaperWriter = s3.NewFromConfig(awsCfg)
+	}
+	finish := func(rep *harness.Report, code int) int {
+		return finishJanitorReport(
+			ctx, rep, code, *jsonOut, *reaperBucket, *reaperShadow,
+			reaperWriter, stdout, stderr,
+		)
 	}
 
 	rep, serr := harness.Scan(ctx, deps, opts, wfList)
@@ -421,14 +424,64 @@ func runJanitor(rest []string, stdin io.Reader, stdout, stderr io.Writer) int {
 			// The report is partial by definition here (the cycle stopped mid-sweep),
 			// and partial is exactly what the human needs to see: which candidates were
 			// already destroyed before the abort.
-			return emitJSON(rep, 3)
+			return finish(rep, 3)
 		}
 		fmt.Fprintln(stdout)
 		printJanitorReport(stdout, rep)
 		exitCode = janitorExitCode(rep)
 	}
 
-	return emitJSON(rep, exitCode)
+	return finish(rep, exitCode)
+}
+
+func emitJanitorJSON(rep *harness.Report, code int, enabled bool, stdout, stderr io.Writer) int {
+	if !enabled || rep == nil {
+		return code
+	}
+	out, err := json.Marshal(rep)
+	if err != nil {
+		fmt.Fprintf(stderr, "janitor: marshal report: %v\n", err)
+		return 1
+	}
+	fmt.Fprintln(stdout, string(out))
+	return code
+}
+
+func finishJanitorReport(
+	ctx context.Context,
+	rep *harness.Report,
+	code int,
+	jsonOut bool,
+	reaperBucket string,
+	reaperShadow bool,
+	reaperWriter harness.EngineReportWriter,
+	stdout, stderr io.Writer,
+) int {
+	if reaperBucket == "" || rep == nil {
+		return emitJanitorJSON(rep, code, jsonOut, stdout, stderr)
+	}
+	engineReport, err := harness.ToEngineReport(*rep)
+	if err != nil {
+		fmt.Fprintf(stderr, "janitor: build Resource Reaper report: %v\n", err)
+		if code == 0 {
+			code = 1
+		}
+		return emitJanitorJSON(rep, code, jsonOut, stdout, stderr)
+	}
+	key, err := harness.WriteEngineReport(ctx, reaperWriter, reaperBucket, engineReport)
+	if err != nil {
+		fmt.Fprintf(stderr, "janitor: publish Resource Reaper report: %v\n", err)
+		if code == 0 {
+			code = 1
+		}
+		return emitJanitorJSON(rep, code, jsonOut, stdout, stderr)
+	}
+	mode := "producer"
+	if reaperShadow {
+		mode = "shadow producer"
+	}
+	fmt.Fprintf(stdout, "janitor: Resource Reaper %s report archived at s3://%s/%s\n", mode, reaperBucket, key)
+	return emitJanitorJSON(rep, code, jsonOut, stdout, stderr)
 }
 
 // janitorExitCode is the sweep-cycle verdict: non-zero whenever a candidate ended in a

--- a/live/tests/cmd/harness/main.go
+++ b/live/tests/cmd/harness/main.go
@@ -20,7 +20,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/sts"
 )
 
-const usage = `usage: harness <provision|upgrade|validate|teardown|evidence|janitor> [flags]
+const usage = `usage: harness <provision|upgrade|validate|teardown|evidence|janitor|reaper-worker|reaper-drain-cancelled> [flags]
   common: --run-id --config --repo-dir --account-id --profile --region --matrix --state-bucket [--mem-store]
   provision: --scenario <upgrade|fresh> --from-ref --to-ref --namespace
   teardown:  --keep-on-failure --failed
@@ -30,7 +30,11 @@ const usage = `usage: harness <provision|upgrade|validate|teardown|evidence|jani
              [--max-sweep-failures] [--sweep-budget]
              [--reaper-report-bucket <bucket>] [--reaper-shadow]
              (Phase 4 orphan sweeper; reads a WorkflowList json on stdin, defaults to a
-             dry-run report; needs neither --run-id nor --config)`
+             dry-run report; needs neither --run-id nor --config)
+  reaper-worker: --action-queue-url --result-queue-url --control-table --account-id
+                 --region --dr-region --self-workflow (reads WorkflowList JSON on stdin)
+  reaper-drain-cancelled: --action-queue-url --result-queue-url --control-table
+                           --archive-bucket --account-id --region`
 
 func main() { os.Exit(dispatch(os.Args[1:], os.Stdin, os.Stdout, os.Stderr)) }
 
@@ -48,6 +52,12 @@ func dispatch(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	}
 	if sub == "janitor" {
 		return runJanitor(rest, stdin, stdout, stderr)
+	}
+	if sub == "reaper-worker" {
+		return runReaperWorker(rest, stdin, stdout, stderr)
+	}
+	if sub == "reaper-drain-cancelled" {
+		return runReaperDrainCancelled(rest, stdout, stderr)
 	}
 
 	fs := flag.NewFlagSet(sub, flag.ContinueOnError)

--- a/live/tests/cmd/harness/main.go
+++ b/live/tests/cmd/harness/main.go
@@ -32,7 +32,8 @@ const usage = `usage: harness <provision|upgrade|validate|teardown|evidence|jani
              (Phase 4 orphan sweeper; reads a WorkflowList json on stdin, defaults to a
              dry-run report; needs neither --run-id nor --config)
   reaper-worker: --action-queue-url --result-queue-url --control-table --account-id
-                 --region --dr-region --self-workflow (reads WorkflowList JSON on stdin)
+                 --region --dr-region --self-workflow --actions-enabled
+                 (reads WorkflowList JSON on stdin only when actions are enabled)
   reaper-drain-cancelled: --action-queue-url --result-queue-url --control-table
                            --archive-bucket --account-id --region`
 
@@ -225,9 +226,9 @@ func runEvidence(rest []string, stdin io.Reader, stdout, stderr io.Writer) int {
 // uses - no client-go against the Argo cluster), recomputes each candidate's identity
 // with the exact same code the apply used (Config.Salted), and only ever acts on a
 // candidate that is simultaneously stale, unowned by any live workflow or fresh lock, and
-// still holding real tagged AWS resources. Defaults to a dry-run report; --sweep and the
-// harness-config `janitor_mode` ConfigMap key both have to say so before anything is
-// destroyed.
+// still holding real tagged AWS resources. The CLI defaults to a dry-run report; the
+// Argo daily entrypoint fixes --sweep=false, and only the separate Resource Reaper
+// worker reaches selected teardown after its durable action and final-veto checks.
 //
 // Exit codes: 2 is a usage error (bad flags). 3 is a SAFETY ABORT - the account identity
 // did not match, the workflow list could not be trusted, or a candidate resolved to a
@@ -477,6 +478,12 @@ func finishJanitorReport(
 			code = 1
 		}
 		return emitJanitorJSON(rep, code, jsonOut, stdout, stderr)
+	}
+	if reaperShadow {
+		engineReport.Shadow = true
+		for index := range engineReport.CleanupUnits {
+			engineReport.CleanupUnits[index].Evidence.Shadow = true
+		}
 	}
 	key, err := harness.WriteEngineReport(ctx, reaperWriter, reaperBucket, engineReport)
 	if err != nil {

--- a/live/tests/cmd/harness/main_test.go
+++ b/live/tests/cmd/harness/main_test.go
@@ -116,6 +116,37 @@ func TestReaperPublishFailureReturnsNonzeroAfterLegacyJSON(t *testing.T) {
 	}
 }
 
+func TestReaperWorkerCLIRequiresControlPlaneFlags(t *testing.T) {
+	var stderr bytes.Buffer
+	code := dispatch([]string{"reaper-worker"}, strings.NewReader(""), io.Discard, &stderr)
+	if code != 2 || !strings.Contains(stderr.String(), "--action-queue-url") {
+		t.Fatalf("code=%d stderr=%q", code, stderr.String())
+	}
+}
+
+func TestReaperWorkerCLIUsesJanitorOwnershipGate(t *testing.T) {
+	var stderr bytes.Buffer
+	code := dispatch([]string{
+		"reaper-worker",
+		"--action-queue-url", "actions",
+		"--result-queue-url", "results",
+		"--control-table", "control",
+		"--account-id", "076248559428",
+		"--self-workflow", "worker-1",
+	}, strings.NewReader(`{"items":[]}`), io.Discard, &stderr)
+	if code != 3 || !strings.Contains(stderr.String(), "not found among 0 workflows") {
+		t.Fatalf("code=%d stderr=%q", code, stderr.String())
+	}
+}
+
+func TestReaperDrainCancelledCLIRequiresArchiveBucket(t *testing.T) {
+	var stderr bytes.Buffer
+	code := dispatch([]string{"reaper-drain-cancelled"}, strings.NewReader(""), io.Discard, &stderr)
+	if code != 2 || !strings.Contains(stderr.String(), "--archive-bucket") {
+		t.Fatalf("code=%d stderr=%q", code, stderr.String())
+	}
+}
+
 // ---- janitor bucket routing ----
 
 // TestMultiRegionS3RoutesByExactBucketName: the router used to pick a client by

--- a/live/tests/cmd/harness/main_test.go
+++ b/live/tests/cmd/harness/main_test.go
@@ -2,6 +2,9 @@ package main
 
 import (
 	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
 	"io"
 	"strings"
 	"testing"
@@ -9,6 +12,12 @@ import (
 	"github.com/Dozuki/CloudPrem-Infra/live/tests/harness"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 )
+
+type failingReaperWriter struct{}
+
+func (failingReaperWriter) PutObject(context.Context, *s3.PutObjectInput, ...func(*s3.Options)) (*s3.PutObjectOutput, error) {
+	return nil, errors.New("report bucket denied")
+}
 
 func TestDispatchUnknownSubcommand(t *testing.T) {
 	var b bytes.Buffer
@@ -44,6 +53,66 @@ func TestDispatchEvidenceRejectsMalformedInput(t *testing.T) {
 	code := dispatch([]string{"evidence"}, strings.NewReader("not json"), &stdout, &stderr)
 	if code == 0 {
 		t.Fatalf("malformed stdin should be non-zero (so the caller's jq fallback triggers)")
+	}
+}
+
+func TestJanitorReaperShadowRequiresReportBucket(t *testing.T) {
+	var stderr bytes.Buffer
+	code := dispatch(
+		[]string{"janitor", "--account-id", "076248559428", "--self-workflow", "janitor-1", "--reaper-shadow"},
+		strings.NewReader(""),
+		io.Discard,
+		&stderr,
+	)
+	if code != 2 || !strings.Contains(stderr.String(), "--reaper-shadow requires --reaper-report-bucket") {
+		t.Fatalf("code = %d, stderr = %q", code, stderr.String())
+	}
+}
+
+func TestJanitorAcceptsReaperShadowFlagsBeforeOwnershipGate(t *testing.T) {
+	var stderr bytes.Buffer
+	code := dispatch(
+		[]string{
+			"janitor", "--account-id", "076248559428", "--self-workflow", "janitor-1",
+			"--reaper-report-bucket", "resource-reaper-reports", "--reaper-shadow",
+		},
+		strings.NewReader(`{"items":[]}`),
+		io.Discard,
+		&stderr,
+	)
+	if code != 3 || !strings.Contains(stderr.String(), "not found among 0 workflows") {
+		t.Fatalf("code = %d, stderr = %q", code, stderr.String())
+	}
+}
+
+func TestReaperPublishFailureReturnsNonzeroAfterLegacyJSON(t *testing.T) {
+	report := &harness.Report{
+		SchemaVersion: harness.JanitorReportSchemaVersion,
+		Mode:          "report",
+		At:            "2026-08-08T13:00:00Z",
+		Account:       "076248559428",
+		Candidates: []harness.Candidate{{
+			Bucket: "dozuki-terraform-state-us-east-1-076248559428",
+			Prefix: "run-min_default/", State: harness.StateNeedsReview,
+			Reason: "manifest unreadable",
+		}},
+	}
+	var stdout, stderr bytes.Buffer
+	code := finishJanitorReport(
+		context.Background(), report, 0, true,
+		"resource-reaper-reports", true, failingReaperWriter{},
+		&stdout, &stderr,
+	)
+	if code != 1 || !strings.Contains(stderr.String(), "report bucket denied") {
+		t.Fatalf("code = %d, stderr = %q", code, stderr.String())
+	}
+	lines := strings.Split(strings.TrimSpace(stdout.String()), "\n")
+	var preserved harness.Report
+	if err := json.Unmarshal([]byte(lines[len(lines)-1]), &preserved); err != nil {
+		t.Fatalf("last stdout line is not the legacy report: %v\nstdout=%q", err, stdout.String())
+	}
+	if preserved.Candidates[0].Prefix != report.Candidates[0].Prefix {
+		t.Fatalf("preserved report = %+v", preserved)
 	}
 }
 

--- a/live/tests/cmd/harness/main_test.go
+++ b/live/tests/cmd/harness/main_test.go
@@ -19,6 +19,15 @@ func (failingReaperWriter) PutObject(context.Context, *s3.PutObjectInput, ...fun
 	return nil, errors.New("report bucket denied")
 }
 
+type recordingReaperWriter struct {
+	input *s3.PutObjectInput
+}
+
+func (writer *recordingReaperWriter) PutObject(_ context.Context, input *s3.PutObjectInput, _ ...func(*s3.Options)) (*s3.PutObjectOutput, error) {
+	writer.input = input
+	return &s3.PutObjectOutput{}, nil
+}
+
 func TestDispatchUnknownSubcommand(t *testing.T) {
 	var b bytes.Buffer
 	if code := dispatch([]string{"frobnicate"}, strings.NewReader(""), io.Discard, &b); code == 0 {
@@ -85,6 +94,38 @@ func TestJanitorAcceptsReaperShadowFlagsBeforeOwnershipGate(t *testing.T) {
 	}
 }
 
+func TestJanitorShadowReportMarksEveryCleanupUnit(t *testing.T) {
+	report := &harness.Report{
+		SchemaVersion: harness.JanitorReportSchemaVersion,
+		Mode:          "report",
+		At:            "2026-08-08T13:00:00Z",
+		Account:       "076248559428",
+		Candidates: []harness.Candidate{{
+			Bucket: "dozuki-terraform-state-us-east-1-076248559428",
+			Prefix: "run-min_default/", RunID: "run", ConfigName: "min_default",
+			Region: "us-east-1", State: harness.StateNeedsReview, Reason: "review",
+		}},
+	}
+	writer := &recordingReaperWriter{}
+	if code := finishJanitorReport(context.Background(), report, 0, false, "reports", true, writer, io.Discard, io.Discard); code != 0 {
+		t.Fatalf("code=%d", code)
+	}
+	if writer.input == nil {
+		t.Fatal("shadow report was not written")
+	}
+	body, err := io.ReadAll(writer.input.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var engineReport harness.EngineReport
+	if err := json.Unmarshal(body, &engineReport); err != nil {
+		t.Fatal(err)
+	}
+	if !engineReport.Shadow || len(engineReport.CleanupUnits) != 1 || !engineReport.CleanupUnits[0].Evidence.Shadow {
+		t.Fatalf("cleanup_units=%+v", engineReport.CleanupUnits)
+	}
+}
+
 func TestReaperPublishFailureReturnsNonzeroAfterLegacyJSON(t *testing.T) {
 	report := &harness.Report{
 		SchemaVersion: harness.JanitorReportSchemaVersion,
@@ -133,9 +174,25 @@ func TestReaperWorkerCLIUsesJanitorOwnershipGate(t *testing.T) {
 		"--control-table", "control",
 		"--account-id", "076248559428",
 		"--self-workflow", "worker-1",
+		"--actions-enabled=true",
 	}, strings.NewReader(`{"items":[]}`), io.Discard, &stderr)
 	if code != 3 || !strings.Contains(stderr.String(), "not found among 0 workflows") {
 		t.Fatalf("code=%d stderr=%q", code, stderr.String())
+	}
+}
+
+func TestReaperWorkerCLIExitsBeforeOwnershipOrAWSWhenActionsDisabled(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := dispatch([]string{
+		"reaper-worker",
+		"--action-queue-url", "actions",
+		"--result-queue-url", "results",
+		"--control-table", "control",
+		"--account-id", "076248559428",
+		"--self-workflow", "worker-1",
+	}, strings.NewReader("not workflow json"), &stdout, &stderr)
+	if code != 0 || !strings.Contains(stdout.String(), `"status":"disabled"`) || stderr.Len() != 0 {
+		t.Fatalf("code=%d stdout=%q stderr=%q", code, stdout.String(), stderr.String())
 	}
 }
 

--- a/live/tests/cmd/harness/reaper_worker.go
+++ b/live/tests/cmd/harness/reaper_worker.go
@@ -1,0 +1,239 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/Dozuki/CloudPrem-Infra/live/tests/harness"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/databasemigrationservice"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	"github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/sqs"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+)
+
+type reaperWorkerFlags struct {
+	actionQueueURL string
+	resultQueueURL string
+	controlTable   string
+	accountID      string
+	region         string
+	drRegion       string
+	profile        string
+	repoDir        string
+	matrixPath     string
+	lockTable      string
+	selfWorkflow   string
+}
+
+func parseReaperWorkerFlags(rest []string, stderr io.Writer) (reaperWorkerFlags, int) {
+	fs := flag.NewFlagSet("reaper-worker", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	var flags reaperWorkerFlags
+	fs.StringVar(&flags.actionQueueURL, "action-queue-url", "", "Resource Reaper harness action FIFO URL")
+	fs.StringVar(&flags.resultQueueURL, "result-queue-url", "", "Resource Reaper harness result FIFO URL")
+	fs.StringVar(&flags.controlTable, "control-table", "", "Resource Reaper control table name")
+	fs.StringVar(&flags.accountID, "account-id", "", "DDVtest account id")
+	fs.StringVar(&flags.region, "region", "us-east-1", "primary region")
+	fs.StringVar(&flags.drRegion, "dr-region", "us-west-2", "DR region")
+	fs.StringVar(&flags.profile, "profile", "", "AWS profile (empty in-cluster)")
+	fs.StringVar(&flags.repoDir, "repo-dir", ".", "repo root used by teardown")
+	fs.StringVar(&flags.matrixPath, "matrix", "live/tests/matrix.yaml", "harness matrix path")
+	fs.StringVar(&flags.lockTable, "lock-table", "dozuki-terraform-lock", "terraform state lock table")
+	fs.StringVar(&flags.selfWorkflow, "self-workflow", "", "this worker workflow name")
+	if err := fs.Parse(rest); err != nil {
+		return flags, 2
+	}
+	if flags.actionQueueURL == "" || flags.resultQueueURL == "" || flags.controlTable == "" || flags.accountID == "" || flags.selfWorkflow == "" {
+		fmt.Fprintln(stderr, "error: --action-queue-url, --result-queue-url, --control-table, --account-id, and --self-workflow are required")
+		return flags, 2
+	}
+	return flags, 0
+}
+
+func readWorkerWorkflows(stdin io.Reader, selfWorkflow string) (harness.JanitorWorkflowList, error) {
+	body, err := io.ReadAll(stdin)
+	if err != nil {
+		return harness.JanitorWorkflowList{}, err
+	}
+	var workflows harness.JanitorWorkflowList
+	if len(bytes.TrimSpace(body)) > 0 {
+		if err := json.Unmarshal(body, &workflows); err != nil {
+			return workflows, fmt.Errorf("parse workflows json: %w", err)
+		}
+	}
+	for _, workflow := range workflows.Items {
+		if workflow.Metadata.Name == selfWorkflow {
+			return workflows, nil
+		}
+	}
+	return workflows, fmt.Errorf("--self-workflow %q not found among %d workflows", selfWorkflow, len(workflows.Items))
+}
+
+func runReaperWorker(rest []string, stdin io.Reader, stdout, stderr io.Writer) int {
+	processStart := time.Now()
+	flags, code := parseReaperWorkerFlags(rest, stderr)
+	if code != 0 {
+		return code
+	}
+	workflows, err := readWorkerWorkflows(stdin, flags.selfWorkflow)
+	if err != nil {
+		fmt.Fprintf(stderr, "reaper-worker: %v — the ownership check is blind; aborting\n", err)
+		return 3
+	}
+	ctx := context.Background()
+	awsConfig, err := loadAWS(ctx, flags.profile, flags.region)
+	if err != nil {
+		fmt.Fprintf(stderr, "reaper-worker: aws config (%s): %v\n", flags.region, err)
+		return 1
+	}
+	drConfig, err := loadAWS(ctx, flags.profile, flags.drRegion)
+	if err != nil {
+		fmt.Fprintf(stderr, "reaper-worker: aws config (%s): %v\n", flags.drRegion, err)
+		return 1
+	}
+	identity, err := sts.NewFromConfig(awsConfig).GetCallerIdentity(ctx, &sts.GetCallerIdentityInput{})
+	if err != nil {
+		fmt.Fprintf(stderr, "reaper-worker: sts get-caller-identity: %v\n", err)
+		return 3
+	}
+	if aws.ToString(identity.Account) != flags.accountID {
+		fmt.Fprintf(stderr, "reaper-worker: caller identity account %q does not match --account-id %q\n", aws.ToString(identity.Account), flags.accountID)
+		return 3
+	}
+	matrix, err := harness.LoadMatrix(flags.matrixPath)
+	if err != nil {
+		fmt.Fprintf(stderr, "reaper-worker: load matrix: %v\n", err)
+		return 1
+	}
+	s3Router, err := newMultiRegionS3(flags.accountID, flags.region, map[string]*s3.Client{
+		flags.region: s3.NewFromConfig(awsConfig), flags.drRegion: s3.NewFromConfig(drConfig),
+	})
+	if err != nil {
+		fmt.Fprintf(stderr, "reaper-worker: %v\n", err)
+		return 1
+	}
+	janitorDeps := harness.JanitorDeps{
+		S3: s3Router,
+		Tags: map[string]harness.TagAPI{
+			flags.region: resourcegroupstaggingapi.NewFromConfig(awsConfig), flags.drRegion: resourcegroupstaggingapi.NewFromConfig(drConfig),
+		},
+		Locks: map[string]harness.LockAPI{
+			flags.region: dynamodb.NewFromConfig(awsConfig), flags.drRegion: dynamodb.NewFromConfig(drConfig),
+		},
+		Digests: map[string]harness.DigestAPI{
+			flags.region: dynamodb.NewFromConfig(awsConfig), flags.drRegion: dynamodb.NewFromConfig(drConfig),
+		},
+		DMS: map[string]harness.DMSReclaimAPI{
+			flags.region: databasemigrationservice.NewFromConfig(awsConfig), flags.drRegion: databasemigrationservice.NewFromConfig(drConfig),
+		},
+		Matrix: matrix, Teardown: harness.RealTeardown,
+	}
+	janitorOptions := harness.JanitorOptions{
+		AccountID: flags.accountID, Region: flags.region, DRRegion: flags.drRegion,
+		Profile: flags.profile, RepoDir: flags.repoDir, LockTable: flags.lockTable,
+		Grace: 6 * time.Hour, LockFresh: 4 * time.Hour, SelfWorkflow: flags.selfWorkflow,
+		Sweep: true, MaxSweeps: 1, MaxSweepFailures: 1, ProcessStart: processStart,
+	}
+	workerIO := &harness.AWSReaperWorkerIO{
+		Queue: sqs.NewFromConfig(awsConfig), Control: dynamodb.NewFromConfig(awsConfig),
+	}
+	janitor := &harness.Janitor{Deps: janitorDeps, Options: janitorOptions, Workflows: workflows}
+	workerOptions := harness.ReaperWorkerOptions{
+		ActionQueueURL: flags.actionQueueURL, ResultQueueURL: flags.resultQueueURL,
+		ControlTable: flags.controlTable, AccountID: flags.accountID,
+		VisibilityTimeoutSeconds: 13500,
+	}
+	finalVeto := func(ctx context.Context, request harness.ReaperActionRequest, _ harness.Candidate) error {
+		now := time.Now().UTC().Unix()
+		state, err := workerIO.LoadControl(ctx, flags.controlTable, request, now)
+		if err != nil {
+			if errors.Is(err, harness.ErrControlMismatch) {
+				return err
+			}
+			return fmt.Errorf("%w: final control-plane read: %v", harness.ErrRetryable, err)
+		}
+		if !state.ActionExists || state.ActionStatus != "running" || state.ActiveActionID != request.ActionID || state.ActiveExpiresAt < now+int64(harness.JanitorPodActiveDeadlineSeconds) || state.HoldActive {
+			return harness.ErrBlocked
+		}
+		return nil
+	}
+	result, err := harness.ProcessReaperAction(
+		ctx,
+		harness.ReaperWorkerDeps{IO: workerIO, Sweeper: janitor, FinalVeto: finalVeto},
+		workerOptions,
+	)
+	if err != nil {
+		fmt.Fprintf(stderr, "reaper-worker: %v\n", err)
+		return 1
+	}
+	encoded, _ := json.Marshal(result)
+	fmt.Fprintln(stdout, string(encoded))
+	return 0
+}
+
+func runReaperDrainCancelled(rest []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("reaper-drain-cancelled", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	actionQueueURL := fs.String("action-queue-url", "", "Resource Reaper harness action FIFO URL")
+	resultQueueURL := fs.String("result-queue-url", "", "Resource Reaper harness result FIFO URL")
+	controlTable := fs.String("control-table", "", "Resource Reaper control table name")
+	archiveBucket := fs.String("archive-bucket", "", "Resource Reaper archive bucket")
+	accountID := fs.String("account-id", "", "DDVtest account id")
+	region := fs.String("region", "us-east-1", "Resource Reaper region")
+	profile := fs.String("profile", "", "AWS profile (empty in-cluster)")
+	if err := fs.Parse(rest); err != nil {
+		return 2
+	}
+	if *actionQueueURL == "" || *resultQueueURL == "" || *controlTable == "" || *archiveBucket == "" || *accountID == "" {
+		fmt.Fprintln(stderr, "error: --action-queue-url, --result-queue-url, --control-table, --archive-bucket, and --account-id are required")
+		return 2
+	}
+	ctx := context.Background()
+	awsConfig, err := loadAWS(ctx, *profile, *region)
+	if err != nil {
+		fmt.Fprintf(stderr, "reaper-drain-cancelled: aws config: %v\n", err)
+		return 1
+	}
+	identity, err := sts.NewFromConfig(awsConfig).GetCallerIdentity(ctx, &sts.GetCallerIdentityInput{})
+	if err != nil {
+		fmt.Fprintf(stderr, "reaper-drain-cancelled: sts get-caller-identity: %v\n", err)
+		return 3
+	}
+	if aws.ToString(identity.Account) != *accountID {
+		fmt.Fprintf(stderr, "reaper-drain-cancelled: caller identity account %q does not match --account-id %q\n", aws.ToString(identity.Account), *accountID)
+		return 3
+	}
+	workerIO := &harness.AWSReaperWorkerIO{
+		Queue: sqs.NewFromConfig(awsConfig), Control: dynamodb.NewFromConfig(awsConfig),
+	}
+	options := harness.ReaperWorkerOptions{
+		ActionQueueURL: *actionQueueURL, ResultQueueURL: *resultQueueURL,
+		ControlTable: *controlTable, AccountID: *accountID,
+		VisibilityTimeoutSeconds: 30,
+	}
+	for count := 0; count < 1000; count++ {
+		result, err := harness.DrainCancelledReaperAction(
+			ctx, workerIO, s3.NewFromConfig(awsConfig), *archiveBucket, options,
+		)
+		if err != nil {
+			fmt.Fprintf(stderr, "reaper-drain-cancelled: %v\n", err)
+			return 1
+		}
+		if result.Status == "empty" {
+			return 0
+		}
+		encoded, _ := json.Marshal(result)
+		fmt.Fprintln(stdout, string(encoded))
+	}
+	fmt.Fprintln(stderr, "reaper-drain-cancelled: safety cap reached after 1000 actions")
+	return 1
+}

--- a/live/tests/cmd/harness/reaper_worker.go
+++ b/live/tests/cmd/harness/reaper_worker.go
@@ -32,6 +32,7 @@ type reaperWorkerFlags struct {
 	matrixPath     string
 	lockTable      string
 	selfWorkflow   string
+	actionsEnabled bool
 }
 
 func parseReaperWorkerFlags(rest []string, stderr io.Writer) (reaperWorkerFlags, int) {
@@ -49,6 +50,7 @@ func parseReaperWorkerFlags(rest []string, stderr io.Writer) (reaperWorkerFlags,
 	fs.StringVar(&flags.matrixPath, "matrix", "live/tests/matrix.yaml", "harness matrix path")
 	fs.StringVar(&flags.lockTable, "lock-table", "dozuki-terraform-lock", "terraform state lock table")
 	fs.StringVar(&flags.selfWorkflow, "self-workflow", "", "this worker workflow name")
+	fs.BoolVar(&flags.actionsEnabled, "actions-enabled", false, "permit one Resource Reaper queue receive")
 	if err := fs.Parse(rest); err != nil {
 		return flags, 2
 	}
@@ -83,6 +85,10 @@ func runReaperWorker(rest []string, stdin io.Reader, stdout, stderr io.Writer) i
 	flags, code := parseReaperWorkerFlags(rest, stderr)
 	if code != 0 {
 		return code
+	}
+	if !flags.actionsEnabled {
+		fmt.Fprintln(stdout, `{"status":"disabled"}`)
+		return 0
 	}
 	workflows, err := readWorkerWorkflows(stdin, flags.selfWorkflow)
 	if err != nil {

--- a/live/tests/docker-entrypoint.sh
+++ b/live/tests/docker-entrypoint.sh
@@ -6,7 +6,7 @@
 # launcher; this drives the identical `harness <phase>` subcommands from a pod.
 #
 # Usage:
-#   docker-entrypoint.sh provision|upgrade|validate|teardown|janitor [flags...] -> harness
+#   docker-entrypoint.sh provision|upgrade|validate|teardown|janitor|reaper-worker|reaper-drain-cancelled [flags...] -> harness
 #   docker-entrypoint.sh cpi-dr [flags...]                               -> DR CLI
 #   docker-entrypoint.sh bash|sh|<anything else>                         -> exec as given
 set -euo pipefail
@@ -26,13 +26,13 @@ fi
 # Passthrough for anything that is not a harness phase, so the image doubles as a debug
 # shell and as the host for cpi-dr and the cleanup backstops.
 #
-# janitor rides the same path as a phase on purpose, even in report (dry-run) mode. It
-# needs the DDVtest profile chain below to read S3/tags/locks, and in sweep mode it calls
-# the same Teardown a phase pod uses, so it needs the repo clone and the Vault token too.
-# One setup path means flipping report -> sweep changes nothing about how credentials are
-# obtained: a credential problem surfaces during the dry-run cycles, not after the flip.
+# Janitor and reaper-worker ride the same path as a phase on purpose. The report-only
+# janitor needs the DDVtest profile chain to read S3/tags/locks; the queue-controlled
+# worker can call the same Teardown a phase pod uses, so it also needs the repository and
+# Vault token. One setup path makes credential failures surface in shadow report cycles
+# before Resource Reaper actions are enabled.
 case "${1:-}" in
-  provision | upgrade | validate | teardown | janitor) BIN=harness ;;
+  provision | upgrade | validate | teardown | janitor | reaper-worker | reaper-drain-cancelled) BIN=harness ;;
   cpi-dr)
     shift
     exec cpi-dr "$@"

--- a/live/tests/go.mod
+++ b/live/tests/go.mod
@@ -3,7 +3,7 @@ module github.com/Dozuki/CloudPrem-Infra/live/tests
 go 1.25.0
 
 require (
-	github.com/aws/aws-sdk-go-v2 v1.43.3
+	github.com/aws/aws-sdk-go-v2 v1.43.4
 	github.com/aws/aws-sdk-go-v2/config v1.32.33
 	github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.80.2
 	github.com/aws/aws-sdk-go-v2/service/databasemigrationservice v1.66.2
@@ -16,6 +16,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.35.3
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.106.2
 	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.44.2
+	github.com/aws/aws-sdk-go-v2/service/sqs v1.46.4
 	github.com/aws/aws-sdk-go-v2/service/sts v1.45.2
 	github.com/aws/smithy-go v1.27.6
 	gopkg.in/yaml.v3 v3.0.1
@@ -28,8 +29,8 @@ require (
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.15 // indirect
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.32 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.33 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.34 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.34 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.35 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.35 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.34 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.15 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.9.26 // indirect

--- a/live/tests/go.sum
+++ b/live/tests/go.sum
@@ -1,5 +1,5 @@
-github.com/aws/aws-sdk-go-v2 v1.43.3 h1:XJIcfv8uDs2ukdQsoAC8/Ebu1ejxwzlayl2ZsiFns2A=
-github.com/aws/aws-sdk-go-v2 v1.43.3/go.mod h1:70vwSy16txshwG+g55WkpgPKDIByzHI8ccBsOteo3bQ=
+github.com/aws/aws-sdk-go-v2 v1.43.4 h1:b9FTvbRwy+JCsfp2Wp6wV/KbOx3Aj7nkoFb2cRX0IhE=
+github.com/aws/aws-sdk-go-v2 v1.43.4/go.mod h1:70vwSy16txshwG+g55WkpgPKDIByzHI8ccBsOteo3bQ=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.15 h1:rq/p1VNFfygoKEQ9hHMKsKBE98lspPvT8IxaFs5mFhw=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.15/go.mod h1:bELIhlPfW8OkpDhP1MvCjHDtvv8NhiBTz+K4o26zrXA=
 github.com/aws/aws-sdk-go-v2/config v1.32.33 h1:M1m/Q6f0OKDEDGwhiNOqx1OjTdrewe3v+GDbHmKczWk=
@@ -8,10 +8,10 @@ github.com/aws/aws-sdk-go-v2/credentials v1.19.32 h1:eNE0JnIblBo1NCvd3tqEYuZz9XD
 github.com/aws/aws-sdk-go-v2/credentials v1.19.32/go.mod h1:yYJu+6tqKUYZuJSYcpSGjz/6sV/SUaAaKIufnWKx2OU=
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.33 h1:MobhiR6KIerWxmO74Zit5I3379+mSc2DOdZ3DeRFB9w=
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.33/go.mod h1:xu02847OdZfNr/jAfZpHtyRk0b3v4d0kaoxNHxZGG/w=
-github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.34 h1:vuIfjzoeqhQMGJyOBU3t0ZEjn2jrN8Bbg1N4CgjzM5Q=
-github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.34/go.mod h1:hP28cN4CPJLZHirdQPrZR50JcLN4ApRJP2tzG8cRlhY=
-github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.34 h1:9faHsnqxJ1vDvB4wMZy/ajIDyz5QhllQjjc72RJpXAw=
-github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.34/go.mod h1:Yp6nIyejpa23nzlB/LhT63KTla9Jdi06nv/HH/OkAH8=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.35 h1:kzVuGlatQtYinwBJEEyLAbggepCoavosiaHHX9+fD+c=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.35/go.mod h1:0yLx0yEI+SfqeJMPvOtIEFoZbiQYXMGszBueiutQyaI=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.35 h1:WK6CjihTuLisCjSKKbildJ79sGZZgbBz3iNa7VsKIhU=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.35/go.mod h1:KYleN57luLoe97R7vTnx8PMcVrr9gAcRECtOjl91DNg=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.34 h1:HQYnjFnXpX8EbPW5M1QT8mXzesRPwly0HEPTcFlS02Y=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.34/go.mod h1:tGzj56niKYZBbDIRhwPGDqrULzmWv5b6uBQGqyNaFZw=
 github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.80.2 h1:9VtBzEaQH2UbwXnDdE4XjVVARk3UUiR+C+BrxYI0LoM=
@@ -48,6 +48,8 @@ github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.44.2 h1:FLe010M9ARXddf0bc
 github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.44.2/go.mod h1:v2RPY2DZKoDBk6xVFELvo5xTnUFJNoC4S385MwpXELw=
 github.com/aws/aws-sdk-go-v2/service/signin v1.5.2 h1:EjI1CZzDcBxPkTa3j1BdtIrUDbqnOGssFMeyUS+6W0I=
 github.com/aws/aws-sdk-go-v2/service/signin v1.5.2/go.mod h1:vN3eb5H8MEAZ4dx0F5Wc9LT8eb3eW7bZZ5BjGJdbw9k=
+github.com/aws/aws-sdk-go-v2/service/sqs v1.46.4 h1:Uqz9kiRjrhLwoVHEPt+ZT/n62UeAYxLHPetT6ImySBU=
+github.com/aws/aws-sdk-go-v2/service/sqs v1.46.4/go.mod h1:5QpAlDsMzDn2GUBCgs+pw52OLZzS4Sf3jOQDe4KSoVI=
 github.com/aws/aws-sdk-go-v2/service/sso v1.33.2 h1:zMP1FDFE08L7sM5f1QqkH/ZgKKg8Uc0Dz7KhSSYqWkw=
 github.com/aws/aws-sdk-go-v2/service/sso v1.33.2/go.mod h1:0LoIZSUKjdo2BleHfT1hv/jlD33LQS00IrBlzoUsoUQ=
 github.com/aws/aws-sdk-go-v2/service/ssooidc v1.38.2 h1:9eTqUYl+SyVmaRPMyBXSO9wwqC6TRwZB82pKENK2hdQ=

--- a/live/tests/harness/janitor.go
+++ b/live/tests/harness/janitor.go
@@ -242,10 +242,11 @@ func (o JanitorOptions) now() time.Time {
 	return time.Now()
 }
 
-// JanitorPodActiveDeadlineSeconds MUST match the `scan` container's
+// JanitorPodActiveDeadlineSeconds MUST match the Resource Reaper `execute` template's
 // activeDeadlineSeconds in 50-janitor-cron.yaml - that YAML value carries a comment
-// pointing back here for the same reason. This is the single source of truth; the
-// YAML is the consumer. If the pod deadline ever needs to change, change it here
+// pointing back here for the same reason. The report-only scan has a smaller, separate
+// deadline and never calls Sweep. This is the destructive worker's source of truth; the
+// YAML is the consumer. If the worker deadline ever needs to change, change it here
 // first and let DefaultSweepBudget's derivation carry the new number into Sweep
 // automatically, then copy the same literal into the YAML (Go cannot reach into a
 // YAML manifest at build time, so the copy is manual - but there is only one number
@@ -254,8 +255,8 @@ const JanitorPodActiveDeadlineSeconds = 12600
 
 // sweepSetupMargin is reserved for everything in the pod that runs BEFORE Sweep's own
 // clock starts and so is never inside its budget: image pull/container start, the
-// workspace repo clone or incremental fetch (docker-entrypoint.sh, unconditional even
-// in report mode), Vault login, and Scan itself (S3 listings + tag lookups, "minutes"
+// workspace repo clone or incremental fetch (docker-entrypoint.sh), Vault login, and
+// the worker's fresh Scan (S3 listings + tag lookups, "minutes"
 // per 50-janitor-cron.yaml's own comment). 30 minutes is generous against all of
 // that put together, and generous is the right direction to round: undercounting the
 // margin is what would let Sweep itself blow the pod deadline.

--- a/live/tests/harness/janitor.go
+++ b/live/tests/harness/janitor.go
@@ -1504,6 +1504,108 @@ func clearStateDigests(ctx context.Context, d JanitorDeps, o JanitorOptions, loc
 	return cleared, firstErr
 }
 
+// Janitor binds the dependencies needed to re-scan and sweep exactly one Reaper
+// finding. ScanFunc and FinalVeto are injected seams for deterministic safety tests;
+// production leaves ScanFunc nil and supplies a control-plane veto immediately before
+// the existing Sweep path is allowed to mutate anything.
+type Janitor struct {
+	Deps            JanitorDeps
+	Options         JanitorOptions
+	Workflows       JanitorWorkflowList
+	ScanFunc        func(context.Context, JanitorDeps, JanitorOptions, JanitorWorkflowList) (*Report, error)
+	FinalVeto       func(context.Context, Candidate) error
+	actionRequest   ReaperActionRequest
+	actionFinalVeto func(context.Context, ReaperActionRequest, Candidate) error
+}
+
+func (janitor *Janitor) PrepareReaperAction(request ReaperActionRequest, veto func(context.Context, ReaperActionRequest, Candidate) error) {
+	janitor.actionRequest = request
+	janitor.actionFinalVeto = veto
+}
+
+func (janitor *Janitor) scan(ctx context.Context) (*Report, error) {
+	if janitor.ScanFunc != nil {
+		return janitor.ScanFunc(ctx, janitor.Deps, janitor.Options, janitor.Workflows)
+	}
+	return Scan(ctx, janitor.Deps, janitor.Options, janitor.Workflows)
+}
+
+// SweepSelected re-runs Scan, revalidates the current finding, and delegates one
+// candidate to the existing bounded Sweep implementation. It never trusts the report
+// that originally produced the Slack action.
+func (janitor *Janitor) SweepSelected(ctx context.Context, output *Report, prefix, expectedVersion string) (Candidate, error) {
+	fresh, err := janitor.scan(ctx)
+	if err != nil {
+		return Candidate{}, fmt.Errorf("%w: fresh janitor scan: %v", ErrRetryable, err)
+	}
+	cleanPrefix := strings.Trim(prefix, "/")
+	var matches []Candidate
+	for _, candidate := range fresh.Candidates {
+		if strings.Trim(candidate.Prefix, "/") == cleanPrefix {
+			matches = append(matches, candidate)
+		}
+	}
+	if len(matches) == 0 {
+		return Candidate{}, ErrAlreadyGone
+	}
+	if len(matches) != 1 {
+		return Candidate{}, fmt.Errorf("%w: prefix %q matched %d candidates", ErrBlocked, prefix, len(matches))
+	}
+	candidate := matches[0]
+	decision, _, err := decisionForCandidate(candidate)
+	if err != nil {
+		return Candidate{}, fmt.Errorf("%w: %v", ErrBlocked, err)
+	}
+	if decision == "already_gone" {
+		return candidate, ErrAlreadyGone
+	}
+	if decision != "eligible" || candidate.State != StateOrphan || candidate.KeepOnFailure {
+		return candidate, ErrBlocked
+	}
+	if FindingVersion(candidate, decision) != expectedVersion {
+		return candidate, ErrStale
+	}
+	if err := guardProtected(candidate.Prefix, candidate.Identifier); err != nil {
+		return candidate, fmt.Errorf("%w: %v", ErrBlocked, err)
+	}
+	if janitor.FinalVeto != nil {
+		if err := janitor.FinalVeto(ctx, candidate); err != nil {
+			return candidate, err
+		}
+	}
+	if janitor.actionFinalVeto != nil {
+		if err := janitor.actionFinalVeto(ctx, janitor.actionRequest, candidate); err != nil {
+			return candidate, err
+		}
+	}
+
+	selected := &Report{
+		SchemaVersion: fresh.SchemaVersion,
+		Mode:          "sweep",
+		At:            fresh.At,
+		Account:       fresh.Account,
+		Candidates:    []Candidate{candidate},
+		Orphans:       1,
+	}
+	options := janitor.Options
+	options.Sweep = true
+	options.MaxSweeps = 1
+	if err := Sweep(ctx, janitor.Deps, options, selected); err != nil {
+		return selected.Candidates[0], err
+	}
+	if output != nil {
+		*output = *selected
+	}
+	result := selected.Candidates[0]
+	if strings.HasPrefix(result.SweepResult, "failed:") {
+		return result, fmt.Errorf("%w: %s", ErrTeardown, result.SweepResult)
+	}
+	if result.State == StateOrphan && result.SweepResult != sweepResultDestroyed {
+		return result, fmt.Errorf("%w: %s", ErrBlocked, result.SweepResult)
+	}
+	return result, nil
+}
+
 // Sweep destroys the orphans a prior Scan found, capped at MaxSweeps. It calls the
 // existing PhaseParams.Teardown (via d.Teardown) with failed=true so the full diagnostics
 // dump happens BEFORE the stack goes away: an orphan is evidence that a teardown failed,

--- a/live/tests/harness/janitor_notify_test.go
+++ b/live/tests/harness/janitor_notify_test.go
@@ -3,6 +3,7 @@ package harness
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -58,6 +59,237 @@ func notifyScript(t *testing.T) string {
 	}
 	t.Fatal("no post-report template with a container script found in 50-janitor-cron.yaml")
 	return ""
+}
+
+func argoManifest(t *testing.T, name string) string {
+	t.Helper()
+	body, err := os.ReadFile(filepath.Join("../argo", name))
+	if err != nil {
+		t.Fatalf("read %s: %v", name, err)
+	}
+	return string(body)
+}
+
+type janitorManifestDoc struct {
+	Kind     string `yaml:"kind"`
+	Metadata struct {
+		Name        string            `yaml:"name"`
+		Annotations map[string]string `yaml:"annotations"`
+	} `yaml:"metadata"`
+	Spec struct {
+		Suspend                 bool     `yaml:"suspend"`
+		Schedules               []string `yaml:"schedules"`
+		ConcurrencyPolicy       string   `yaml:"concurrencyPolicy"`
+		StartingDeadlineSeconds int      `yaml:"startingDeadlineSeconds"`
+		WorkflowSpec            struct {
+			Entrypoint            string `yaml:"entrypoint"`
+			ActiveDeadlineSeconds int    `yaml:"activeDeadlineSeconds"`
+		} `yaml:"workflowSpec"`
+		Volumes []struct {
+			Name     string `yaml:"name"`
+			EmptyDir struct {
+				SizeLimit string `yaml:"sizeLimit"`
+			} `yaml:"emptyDir"`
+		} `yaml:"volumes"`
+		Templates []struct {
+			Name                  string `yaml:"name"`
+			ActiveDeadlineSeconds int    `yaml:"activeDeadlineSeconds"`
+			Metadata              struct {
+				Annotations map[string]string `yaml:"annotations"`
+			} `yaml:"metadata"`
+			Container struct {
+				Args      []string `yaml:"args"`
+				Resources struct {
+					Requests map[string]string `yaml:"requests"`
+					Limits   map[string]string `yaml:"limits"`
+				} `yaml:"resources"`
+			} `yaml:"container"`
+		} `yaml:"templates"`
+	} `yaml:"spec"`
+}
+
+func janitorManifestDocs(t *testing.T) []janitorManifestDoc {
+	t.Helper()
+	manifest := argoManifest(t, "50-janitor-cron.yaml")
+	dec := yaml.NewDecoder(strings.NewReader(manifest))
+	var docs []janitorManifestDoc
+	for {
+		var doc janitorManifestDoc
+		if err := dec.Decode(&doc); err != nil {
+			if err != io.EOF {
+				t.Fatalf("decode 50-janitor-cron.yaml: %v", err)
+			}
+			break
+		}
+		docs = append(docs, doc)
+	}
+	return docs
+}
+
+func TestResourceReaperJanitorYAMLContract(t *testing.T) {
+	config := argoManifest(t, "00-phase-templates.yaml")
+	janitor := argoManifest(t, "50-janitor-cron.yaml")
+
+	for _, key := range []string{
+		"reaper_report_bucket:",
+		"reaper_action_queue_url:",
+		"reaper_result_queue_url:",
+		"reaper_control_table:",
+		"reaper_shadow: 'true'",
+		"reaper_actions_enabled: 'false'",
+		"reaper_direct_slack_enabled: 'true'",
+	} {
+		if !strings.Contains(config, key) {
+			t.Errorf("harness ConfigMap is missing explicit Resource Reaper setting %q", key)
+		}
+	}
+	if strings.Contains(config, "janitor_mode:") {
+		t.Fatal("obsolete janitor_mode ConfigMap key remains")
+	}
+	for _, forbidden := range []string{"- name: mode", "-p mode=sweep", "--sweep=true"} {
+		if strings.Contains(janitor, forbidden) {
+			t.Errorf("legacy direct sweep entrypoint remains: %q", forbidden)
+		}
+	}
+	for _, required := range []string{
+		"reaper-direct-slack-enabled",
+	} {
+		if !strings.Contains(janitor, required) {
+			t.Errorf("daily report contract is missing %q", required)
+		}
+	}
+	if !strings.Contains(janitor, "when: \"'{{workflow.parameters.reaper-direct-slack-enabled}}' == 'true'\"") {
+		t.Fatal("legacy direct Slack comparison is not explicitly guarded for removal at cutover")
+	}
+}
+
+func TestResourceReaperActionWorkerYAMLContract(t *testing.T) {
+	manifest := argoManifest(t, "50-janitor-cron.yaml")
+	checkIndex := strings.Index(manifest, `if [ "${REAPER_ACTIONS_ENABLED}" != true ]`)
+	receiveIndex := strings.Index(manifest, "/usr/local/bin/docker-entrypoint.sh reaper-worker")
+	if checkIndex < 0 || receiveIndex < 0 || checkIndex > receiveIndex {
+		t.Fatal("actions-disabled gate must appear before the worker can receive a message")
+	}
+	if !strings.Contains(manifest, "VisibilityTimeoutSeconds: 13500") && !strings.Contains(workerCLISource(t), "VisibilityTimeoutSeconds: 13500") {
+		t.Fatal("worker and manifest no longer document the 13,500-second queue visibility contract")
+	}
+	if strings.Contains(manifest, "volumeClaimTemplates:") {
+		t.Fatal("five-minute empty queue checks must not provision persistent volumes")
+	}
+
+	var workflowFound, scanFound, queueCheckFound, executeFound, dailyFound, workerFound bool
+	for _, doc := range janitorManifestDocs(t) {
+		switch {
+		case doc.Kind == "WorkflowTemplate" && doc.Metadata.Name == "harness-janitor":
+			workflowFound = true
+			if len(doc.Spec.Volumes) != 1 || doc.Spec.Volumes[0].Name != "workspace" || doc.Spec.Volumes[0].EmptyDir.SizeLimit != "10Gi" {
+				t.Fatalf("harness workspace must be one size-limited 10Gi emptyDir: %#v", doc.Spec.Volumes)
+			}
+			for _, tpl := range doc.Spec.Templates {
+				switch tpl.Name {
+				case "scan":
+					scanFound = true
+					if tpl.ActiveDeadlineSeconds != 1800 {
+						t.Errorf("scan activeDeadlineSeconds = %d, want 1800", tpl.ActiveDeadlineSeconds)
+					}
+					script := strings.Join(tpl.Container.Args, "\n")
+					for _, flag := range []string{"--sweep=false", "--reaper-report-bucket"} {
+						if !strings.Contains(script, flag) {
+							t.Errorf("scan command is missing %q", flag)
+						}
+					}
+					assertResources(t, "scan", tpl.Container.Resources.Requests, tpl.Container.Resources.Limits,
+						map[string]string{"cpu": "1", "memory": "4Gi", "ephemeral-storage": "10Gi"},
+						map[string]string{"memory": "6Gi", "ephemeral-storage": "12Gi"})
+				case "queue-check":
+					queueCheckFound = true
+					if tpl.ActiveDeadlineSeconds != 120 {
+						t.Errorf("queue-check activeDeadlineSeconds = %d, want 120", tpl.ActiveDeadlineSeconds)
+					}
+					assertResources(t, "queue-check", tpl.Container.Resources.Requests, tpl.Container.Resources.Limits,
+						map[string]string{"cpu": "100m", "memory": "256Mi"},
+						map[string]string{"memory": "256Mi"})
+				case "execute":
+					executeFound = true
+					if tpl.ActiveDeadlineSeconds != 12600 {
+						t.Errorf("execute activeDeadlineSeconds = %d, want 12600", tpl.ActiveDeadlineSeconds)
+					}
+					if got := tpl.Metadata.Annotations["karpenter.sh/do-not-disrupt"]; got != "true" {
+						t.Errorf("execute do-not-disrupt annotation = %q, want true", got)
+					}
+					script := strings.Join(tpl.Container.Args, "\n")
+					for _, flag := range []string{"reaper-worker", "--action-queue-url", "--result-queue-url", "--control-table"} {
+						if !strings.Contains(script, flag) {
+							t.Errorf("execute command is missing %q", flag)
+						}
+					}
+					assertResources(t, "execute", tpl.Container.Resources.Requests, tpl.Container.Resources.Limits,
+						map[string]string{"cpu": "1", "memory": "4Gi", "ephemeral-storage": "10Gi"},
+						map[string]string{"memory": "6Gi", "ephemeral-storage": "12Gi"})
+				default:
+					if tpl.Container.Resources.Requests["ephemeral-storage"] != "" || tpl.Container.Resources.Limits["ephemeral-storage"] != "" {
+						t.Errorf("template %q unexpectedly reserves workspace ephemeral storage", tpl.Name)
+					}
+				}
+			}
+		case doc.Kind == "CronWorkflow" && doc.Metadata.Name == "harness-janitor":
+			dailyFound = true
+			if doc.Spec.Suspend {
+				t.Error("daily report CronWorkflow must remain active in shadow mode")
+			}
+			if doc.Spec.StartingDeadlineSeconds != 600 || doc.Spec.WorkflowSpec.ActiveDeadlineSeconds != 2400 {
+				t.Errorf("daily deadlines = start %d workflow %d, want 600 and 2400", doc.Spec.StartingDeadlineSeconds, doc.Spec.WorkflowSpec.ActiveDeadlineSeconds)
+			}
+			if doc.Spec.ConcurrencyPolicy != "Forbid" {
+				t.Errorf("daily concurrencyPolicy = %q, want Forbid", doc.Spec.ConcurrencyPolicy)
+			}
+		case doc.Kind == "CronWorkflow" && doc.Metadata.Name == "harness-reaper-worker":
+			workerFound = true
+			if !doc.Spec.Suspend {
+				t.Error("action worker CronWorkflow must remain suspended until cutover")
+			}
+			if doc.Spec.WorkflowSpec.Entrypoint != "consume-one" || doc.Spec.WorkflowSpec.ActiveDeadlineSeconds != 14400 {
+				t.Errorf("worker workflow = entrypoint %q deadline %d, want consume-one and 14400", doc.Spec.WorkflowSpec.Entrypoint, doc.Spec.WorkflowSpec.ActiveDeadlineSeconds)
+			}
+			if doc.Spec.ConcurrencyPolicy != "Forbid" || len(doc.Spec.Schedules) != 1 || doc.Spec.Schedules[0] != "*/5 * * * *" {
+				t.Errorf("worker schedule/concurrency = %#v/%q, want five-minute Forbid", doc.Spec.Schedules, doc.Spec.ConcurrencyPolicy)
+			}
+		}
+	}
+	if !workflowFound || !scanFound || !queueCheckFound || !executeFound || !dailyFound || !workerFound {
+		t.Fatalf("missing expected janitor documents: workflow=%t scan=%t queue-check=%t execute=%t daily=%t worker=%t", workflowFound, scanFound, queueCheckFound, executeFound, dailyFound, workerFound)
+	}
+}
+
+func assertResources(t *testing.T, template string, gotRequests, gotLimits, wantRequests, wantLimits map[string]string) {
+	t.Helper()
+	if !sameStringMap(gotRequests, wantRequests) {
+		t.Errorf("%s requests = %#v, want %#v", template, gotRequests, wantRequests)
+	}
+	if !sameStringMap(gotLimits, wantLimits) {
+		t.Errorf("%s limits = %#v, want %#v", template, gotLimits, wantLimits)
+	}
+}
+
+func sameStringMap(got, want map[string]string) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	for key, value := range want {
+		if got[key] != value {
+			return false
+		}
+	}
+	return true
+}
+
+func workerCLISource(t *testing.T) string {
+	t.Helper()
+	body, err := os.ReadFile("../cmd/harness/reaper_worker.go")
+	if err != nil {
+		t.Fatalf("read reaper_worker.go: %v", err)
+	}
+	return string(body)
 }
 
 // runNotify executes the script with REPORT/SCAN_STATUS/MODE set, against stub vault

--- a/live/tests/harness/janitor_test.go
+++ b/live/tests/harness/janitor_test.go
@@ -1492,7 +1492,7 @@ func TestDefaultSweepBudgetDerivesFromPodDeadline(t *testing.T) {
 	}
 	// 50-janitor-cron.yaml's own comment claims this literal; keep the claim honest.
 	if JanitorPodActiveDeadlineSeconds != 12600 {
-		t.Fatalf("JanitorPodActiveDeadlineSeconds = %d, want 12600 to match 50-janitor-cron.yaml activeDeadlineSeconds - update the YAML comment (and literal) if this ever changes", JanitorPodActiveDeadlineSeconds)
+		t.Fatalf("JanitorPodActiveDeadlineSeconds = %d, want 12600 to match the 50-janitor-cron.yaml execute template deadline - update the YAML comment (and literal) if this ever changes", JanitorPodActiveDeadlineSeconds)
 	}
 }
 

--- a/live/tests/harness/matrix_invariants_test.go
+++ b/live/tests/harness/matrix_invariants_test.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"strings"
 	"testing"
+
+	"gopkg.in/yaml.v3"
 )
 
 // Guards the real matrix.yaml, not testdata/. Everything else in this package
@@ -96,37 +98,59 @@ func TestMatrixConfigsSaltProducesUniqueCustomer(t *testing.T) {
 //     script keeps asserting the old number, EVERY cycle posts "cannot read this
 //     cycle's report" instead of a report - loud, but permanently wrong.
 //   - activeDeadlineSeconds: JanitorPodActiveDeadlineSeconds is the source of truth
-//     Sweep's wall-clock budget is derived from. If the pod's real deadline is shorter
-//     than the constant, Sweep budgets time the pod does not have and a destroy gets
-//     SIGKILLed mid-run - the one failure the budget exists to prevent.
+//     Sweep's wall-clock budget is derived from. The Resource Reaper execute template,
+//     not the report-only scan, must carry it. If the destructive pod's real deadline is
+//     shorter than the constant, Sweep budgets time the pod does not have and a destroy
+//     gets SIGKILLed mid-run - the one failure the budget exists to prevent.
 func TestJanitorCronMatchesTheGoConstants(t *testing.T) {
 	b, err := os.ReadFile("../argo/50-janitor-cron.yaml")
 	if err != nil {
 		t.Fatalf("read 50-janitor-cron.yaml: %v", err)
 	}
-	yaml := string(b)
+	yamlText := string(b)
 
 	wantSchema := fmt.Sprintf(`[ "$SCHEMA_VERSION" != "%d" ]`, JanitorReportSchemaVersion)
-	if !strings.Contains(yaml, wantSchema) {
+	if !strings.Contains(yamlText, wantSchema) {
 		t.Errorf("the notify script does not assert schema_version %d (looked for %s); Go's JanitorReportSchemaVersion and the script's literal have drifted apart",
 			JanitorReportSchemaVersion, wantSchema)
 	}
 
-	wantDeadline := fmt.Sprintf("activeDeadlineSeconds: %d", JanitorPodActiveDeadlineSeconds)
-	if !strings.Contains(yaml, wantDeadline) {
-		t.Errorf("the scan pod does not carry %q; JanitorPodActiveDeadlineSeconds (%d) is the number Sweep's budget is derived from and the pod must actually get that long",
-			wantDeadline, JanitorPodActiveDeadlineSeconds)
+	var templateDoc struct {
+		Kind string `yaml:"kind"`
+		Spec struct {
+			Templates []struct {
+				Name                  string `yaml:"name"`
+				ActiveDeadlineSeconds int    `yaml:"activeDeadlineSeconds"`
+			} `yaml:"templates"`
+		} `yaml:"spec"`
+	}
+	decoder := yaml.NewDecoder(strings.NewReader(yamlText))
+	for templateDoc.Kind != "WorkflowTemplate" {
+		if err := decoder.Decode(&templateDoc); err != nil {
+			t.Fatalf("decode janitor WorkflowTemplate: %v", err)
+		}
+	}
+	executeDeadline := 0
+	for _, template := range templateDoc.Spec.Templates {
+		if template.Name == "execute" {
+			executeDeadline = template.ActiveDeadlineSeconds
+			break
+		}
+	}
+	if executeDeadline != JanitorPodActiveDeadlineSeconds {
+		t.Errorf("Resource Reaper execute activeDeadlineSeconds=%d, want JanitorPodActiveDeadlineSeconds=%d; the destructive pod must receive the full budget",
+			executeDeadline, JanitorPodActiveDeadlineSeconds)
 	}
 
 	// The selector contract, in the other direction: these are the exact state strings
 	// harness/janitor.go emits, and a rename on the Go side that missed the script
 	// would silently drop a whole class of candidate out of Slack.
 	for _, state := range []CandidateState{StateOrphan, StateBlocked, StateResidue, StateUnknown, StateNeedsReview} {
-		if !strings.Contains(yaml, fmt.Sprintf(`.state=="%s"`, state)) {
+		if !strings.Contains(yamlText, fmt.Sprintf(`.state=="%s"`, state)) {
 			t.Errorf("the notify script's selectors never mention state %q; candidates in that state would be invisible in Slack", state)
 		}
 	}
-	if !strings.Contains(yaml, `(.sweep_result // "") != "destroyed"`) {
+	if !strings.Contains(yamlText, `(.sweep_result // "") != "destroyed"`) {
 		t.Error(`the notify script no longer excludes sweep_result "destroyed" from the alarm set; a clean destroy would render under a "teardown FAILED" headline (Sweep leaves State=orphan on purpose)`)
 	}
 }

--- a/live/tests/harness/reaper_contract.go
+++ b/live/tests/harness/reaper_contract.go
@@ -33,6 +33,7 @@ type EngineReport struct {
 	ObservedAt    string              `json:"observed_at"`
 	Account       string              `json:"account"`
 	Status        string              `json:"status"`
+	Shadow        bool                `json:"shadow,omitempty"`
 	CleanupUnits  []EngineCleanupUnit `json:"cleanup_units"`
 	Errors        []string            `json:"errors"`
 }
@@ -61,6 +62,7 @@ type HarnessEngineEvidence struct {
 	KeepOnFailure         bool   `json:"keep_on_failure"`
 	LockPresent           bool   `json:"lock_present"`
 	State                 string `json:"state"`
+	Shadow                bool   `json:"shadow,omitempty"`
 	SweepResult           string `json:"sweep_result,omitempty"`
 	ResidueIndexLagCaveat string `json:"residueIndexLagCaveat,omitempty"`
 }

--- a/live/tests/harness/reaper_contract.go
+++ b/live/tests/harness/reaper_contract.go
@@ -1,0 +1,358 @@
+package harness
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+)
+
+const engineReportSchemaVersion = 1
+
+var (
+	engineReportAccountPattern = regexp.MustCompile(`^[0-9]{12}$`)
+	engineReportRegionPattern  = regexp.MustCompile(`^[a-z0-9-]+$`)
+)
+
+// EngineReport is the shared Resource Reaper producer contract. The legacy janitor
+// Report remains unchanged because its Argo artifact and notification tests consume it.
+type EngineReport struct {
+	SchemaVersion int                 `json:"schema_version"`
+	Engine        string              `json:"engine"`
+	ScanID        string              `json:"scan_id"`
+	ObservedAt    string              `json:"observed_at"`
+	Account       string              `json:"account"`
+	Status        string              `json:"status"`
+	CleanupUnits  []EngineCleanupUnit `json:"cleanup_units"`
+	Errors        []string            `json:"errors"`
+}
+
+type EngineCleanupUnit struct {
+	FindingID            string                `json:"finding_id"`
+	Version              string                `json:"version"`
+	Kind                 string                `json:"kind"`
+	Identity             string                `json:"identity"`
+	Regions              []string              `json:"regions"`
+	Decision             string                `json:"decision"`
+	Reason               string                `json:"reason"`
+	ExpiresAt            *string               `json:"expires_at"`
+	EstimatedMonthlyCost *float64              `json:"estimated_monthly_cost"`
+	Evidence             HarnessEngineEvidence `json:"evidence"`
+	Capabilities         []string              `json:"capabilities"`
+}
+
+type HarnessEngineEvidence struct {
+	StateBucket           string `json:"state_bucket"`
+	StatePrefix           string `json:"state_prefix"`
+	RunID                 string `json:"run_id"`
+	ConfigName            string `json:"config_name"`
+	ResourceCount         int    `json:"resource_count"`
+	WorkflowPhase         string `json:"workflow_phase"`
+	KeepOnFailure         bool   `json:"keep_on_failure"`
+	LockPresent           bool   `json:"lock_present"`
+	State                 string `json:"state"`
+	SweepResult           string `json:"sweep_result,omitempty"`
+	ResidueIndexLagCaveat string `json:"residueIndexLagCaveat,omitempty"`
+}
+
+func hashString(value string) string {
+	sum := sha256.Sum256([]byte(value))
+	return "sha256:" + hex.EncodeToString(sum[:])
+}
+
+// CanonicalHarnessIdentity matches report_contract.canonical_harness_identity.
+func CanonicalHarnessIdentity(stateBucket, statePrefix string) string {
+	return stateBucket + "/" + strings.Trim(statePrefix, "/")
+}
+
+// FindingID is stable for one engine/account/state-prefix identity.
+func FindingID(engine, account, identity string) string {
+	return hashString(engine + "\n" + account + "\n" + identity)
+}
+
+// FindingVersion invalidates an action when any cleanup-relevant source field changes.
+func FindingVersion(candidate Candidate, decision string) string {
+	regions := candidateRegions(candidate)
+	fields := []string{
+		"v1",
+		CanonicalHarnessIdentity(candidate.Bucket, candidate.Prefix),
+		candidate.RunID,
+		strings.Join(regions, ","),
+		decision,
+		candidate.DeleteAfter,
+		strconv.Itoa(candidate.Resources),
+		candidate.WorkflowPhase,
+		strconv.FormatBool(candidate.KeepOnFailure),
+		strconv.FormatBool(candidate.LockAge != ""),
+	}
+	return hashString(strings.Join(fields, "\x00"))
+}
+
+func candidateRegions(candidate Candidate) []string {
+	seen := map[string]bool{}
+	for _, region := range []string{candidate.Region, candidate.DRRegion} {
+		if region != "" {
+			seen[region] = true
+		}
+	}
+	regions := make([]string, 0, len(seen))
+	for region := range seen {
+		regions = append(regions, region)
+	}
+	sort.Strings(regions)
+	return regions
+}
+
+func decisionForCandidate(candidate Candidate) (string, []string, error) {
+	if candidate.SweepResult == sweepResultDestroyed {
+		return "already_gone", []string{"explain"}, nil
+	}
+	switch candidate.State {
+	case StateActive, StateKept:
+		return "protected", []string{"explain", "hold"}, nil
+	case StatePending:
+		return "held", []string{"explain", "hold"}, nil
+	case StateClean:
+		return "already_gone", []string{"explain"}, nil
+	case StateOrphan:
+		return "eligible", []string{"explain", "hold", "sweep"}, nil
+	case StateBlocked, StateNeedsReview, StateUnknown, StateResidue:
+		return "needs_review", []string{"explain", "hold"}, nil
+	default:
+		return "", nil, fmt.Errorf("unsupported candidate state %q", candidate.State)
+	}
+}
+
+func rejectNUL(location string, values ...string) error {
+	for _, value := range values {
+		if strings.ContainsRune(value, '\x00') {
+			return fmt.Errorf("%s must not contain NUL", location)
+		}
+	}
+	return nil
+}
+
+func validateContractTimestamp(value, location string) (time.Time, error) {
+	if err := rejectNUL(location, value); err != nil {
+		return time.Time{}, err
+	}
+	parsed, err := time.Parse(time.RFC3339Nano, value)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("%s must be an RFC3339 timestamp: %w", location, err)
+	}
+	return parsed, nil
+}
+
+func regionFromStateBucket(bucket, account string) string {
+	const marker = "dozuki-terraform-state-"
+	suffix := "-" + account
+	if !strings.HasSuffix(bucket, suffix) {
+		return ""
+	}
+	withoutAccount := strings.TrimSuffix(bucket, suffix)
+	index := strings.LastIndex(withoutAccount, marker)
+	if index < 0 {
+		return ""
+	}
+	return withoutAccount[index+len(marker):]
+}
+
+func normalizeCandidateRegions(candidate Candidate, account string) (Candidate, error) {
+	if candidate.Region == "" && candidate.DRRegion == "" {
+		candidate.Region = regionFromStateBucket(candidate.Bucket, account)
+	}
+	regions := candidateRegions(candidate)
+	if len(regions) == 0 {
+		return candidate, fmt.Errorf("candidate region is required")
+	}
+	for _, region := range regions {
+		if err := rejectNUL("candidate region", region); err != nil {
+			return candidate, err
+		}
+		if !engineReportRegionPattern.MatchString(region) {
+			return candidate, fmt.Errorf("candidate region %q is invalid", region)
+		}
+	}
+	return candidate, nil
+}
+
+// ToEngineReport maps one completed legacy janitor report into Engine Report v1.
+func ToEngineReport(report Report) (EngineReport, error) {
+	if report.SchemaVersion != JanitorReportSchemaVersion {
+		return EngineReport{}, fmt.Errorf("unsupported janitor schema_version %d", report.SchemaVersion)
+	}
+	if report.Mode != "report" && report.Mode != "sweep" {
+		return EngineReport{}, fmt.Errorf("unsupported janitor mode %q", report.Mode)
+	}
+	if !engineReportAccountPattern.MatchString(report.Account) {
+		return EngineReport{}, fmt.Errorf("account must be a 12-digit string")
+	}
+	observed, err := validateContractTimestamp(report.At, "observed_at")
+	if err != nil {
+		return EngineReport{}, err
+	}
+	if err := rejectNUL("report", report.Account, report.Mode); err != nil {
+		return EngineReport{}, err
+	}
+
+	legacyJSON, err := json.Marshal(report)
+	if err != nil {
+		return EngineReport{}, fmt.Errorf("marshal janitor report for scan_id: %w", err)
+	}
+	scanDigest := sha256.Sum256(legacyJSON)
+	scanID := "harness-" + observed.UTC().Format("20060102T150405Z") + "-" + hex.EncodeToString(scanDigest[:6])
+
+	result := EngineReport{
+		SchemaVersion: engineReportSchemaVersion,
+		Engine:        "harness",
+		ScanID:        scanID,
+		ObservedAt:    report.At,
+		Account:       report.Account,
+		Status:        "ok",
+		CleanupUnits:  make([]EngineCleanupUnit, 0, len(report.Candidates)),
+		Errors:        []string{},
+	}
+	if report.Failed > 0 || report.Residue > 0 || report.Inconclusive > 0 {
+		result.Status = "degraded"
+	}
+
+	seen := map[string]bool{}
+	for index, source := range report.Candidates {
+		candidate, regionErr := normalizeCandidateRegions(source, report.Account)
+		if regionErr != nil {
+			return EngineReport{}, fmt.Errorf("candidate %d: %w", index, regionErr)
+		}
+		if err := rejectNUL(
+			fmt.Sprintf("candidate %d", index),
+			candidate.Bucket,
+			candidate.Prefix,
+			candidate.RunID,
+			candidate.ConfigName,
+			candidate.Identifier,
+			candidate.DeleteAfter,
+			string(candidate.State),
+			candidate.Reason,
+			candidate.WorkflowPhase,
+			candidate.LockAge,
+			candidate.SweepResult,
+		); err != nil {
+			return EngineReport{}, err
+		}
+		cleanPrefix := strings.Trim(candidate.Prefix, "/")
+		if candidate.Bucket == "" || cleanPrefix == "" {
+			return EngineReport{}, fmt.Errorf("candidate %d state_bucket and state_prefix must be non-empty", index)
+		}
+		if candidate.Resources < 0 {
+			return EngineReport{}, fmt.Errorf("candidate %d resource_count must be non-negative", index)
+		}
+		decision, capabilities, mapErr := decisionForCandidate(candidate)
+		if mapErr != nil {
+			return EngineReport{}, fmt.Errorf("candidate %d: %w", index, mapErr)
+		}
+		if candidate.State == StateUnknown || candidate.State == StateResidue {
+			result.Status = "degraded"
+		}
+		var expiresAt *string
+		if candidate.DeleteAfter != "" {
+			if _, err := validateContractTimestamp(candidate.DeleteAfter, "expires_at"); err != nil {
+				return EngineReport{}, fmt.Errorf("candidate %d: %w", index, err)
+			}
+			expiry := candidate.DeleteAfter
+			expiresAt = &expiry
+		}
+		identity := CanonicalHarnessIdentity(candidate.Bucket, candidate.Prefix)
+		findingID := FindingID("harness", report.Account, identity)
+		if seen[findingID] {
+			return EngineReport{}, fmt.Errorf("duplicate finding_id %s", findingID)
+		}
+		seen[findingID] = true
+		configName := candidate.ConfigName
+		if configName == "" {
+			configName = "unknown"
+		}
+		evidence := HarnessEngineEvidence{
+			StateBucket:   candidate.Bucket,
+			StatePrefix:   candidate.Prefix,
+			RunID:         candidate.RunID,
+			ConfigName:    configName,
+			ResourceCount: candidate.Resources,
+			WorkflowPhase: candidate.WorkflowPhase,
+			KeepOnFailure: candidate.KeepOnFailure,
+			LockPresent:   candidate.LockAge != "",
+			State:         string(candidate.State),
+			SweepResult:   candidate.SweepResult,
+		}
+		if candidate.State == StateResidue {
+			evidence.ResidueIndexLagCaveat = residueIndexLagCaveat
+		}
+		result.CleanupUnits = append(result.CleanupUnits, EngineCleanupUnit{
+			FindingID:            findingID,
+			Version:              FindingVersion(candidate, decision),
+			Kind:                 "harness-stack",
+			Identity:             identity,
+			Regions:              candidateRegions(candidate),
+			Decision:             decision,
+			Reason:               candidate.Reason,
+			ExpiresAt:            expiresAt,
+			EstimatedMonthlyCost: nil,
+			Evidence:             evidence,
+			Capabilities:         capabilities,
+		})
+	}
+	return result, nil
+}
+
+// EngineReportWriter is the create-only S3 surface used by the shadow producer.
+type EngineReportWriter interface {
+	PutObject(context.Context, *s3.PutObjectInput, ...func(*s3.Options)) (*s3.PutObjectOutput, error)
+}
+
+// WriteEngineReport uploads one immutable report under the shared ingestion prefix.
+func WriteEngineReport(ctx context.Context, writer EngineReportWriter, bucket string, report EngineReport) (string, error) {
+	if writer == nil {
+		return "", fmt.Errorf("engine report writer is required")
+	}
+	if bucket == "" {
+		return "", fmt.Errorf("engine report bucket is required")
+	}
+	if err := rejectNUL("engine report bucket", bucket); err != nil {
+		return "", err
+	}
+	observed, err := validateContractTimestamp(report.ObservedAt, "observed_at")
+	if err != nil {
+		return "", err
+	}
+	if report.Engine != "harness" || report.ScanID == "" {
+		return "", fmt.Errorf("engine report identity is invalid")
+	}
+	body, err := json.Marshal(report)
+	if err != nil {
+		return "", fmt.Errorf("marshal engine report: %w", err)
+	}
+	key := fmt.Sprintf(
+		"engine-reports/harness/%s/%s.json",
+		observed.UTC().Format("2006-01-02"),
+		report.ScanID,
+	)
+	_, err = writer.PutObject(ctx, &s3.PutObjectInput{
+		Bucket:      aws.String(bucket),
+		Key:         aws.String(key),
+		Body:        bytes.NewReader(body),
+		ContentType: aws.String("application/json"),
+		IfNoneMatch: aws.String("*"),
+	})
+	if err != nil {
+		return "", fmt.Errorf("write immutable engine report s3://%s/%s: %w", bucket, key, err)
+	}
+	return key, nil
+}

--- a/live/tests/harness/reaper_contract_test.go
+++ b/live/tests/harness/reaper_contract_test.go
@@ -1,0 +1,315 @@
+package harness
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"os"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+)
+
+const contractAccount = "076248559428"
+
+func contractCandidate(state CandidateState) Candidate {
+	return Candidate{
+		Bucket:        "state-bucket",
+		Prefix:        "/runs/bi-ha/",
+		RunID:         "run-123",
+		ConfigName:    "bi_ha",
+		DeleteAfter:   "2026-08-07T08:00:00Z",
+		State:         state,
+		Reason:        "candidate reason",
+		Resources:     12,
+		WorkflowPhase: "",
+		Region:        "us-west-2",
+		DRRegion:      "us-east-1",
+	}
+}
+
+func contractReport(candidate Candidate) Report {
+	return Report{
+		SchemaVersion: JanitorReportSchemaVersion,
+		Mode:          "report",
+		At:            "2026-08-08T13:00:00Z",
+		Account:       contractAccount,
+		Candidates:    []Candidate{candidate},
+	}
+}
+
+func TestToEngineReportMapsOrphanAsOneEligibleStack(t *testing.T) {
+	got, err := ToEngineReport(contractReport(contractCandidate(StateOrphan)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got.CleanupUnits) != 1 || got.CleanupUnits[0].Decision != "eligible" {
+		t.Fatalf("%+v", got)
+	}
+	if got.CleanupUnits[0].Evidence.ResourceCount != 12 {
+		t.Fatalf("%+v", got.CleanupUnits[0])
+	}
+	if !reflect.DeepEqual(got.CleanupUnits[0].Capabilities, []string{"explain", "hold", "sweep"}) {
+		t.Fatalf("capabilities = %#v", got.CleanupUnits[0].Capabilities)
+	}
+}
+
+func TestToEngineReportMapsEveryCandidateState(t *testing.T) {
+	cases := []struct {
+		state    CandidateState
+		decision string
+	}{
+		{StateActive, "protected"},
+		{StatePending, "held"},
+		{StateClean, "already_gone"},
+		{StateOrphan, "eligible"},
+		{StateKept, "protected"},
+		{StateBlocked, "needs_review"},
+		{StateNeedsReview, "needs_review"},
+		{StateUnknown, "needs_review"},
+		{StateResidue, "needs_review"},
+	}
+	for _, tc := range cases {
+		t.Run(string(tc.state), func(t *testing.T) {
+			got, err := ToEngineReport(contractReport(contractCandidate(tc.state)))
+			if err != nil {
+				t.Fatal(err)
+			}
+			unit := got.CleanupUnits[0]
+			if unit.Decision != tc.decision {
+				t.Fatalf("decision = %q, want %q", unit.Decision, tc.decision)
+			}
+			if tc.state != StateOrphan && containsString(unit.Capabilities, "sweep") {
+				t.Fatalf("non-orphan capabilities = %#v", unit.Capabilities)
+			}
+			if (tc.state == StateUnknown || tc.state == StateResidue) && got.Status != "degraded" {
+				t.Fatalf("status = %q, want degraded", got.Status)
+			}
+		})
+	}
+}
+
+func TestDestroyedSweepResultTakesPrecedenceOverRetainedOrphanState(t *testing.T) {
+	candidate := contractCandidate(StateOrphan)
+	candidate.SweepResult = sweepResultDestroyed
+	got, err := ToEngineReport(contractReport(candidate))
+	if err != nil {
+		t.Fatal(err)
+	}
+	unit := got.CleanupUnits[0]
+	if unit.Decision != "already_gone" || containsString(unit.Capabilities, "sweep") {
+		t.Fatalf("%+v", unit)
+	}
+}
+
+func TestResidueCarriesExactIndexLagCaveat(t *testing.T) {
+	got, err := ToEngineReport(contractReport(contractCandidate(StateResidue)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.CleanupUnits[0].Evidence.ResidueIndexLagCaveat != residueIndexLagCaveat {
+		t.Fatalf("caveat = %q", got.CleanupUnits[0].Evidence.ResidueIndexLagCaveat)
+	}
+}
+
+func TestFindingVersionChangesWhenRunReusesPrefix(t *testing.T) {
+	a := contractCandidate(StateOrphan)
+	b := a
+	b.RunID = "run-456"
+	if FindingVersion(a, "eligible") == FindingVersion(b, "eligible") {
+		t.Fatal("run id must version a finding")
+	}
+	if FindingID("harness", contractAccount, CanonicalHarnessIdentity(a.Bucket, a.Prefix)) !=
+		FindingID("harness", contractAccount, CanonicalHarnessIdentity(b.Bucket, b.Prefix)) {
+		t.Fatal("run id must not change the stable finding id")
+	}
+}
+
+func TestFindingVersionCoversCleanupRelevantFields(t *testing.T) {
+	base := contractCandidate(StateOrphan)
+	baseVersion := FindingVersion(base, "eligible")
+	cases := []struct {
+		name     string
+		decision string
+		mutate   func(*Candidate)
+	}{
+		{"decision", "protected", func(*Candidate) {}},
+		{"expiry", "eligible", func(c *Candidate) { c.DeleteAfter = "2026-08-09T08:00:00Z" }},
+		{"resource count", "eligible", func(c *Candidate) { c.Resources++ }},
+		{"workflow phase", "eligible", func(c *Candidate) { c.WorkflowPhase = "Running" }},
+		{"keep on failure", "eligible", func(c *Candidate) { c.KeepOnFailure = true }},
+		{"lock present", "eligible", func(c *Candidate) { c.LockAge = "5h0m0s" }},
+		{"regions", "eligible", func(c *Candidate) { c.DRRegion = "us-gov-west-1" }},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			candidate := base
+			tc.mutate(&candidate)
+			if got := FindingVersion(candidate, tc.decision); got == baseVersion {
+				t.Fatalf("version did not change: %s", got)
+			}
+		})
+	}
+
+	cosmetic := base
+	cosmetic.Reason = "different human text"
+	if got := FindingVersion(cosmetic, "eligible"); got != baseVersion {
+		t.Fatalf("reason changed version: %s != %s", got, baseVersion)
+	}
+	cosmetic.LockAge = "9h0m0s"
+	base.LockAge = "5h0m0s"
+	if FindingVersion(cosmetic, "eligible") != FindingVersion(base, "eligible") {
+		t.Fatal("lock age changed version even though lock presence stayed true")
+	}
+}
+
+func TestGoIdentityAndHashesMatchPythonGoldenVector(t *testing.T) {
+	body, err := os.ReadFile("testdata/reaper-contract-v1-golden.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var golden struct {
+		CanonicalIdentity string   `json:"canonical_identity"`
+		FindingID         string   `json:"finding_id"`
+		Version           string   `json:"version"`
+		Regions           []string `json:"regions"`
+	}
+	if err := json.Unmarshal(body, &golden); err != nil {
+		t.Fatal(err)
+	}
+	candidate := contractCandidate(StateOrphan)
+	candidate.Region, candidate.DRRegion = golden.Regions[0], golden.Regions[1]
+	for _, prefix := range []string{"/runs/bi-ha/", "runs/bi-ha"} {
+		candidate.Prefix = prefix
+		identity := CanonicalHarnessIdentity(candidate.Bucket, candidate.Prefix)
+		if identity != golden.CanonicalIdentity {
+			t.Fatalf("identity = %q, want %q", identity, golden.CanonicalIdentity)
+		}
+		if got := FindingID("harness", contractAccount, identity); got != golden.FindingID {
+			t.Fatalf("finding id = %q, want %q", got, golden.FindingID)
+		}
+		if got := FindingVersion(candidate, "eligible"); got != golden.Version {
+			t.Fatalf("version = %q, want %q", got, golden.Version)
+		}
+	}
+}
+
+func TestToEngineReportRejectsInvalidSourceValues(t *testing.T) {
+	cases := []struct {
+		name   string
+		mutate func(*Report)
+		want   string
+	}{
+		{"invalid observed timestamp", func(r *Report) { r.At = "not-a-time" }, "observed_at"},
+		{"invalid expiry timestamp", func(r *Report) { r.Candidates[0].DeleteAfter = "tomorrow" }, "expires_at"},
+		{"nul bucket", func(r *Report) { r.Candidates[0].Bucket = "state\x00bucket" }, "NUL"},
+		{"nul run id", func(r *Report) { r.Candidates[0].RunID = "run\x00123" }, "NUL"},
+		{"empty prefix", func(r *Report) { r.Candidates[0].Prefix = "///" }, "state_prefix"},
+		{"missing region", func(r *Report) { r.Candidates[0].Region = ""; r.Candidates[0].DRRegion = "" }, "region"},
+		{"unknown state", func(r *Report) { r.Candidates[0].State = CandidateState("future") }, "state"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rep := contractReport(contractCandidate(StateOrphan))
+			tc.mutate(&rep)
+			if _, err := ToEngineReport(rep); err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error = %v, want substring %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestToEngineReportPreservesEarlyNeedsReviewCandidate(t *testing.T) {
+	candidate := Candidate{
+		Bucket: "prefix-dozuki-terraform-state-us-east-1-" + contractAccount,
+		Prefix: "unreadable-run/",
+		State:  StateNeedsReview,
+		Reason: "manifest unreadable",
+	}
+	got, err := ToEngineReport(contractReport(candidate))
+	if err != nil {
+		t.Fatal(err)
+	}
+	unit := got.CleanupUnits[0]
+	if !reflect.DeepEqual(unit.Regions, []string{"us-east-1"}) {
+		t.Fatalf("regions = %#v", unit.Regions)
+	}
+	if unit.Evidence.ConfigName != "unknown" || unit.Decision != "needs_review" {
+		t.Fatalf("unit = %+v", unit)
+	}
+}
+
+func containsString(values []string, target string) bool {
+	for _, value := range values {
+		if value == target {
+			return true
+		}
+	}
+	return false
+}
+
+type recordingEngineReportWriter struct {
+	input *s3.PutObjectInput
+	err   error
+}
+
+func (writer *recordingEngineReportWriter) PutObject(_ context.Context, input *s3.PutObjectInput, _ ...func(*s3.Options)) (*s3.PutObjectOutput, error) {
+	writer.input = input
+	return &s3.PutObjectOutput{}, writer.err
+}
+
+func TestWriteEngineReportUsesImmutableIngestionKey(t *testing.T) {
+	report, err := ToEngineReport(contractReport(contractCandidate(StateOrphan)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	writer := &recordingEngineReportWriter{}
+	key, err := WriteEngineReport(context.Background(), writer, "reaper-reports", report)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantKey := "engine-reports/harness/2026-08-08/" + report.ScanID + ".json"
+	if key != wantKey || aws.ToString(writer.input.Key) != wantKey {
+		t.Fatalf("key = %q input key = %q, want %q", key, aws.ToString(writer.input.Key), wantKey)
+	}
+	if aws.ToString(writer.input.IfNoneMatch) != "*" {
+		t.Fatalf("IfNoneMatch = %q, want *", aws.ToString(writer.input.IfNoneMatch))
+	}
+	body, err := io.ReadAll(writer.input.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var decoded EngineReport
+	if err := json.Unmarshal(body, &decoded); err != nil {
+		t.Fatal(err)
+	}
+	if decoded.ScanID != report.ScanID || decoded.CleanupUnits[0].FindingID != report.CleanupUnits[0].FindingID {
+		t.Fatalf("uploaded report = %+v", decoded)
+	}
+}
+
+func TestWriteEngineReportReturnsConditionalWriteFailure(t *testing.T) {
+	report, err := ToEngineReport(contractReport(contractCandidate(StateOrphan)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	writer := &recordingEngineReportWriter{err: errors.New("precondition failed")}
+	if _, err := WriteEngineReport(context.Background(), writer, "reaper-reports", report); err == nil || !strings.Contains(err.Error(), "precondition failed") {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestEphemeralHarnessStacksCarryEngineOwnershipTag(t *testing.T) {
+	body, err := os.ReadFile("../../root.hcl")
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := `%{if local.delete_after != ""}"reaper:engine" = "harness"%{endif}`
+	if count := strings.Count(string(body), want); count != 1 {
+		t.Fatalf("conditional ownership tag count = %d, want 1", count)
+	}
+}

--- a/live/tests/harness/reaper_worker.go
+++ b/live/tests/harness/reaper_worker.go
@@ -1,0 +1,712 @@
+package harness
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	ddbtypes "github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/sqs"
+	"github.com/aws/smithy-go"
+)
+
+var (
+	ErrStale                = errors.New("resource reaper action is stale")
+	ErrBlocked              = errors.New("resource reaper action is blocked")
+	ErrAlreadyGone          = errors.New("resource reaper target is already gone")
+	ErrTeardown             = errors.New("resource reaper teardown failed")
+	ErrMessageNotInflight   = errors.New("resource reaper request is no longer in flight")
+	ErrControlMismatch      = errors.New("resource reaper control record does not match request")
+	ErrRetryable            = errors.New("resource reaper action should be retried")
+	reaperWorkerHashPattern = regexp.MustCompile(`^sha256:[0-9a-f]{64}$`)
+	reaperActionIDPattern   = regexp.MustCompile(`^[A-Za-z0-9-]{1,128}$`)
+)
+
+const activeActionLeaseSeconds int64 = 21600
+
+type ReaperActionRequest struct {
+	SchemaVersion   int    `json:"schema_version"`
+	ActionID        string `json:"action_id"`
+	Action          string `json:"action"`
+	Engine          string `json:"engine"`
+	Account         string `json:"account"`
+	ScanID          string `json:"scan_id"`
+	FindingID       string `json:"finding_id"`
+	ExpectedVersion string `json:"expected_version"`
+	Identity        string `json:"identity"`
+	Actor           string `json:"actor"`
+	Reason          string `json:"reason"`
+	RequestedAt     int64  `json:"requested_at"`
+}
+
+type ActionResult struct {
+	SchemaVersion int               `json:"schema_version"`
+	ActionID      string            `json:"action_id"`
+	EventType     string            `json:"event_type"`
+	Status        string            `json:"status"`
+	Engine        string            `json:"engine"`
+	FindingID     string            `json:"finding_id"`
+	OccurredAt    int64             `json:"occurred_at"`
+	Message       string            `json:"message"`
+	Evidence      map[string]string `json:"evidence,omitempty"`
+}
+
+type ReceivedReaperAction struct {
+	MessageID     string
+	ReceiptHandle string
+	Body          string
+}
+
+type ReaperControlState struct {
+	ActionExists    bool
+	ActionStatus    string
+	ActiveActionID  string
+	ActiveExpiresAt int64
+	HoldActive      bool
+}
+
+type ReaperWorkerIO interface {
+	ReceiveAction(context.Context, string, int32) (*ReceivedReaperAction, error)
+	LoadControl(context.Context, string, ReaperActionRequest, int64) (ReaperControlState, error)
+	SendResult(context.Context, string, ActionResult) error
+	DeleteAction(context.Context, string, string) error
+	ChangeActionVisibility(context.Context, string, string, int32) error
+}
+
+type ReaperSQSAPI interface {
+	ReceiveMessage(context.Context, *sqs.ReceiveMessageInput, ...func(*sqs.Options)) (*sqs.ReceiveMessageOutput, error)
+	SendMessage(context.Context, *sqs.SendMessageInput, ...func(*sqs.Options)) (*sqs.SendMessageOutput, error)
+	DeleteMessage(context.Context, *sqs.DeleteMessageInput, ...func(*sqs.Options)) (*sqs.DeleteMessageOutput, error)
+	ChangeMessageVisibility(context.Context, *sqs.ChangeMessageVisibilityInput, ...func(*sqs.Options)) (*sqs.ChangeMessageVisibilityOutput, error)
+}
+
+type ReaperDynamoAPI interface {
+	GetItem(context.Context, *dynamodb.GetItemInput, ...func(*dynamodb.Options)) (*dynamodb.GetItemOutput, error)
+}
+
+type AWSReaperWorkerIO struct {
+	Queue   ReaperSQSAPI
+	Control ReaperDynamoAPI
+}
+
+func (adapter *AWSReaperWorkerIO) ReceiveAction(ctx context.Context, queueURL string, visibility int32) (*ReceivedReaperAction, error) {
+	output, err := adapter.Queue.ReceiveMessage(ctx, &sqs.ReceiveMessageInput{
+		QueueUrl:            aws.String(queueURL),
+		MaxNumberOfMessages: 1,
+		VisibilityTimeout:   visibility,
+		WaitTimeSeconds:     20,
+	})
+	if err != nil {
+		return nil, err
+	}
+	if len(output.Messages) == 0 {
+		return nil, nil
+	}
+	message := output.Messages[0]
+	return &ReceivedReaperAction{
+		MessageID:     aws.ToString(message.MessageId),
+		ReceiptHandle: aws.ToString(message.ReceiptHandle),
+		Body:          aws.ToString(message.Body),
+	}, nil
+}
+
+func dynamoString(item map[string]ddbtypes.AttributeValue, key string) string {
+	if value, ok := item[key].(*ddbtypes.AttributeValueMemberS); ok {
+		return value.Value
+	}
+	return ""
+}
+
+func dynamoInt64(item map[string]ddbtypes.AttributeValue, key string) int64 {
+	if value, ok := item[key].(*ddbtypes.AttributeValueMemberN); ok {
+		parsed, _ := strconv.ParseInt(value.Value, 10, 64)
+		return parsed
+	}
+	return 0
+}
+
+func (adapter *AWSReaperWorkerIO) getControlItem(ctx context.Context, table, pk string) (map[string]ddbtypes.AttributeValue, error) {
+	output, err := adapter.Control.GetItem(ctx, &dynamodb.GetItemInput{
+		TableName:      aws.String(table),
+		ConsistentRead: aws.Bool(true),
+		Key: map[string]ddbtypes.AttributeValue{
+			"PK": &ddbtypes.AttributeValueMemberS{Value: pk},
+			"SK": &ddbtypes.AttributeValueMemberS{Value: "META"},
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+	return output.Item, nil
+}
+
+func (adapter *AWSReaperWorkerIO) LoadControl(ctx context.Context, table string, request ReaperActionRequest, now int64) (ReaperControlState, error) {
+	action, err := adapter.getControlItem(ctx, table, "ACTION#"+request.ActionID)
+	if err != nil {
+		return ReaperControlState{}, err
+	}
+	active, err := adapter.getControlItem(ctx, table, "ACTIVE#harness#"+request.FindingID)
+	if err != nil {
+		return ReaperControlState{}, err
+	}
+	hold, err := adapter.getControlItem(ctx, table, "HOLD#harness#"+request.FindingID)
+	if err != nil {
+		return ReaperControlState{}, err
+	}
+	state := ReaperControlState{
+		ActionExists:    len(action) > 0,
+		ActionStatus:    dynamoString(action, "status"),
+		ActiveActionID:  dynamoString(active, "action_id"),
+		ActiveExpiresAt: dynamoInt64(active, "ttl_epoch_seconds"),
+	}
+	if len(action) > 0 {
+		for field, expected := range map[string]string{
+			"action_id": request.ActionID, "action": request.Action,
+			"engine": request.Engine, "account": request.Account,
+			"scan_id": request.ScanID, "finding_id": request.FindingID,
+			"expected_version": request.ExpectedVersion, "identity": request.Identity,
+			"actor": request.Actor, "reason": request.Reason,
+		} {
+			if dynamoString(action, field) != expected {
+				return ReaperControlState{}, fmt.Errorf("%w: action field %s", ErrControlMismatch, field)
+			}
+		}
+		if dynamoInt64(action, "requested_at") != request.RequestedAt {
+			return ReaperControlState{}, fmt.Errorf("%w: action field requested_at", ErrControlMismatch)
+		}
+	}
+	if len(hold) > 0 {
+		expires := dynamoInt64(hold, "expires_at")
+		state.HoldActive = expires == 0 || expires > now
+	}
+	return state, nil
+}
+
+func (adapter *AWSReaperWorkerIO) SendResult(ctx context.Context, queueURL string, result ActionResult) error {
+	body, err := json.Marshal(result)
+	if err != nil {
+		return err
+	}
+	_, err = adapter.Queue.SendMessage(ctx, &sqs.SendMessageInput{
+		QueueUrl:               aws.String(queueURL),
+		MessageBody:            aws.String(string(body)),
+		MessageGroupId:         aws.String(result.FindingID),
+		MessageDeduplicationId: aws.String(result.ActionID + ":" + result.EventType),
+	})
+	return err
+}
+
+func (adapter *AWSReaperWorkerIO) DeleteAction(ctx context.Context, queueURL, receiptHandle string) error {
+	_, err := adapter.Queue.DeleteMessage(ctx, &sqs.DeleteMessageInput{
+		QueueUrl: aws.String(queueURL), ReceiptHandle: aws.String(receiptHandle),
+	})
+	return err
+}
+
+func (adapter *AWSReaperWorkerIO) ChangeActionVisibility(ctx context.Context, queueURL, receiptHandle string, visibility int32) error {
+	_, err := adapter.Queue.ChangeMessageVisibility(ctx, &sqs.ChangeMessageVisibilityInput{
+		QueueUrl: aws.String(queueURL), ReceiptHandle: aws.String(receiptHandle),
+		VisibilityTimeout: visibility,
+	})
+	if err == nil {
+		return nil
+	}
+	var apiError smithy.APIError
+	if errors.As(err, &apiError) {
+		switch apiError.ErrorCode() {
+		case "MessageNotInflight", "ReceiptHandleIsInvalid", "InvalidParameterValue":
+			return fmt.Errorf("%w: %s", ErrMessageNotInflight, apiError.ErrorMessage())
+		}
+	}
+	return err
+}
+
+type SelectedSweeper interface {
+	SweepSelected(context.Context, *Report, string, string) (Candidate, error)
+}
+
+type ReaperWorkerDeps struct {
+	IO        ReaperWorkerIO
+	Sweeper   SelectedSweeper
+	FinalVeto func(context.Context, ReaperActionRequest, Candidate) error
+}
+
+type actionPreparedSweeper interface {
+	PrepareReaperAction(ReaperActionRequest, func(context.Context, ReaperActionRequest, Candidate) error)
+}
+
+type ReaperWorkerOptions struct {
+	ActionQueueURL           string
+	ResultQueueURL           string
+	ControlTable             string
+	AccountID                string
+	VisibilityTimeoutSeconds int32
+	PollTimeout              time.Duration
+	PollInterval             time.Duration
+	HeartbeatInterval        time.Duration
+	HeartbeatRetryInterval   time.Duration
+	Now                      func() time.Time
+}
+
+func (options ReaperWorkerOptions) now() time.Time {
+	if options.Now != nil {
+		return options.Now().UTC()
+	}
+	return time.Now().UTC()
+}
+
+func (options ReaperWorkerOptions) defaults() ReaperWorkerOptions {
+	if options.VisibilityTimeoutSeconds <= 0 {
+		options.VisibilityTimeoutSeconds = 13500
+	}
+	if options.PollTimeout <= 0 {
+		options.PollTimeout = 60 * time.Second
+	}
+	if options.PollInterval <= 0 {
+		options.PollInterval = time.Second
+	}
+	if options.HeartbeatInterval <= 0 {
+		half := time.Duration(options.VisibilityTimeoutSeconds) * time.Second / 2
+		options.HeartbeatInterval = half - time.Minute
+		if options.HeartbeatInterval <= 0 {
+			options.HeartbeatInterval = half / 2
+		}
+	}
+	if options.HeartbeatRetryInterval <= 0 {
+		options.HeartbeatRetryInterval = 30 * time.Second
+	}
+	return options
+}
+
+func validateReaperAction(request ReaperActionRequest, account string) error {
+	if request.SchemaVersion != 1 {
+		return fmt.Errorf("unsupported action schema_version %d", request.SchemaVersion)
+	}
+	if request.Engine != "harness" || request.Action != "sweep" {
+		return fmt.Errorf("unsupported engine/action %q/%q", request.Engine, request.Action)
+	}
+	if request.Account != account || !engineReportAccountPattern.MatchString(request.Account) {
+		return fmt.Errorf("action account %q does not match worker account", request.Account)
+	}
+	if request.ActionID == "" || request.ScanID == "" || request.Identity == "" || request.Actor == "" || strings.TrimSpace(request.Reason) == "" {
+		return fmt.Errorf("action identity, actor, and reason are required")
+	}
+	if !reaperActionIDPattern.MatchString(request.ActionID) || len(request.ScanID) > 128 || len([]rune(request.Reason)) > 2000 {
+		return fmt.Errorf("action_id, scan_id, or reason is invalid or too long")
+	}
+	if !reaperWorkerHashPattern.MatchString(request.FindingID) || !reaperWorkerHashPattern.MatchString(request.ExpectedVersion) {
+		return fmt.Errorf("action finding_id or expected_version is invalid")
+	}
+	if request.FindingID != FindingID("harness", request.Account, request.Identity) {
+		return fmt.Errorf("action finding_id does not match account and identity")
+	}
+	if err := rejectNUL(
+		"action",
+		request.ActionID,
+		request.ScanID,
+		request.Identity,
+		request.Actor,
+		request.Reason,
+	); err != nil {
+		return err
+	}
+	if request.RequestedAt < 0 {
+		return fmt.Errorf("requested_at must be non-negative")
+	}
+	if _, err := actionStatePrefix(request.Identity); err != nil {
+		return err
+	}
+	return nil
+}
+
+func actionStatePrefix(identity string) (string, error) {
+	separator := strings.Index(identity, "/")
+	if separator <= 0 || separator == len(identity)-1 {
+		return "", fmt.Errorf("action identity must contain state bucket and prefix")
+	}
+	prefix := strings.Trim(identity[separator+1:], "/")
+	if prefix == "" {
+		return "", fmt.Errorf("action identity state prefix is empty")
+	}
+	return prefix, nil
+}
+
+func workerResult(options ReaperWorkerOptions, request ReaperActionRequest, status, message string) ActionResult {
+	if message == "" {
+		message = "Harness action update."
+	}
+	if runes := []rune(message); len(runes) > 2000 {
+		message = string(runes[:2000])
+	}
+	return ActionResult{
+		SchemaVersion: 1,
+		ActionID:      request.ActionID,
+		EventType:     status,
+		Status:        status,
+		Engine:        "harness",
+		FindingID:     request.FindingID,
+		OccurredAt:    options.now().Unix(),
+		Message:       message,
+	}
+}
+
+func sendTerminalAndDelete(
+	ctx context.Context,
+	io ReaperWorkerIO,
+	options ReaperWorkerOptions,
+	request ReaperActionRequest,
+	message *ReceivedReaperAction,
+	result ActionResult,
+) (ActionResult, error) {
+	if err := io.SendResult(ctx, options.ResultQueueURL, result); err != nil {
+		return ActionResult{}, fmt.Errorf("send %s result: %w", result.Status, err)
+	}
+	if err := io.DeleteAction(ctx, options.ActionQueueURL, message.ReceiptHandle); err != nil {
+		return ActionResult{}, fmt.Errorf("delete completed action request: %w", err)
+	}
+	return result, nil
+}
+
+func releaseActionForRetry(ctx context.Context, io ReaperWorkerIO, options ReaperWorkerOptions, message *ReceivedReaperAction, cause error) error {
+	return deferActionForRetry(ctx, io, options, message, 0, cause)
+}
+
+func deferActionForRetry(ctx context.Context, io ReaperWorkerIO, options ReaperWorkerOptions, message *ReceivedReaperAction, visibility int32, cause error) error {
+	if err := io.ChangeActionVisibility(ctx, options.ActionQueueURL, message.ReceiptHandle, visibility); err != nil {
+		return errors.Join(cause, fmt.Errorf("release action request for retry: %w", err))
+	}
+	return cause
+}
+
+func activeControl(state ReaperControlState, request ReaperActionRequest, now int64) bool {
+	return state.ActionExists &&
+		state.ActiveActionID == request.ActionID &&
+		state.ActiveExpiresAt >= now
+}
+
+func executionLeaseReady(state ReaperControlState, request ReaperActionRequest, now int64) bool {
+	return activeControl(state, request, now) &&
+		state.ActiveExpiresAt >= now+int64(JanitorPodActiveDeadlineSeconds)
+}
+
+var terminalActionStatuses = map[string]bool{
+	"succeeded": true, "partial": true, "blocked": true, "stale": true,
+	"failed": true, "cancelled": true, "already_gone": true, "visibility_lost": true,
+}
+
+func waitForRunning(
+	ctx context.Context,
+	io ReaperWorkerIO,
+	options ReaperWorkerOptions,
+	request ReaperActionRequest,
+	runningAt int64,
+) (ReaperControlState, error) {
+	deadline := time.NewTimer(options.PollTimeout)
+	defer deadline.Stop()
+	ticker := time.NewTicker(options.PollInterval)
+	defer ticker.Stop()
+	for {
+		state, err := io.LoadControl(ctx, options.ControlTable, request, options.now().Unix())
+		if err != nil {
+			return ReaperControlState{}, err
+		}
+		if state.ActionStatus == "cancelled" || state.HoldActive {
+			return state, nil
+		}
+		if state.ActionStatus == "running" && activeControl(state, request, options.now().Unix()) && state.ActiveExpiresAt >= runningAt+activeActionLeaseSeconds {
+			return state, nil
+		}
+		select {
+		case <-ctx.Done():
+			return ReaperControlState{}, ctx.Err()
+		case <-deadline.C:
+			return ReaperControlState{}, fmt.Errorf("timed out waiting for committed running action")
+		case <-ticker.C:
+		}
+	}
+}
+
+type heartbeatOutcome struct {
+	result ActionResult
+	err    error
+}
+
+func startVisibilityHeartbeat(
+	ctx context.Context,
+	io ReaperWorkerIO,
+	options ReaperWorkerOptions,
+	request ReaperActionRequest,
+	message *ReceivedReaperAction,
+	cancelSweep context.CancelFunc,
+) (context.CancelFunc, <-chan heartbeatOutcome) {
+	heartbeatContext, cancel := context.WithCancel(ctx)
+	finished := make(chan heartbeatOutcome, 1)
+	go func() {
+		timer := time.NewTimer(options.HeartbeatInterval)
+		defer timer.Stop()
+		visibleUntil := time.Now().Add(time.Duration(options.VisibilityTimeoutSeconds) * time.Second)
+		for {
+			select {
+			case <-heartbeatContext.Done():
+				finished <- heartbeatOutcome{}
+				return
+			case <-timer.C:
+				err := io.ChangeActionVisibility(
+					heartbeatContext,
+					options.ActionQueueURL,
+					message.ReceiptHandle,
+					options.VisibilityTimeoutSeconds,
+				)
+				if heartbeatContext.Err() != nil {
+					finished <- heartbeatOutcome{}
+					return
+				}
+				if err == nil {
+					visibleUntil = time.Now().Add(time.Duration(options.VisibilityTimeoutSeconds) * time.Second)
+					timer.Reset(options.HeartbeatInterval)
+					continue
+				}
+				// A transient API error is not visibility loss. Keep retrying while the
+				// last known visibility grant still has a one-minute safety margin.
+				if !errors.Is(err, ErrMessageNotInflight) && time.Until(visibleUntil) > time.Minute+options.HeartbeatRetryInterval {
+					timer.Reset(options.HeartbeatRetryInterval)
+					continue
+				}
+				cancelSweep()
+				result := workerResult(options, request, "visibility_lost", "Action request visibility was lost while teardown was running; outcome requires review.")
+				result.Evidence = map[string]string{
+					"severity": "alarm", "outcome": "inconclusive", "error": err.Error(),
+					"teardown": "cancellation_requested",
+				}
+				sendErr := io.SendResult(context.WithoutCancel(ctx), options.ResultQueueURL, result)
+				finished <- heartbeatOutcome{result: result, err: sendErr}
+				return
+			}
+		}
+	}()
+	return cancel, finished
+}
+
+func mapSweepResult(options ReaperWorkerOptions, request ReaperActionRequest, candidate Candidate, sweepErr error) (ActionResult, error) {
+	switch {
+	case errors.Is(sweepErr, ErrStale):
+		return workerResult(options, request, "stale", "Harness finding changed after the action was requested; nothing was destroyed."), nil
+	case errors.Is(sweepErr, ErrBlocked):
+		return workerResult(options, request, "blocked", "Harness cleanup was blocked by the final safety check; nothing was destroyed."), nil
+	case errors.Is(sweepErr, ErrControlMismatch):
+		return workerResult(options, request, "blocked", "Harness control record no longer matches the queued request; nothing was destroyed."), nil
+	case errors.Is(sweepErr, ErrAlreadyGone):
+		return workerResult(options, request, "already_gone", "Harness resources were already gone; no teardown was needed."), nil
+	case errors.Is(sweepErr, ErrTeardown):
+		return workerResult(options, request, "failed", "Harness teardown failed; inspect the action worker logs."), nil
+	case errors.Is(sweepErr, ErrRetryable):
+		return ActionResult{}, sweepErr
+	case sweepErr != nil:
+		result := workerResult(options, request, "failed", "Harness cleanup stopped on an unexpected worker error; automatic destructive retry was suppressed.")
+		result.Evidence = map[string]string{"severity": "alarm", "error": sweepErr.Error()}
+		return result, nil
+	case candidate.State == StateResidue:
+		result := workerResult(options, request, "partial", candidate.Reason)
+		result.Evidence = map[string]string{"residueIndexLagCaveat": residueIndexLagCaveat}
+		return result, nil
+	case candidate.State == StateUnknown:
+		message := candidate.SweepResult
+		if message == "" {
+			message = candidate.Reason
+		}
+		result := workerResult(options, request, "failed", message)
+		result.Evidence = map[string]string{"severity": "alarm", "outcome": "inconclusive", "state": string(StateUnknown)}
+		return result, nil
+	case candidate.SweepResult == sweepResultDestroyed:
+		return workerResult(options, request, "succeeded", "Harness teardown completed and no tagged resources remain."), nil
+	default:
+		return workerResult(options, request, "blocked", "Harness cleanup did not reach a destructive terminal outcome."), nil
+	}
+}
+
+// ProcessReaperAction receives and processes at most one FIFO cleanup request.
+func ProcessReaperAction(ctx context.Context, deps ReaperWorkerDeps, options ReaperWorkerOptions) (ActionResult, error) {
+	options = options.defaults()
+	if deps.IO == nil || deps.Sweeper == nil || deps.FinalVeto == nil {
+		return ActionResult{}, fmt.Errorf("reaper worker IO, sweeper, and final veto are required")
+	}
+	message, err := deps.IO.ReceiveAction(ctx, options.ActionQueueURL, options.VisibilityTimeoutSeconds)
+	if err != nil {
+		return ActionResult{}, fmt.Errorf("receive action: %w", err)
+	}
+	if message == nil {
+		return ActionResult{Status: "empty"}, nil
+	}
+	var request ReaperActionRequest
+	if err := json.Unmarshal([]byte(message.Body), &request); err != nil {
+		return ActionResult{}, deferActionForRetry(ctx, deps.IO, options, message, 30, fmt.Errorf("decode action request: %w", err))
+	}
+	if err := validateReaperAction(request, options.AccountID); err != nil {
+		return ActionResult{}, deferActionForRetry(ctx, deps.IO, options, message, 30, err)
+	}
+	now := options.now().Unix()
+	state, err := deps.IO.LoadControl(ctx, options.ControlTable, request, now)
+	if err != nil {
+		if errors.Is(err, ErrControlMismatch) {
+			result := workerResult(options, request, "blocked", "Harness control record does not match the queued request; nothing was destroyed.")
+			result.Evidence = map[string]string{"severity": "alarm", "error": err.Error()}
+			return sendTerminalAndDelete(ctx, deps.IO, options, request, message, result)
+		}
+		return ActionResult{}, releaseActionForRetry(
+			ctx, deps.IO, options, message,
+			fmt.Errorf("load action control state: %w", err),
+		)
+	}
+	if terminalActionStatuses[state.ActionStatus] {
+		if err := deps.IO.DeleteAction(ctx, options.ActionQueueURL, message.ReceiptHandle); err != nil {
+			return ActionResult{}, err
+		}
+		return workerResult(options, request, state.ActionStatus, "Duplicate delivery observed after the action reached a terminal state."), nil
+	}
+	if !state.ActionExists {
+		if err := deps.IO.DeleteAction(ctx, options.ActionQueueURL, message.ReceiptHandle); err != nil {
+			return ActionResult{}, err
+		}
+		return workerResult(options, request, "blocked", "Action record is missing; the queue message was discarded without teardown."), nil
+	}
+	if !activeControl(state, request, now) || state.HoldActive {
+		result := workerResult(options, request, "blocked", "Harness action or active marker is missing, expired, mismatched, or held; nothing was destroyed.")
+		return sendTerminalAndDelete(ctx, deps.IO, options, request, message, result)
+	}
+	if state.ActionStatus == "running" && !executionLeaseReady(state, request, now) {
+		result := workerResult(options, request, "blocked", "Harness running-action lease is too short to cover the worker deadline; nothing was destroyed.")
+		return sendTerminalAndDelete(ctx, deps.IO, options, request, message, result)
+	}
+	if state.ActionStatus == "queued" {
+		running := workerResult(options, request, "running", "Harness action worker accepted the request and is revalidating the target.")
+		if err := deps.IO.SendResult(ctx, options.ResultQueueURL, running); err != nil {
+			return ActionResult{}, releaseActionForRetry(
+				ctx, deps.IO, options, message,
+				fmt.Errorf("send running result: %w", err),
+			)
+		}
+		state, err = waitForRunning(ctx, deps.IO, options, request, running.OccurredAt)
+		if err != nil {
+			return ActionResult{}, releaseActionForRetry(ctx, deps.IO, options, message, err)
+		}
+		if state.ActionStatus == "cancelled" || state.HoldActive {
+			status := "blocked"
+			if state.ActionStatus == "cancelled" {
+				status = "cancelled"
+			}
+			result := workerResult(options, request, status, "Harness action changed while the worker waited for running state; nothing was destroyed.")
+			return sendTerminalAndDelete(ctx, deps.IO, options, request, message, result)
+		}
+	} else if state.ActionStatus != "running" {
+		return ActionResult{}, releaseActionForRetry(
+			ctx, deps.IO, options, message,
+			fmt.Errorf("action status %q is not executable", state.ActionStatus),
+		)
+	}
+
+	prefix, err := actionStatePrefix(request.Identity)
+	if err != nil {
+		return ActionResult{}, err
+	}
+	sweepContext, cancelSweep := context.WithCancel(ctx)
+	defer cancelSweep()
+	cancelHeartbeat, heartbeatFinished := startVisibilityHeartbeat(ctx, deps.IO, options, request, message, cancelSweep)
+	prepared, ok := deps.Sweeper.(actionPreparedSweeper)
+	if !ok {
+		cancelHeartbeat()
+		<-heartbeatFinished
+		return ActionResult{}, releaseActionForRetry(
+			ctx, deps.IO, options, message,
+			fmt.Errorf("selected sweeper cannot install the final control-plane veto"),
+		)
+	}
+	prepared.PrepareReaperAction(request, deps.FinalVeto)
+	candidate, sweepErr := deps.Sweeper.SweepSelected(sweepContext, nil, prefix, request.ExpectedVersion)
+	cancelHeartbeat()
+	heartbeat := <-heartbeatFinished
+	if heartbeat.result.Status == "visibility_lost" {
+		if heartbeat.err != nil {
+			return ActionResult{}, fmt.Errorf("send visibility_lost result: %w", heartbeat.err)
+		}
+		return heartbeat.result, nil
+	}
+	result, err := mapSweepResult(options, request, candidate, sweepErr)
+	if err != nil {
+		return ActionResult{}, releaseActionForRetry(ctx, deps.IO, options, message, err)
+	}
+	return sendTerminalAndDelete(ctx, deps.IO, options, request, message, result)
+}
+
+func createOnlyConflict(err error) bool {
+	var apiError smithy.APIError
+	if !errors.As(err, &apiError) {
+		return false
+	}
+	return apiError.ErrorCode() == "PreconditionFailed" || apiError.ErrorCode() == "ConditionalRequestConflict"
+}
+
+// DrainCancelledReaperAction is the rollback-only queue drain. It archives and
+// acknowledges one action only when the durable control record is already cancelled.
+func DrainCancelledReaperAction(
+	ctx context.Context,
+	io ReaperWorkerIO,
+	archive EngineReportWriter,
+	archiveBucket string,
+	options ReaperWorkerOptions,
+) (ActionResult, error) {
+	options = options.defaults()
+	if io == nil || archive == nil || archiveBucket == "" {
+		return ActionResult{}, fmt.Errorf("cancelled-action queue and archive dependencies are required")
+	}
+	message, err := io.ReceiveAction(ctx, options.ActionQueueURL, options.VisibilityTimeoutSeconds)
+	if err != nil {
+		return ActionResult{}, fmt.Errorf("receive cancelled action: %w", err)
+	}
+	if message == nil {
+		return ActionResult{Status: "empty"}, nil
+	}
+	var request ReaperActionRequest
+	if err := json.Unmarshal([]byte(message.Body), &request); err != nil {
+		return ActionResult{}, fmt.Errorf("decode cancelled action: %w", err)
+	}
+	if err := validateReaperAction(request, options.AccountID); err != nil {
+		return ActionResult{}, err
+	}
+	state, err := io.LoadControl(ctx, options.ControlTable, request, options.now().Unix())
+	if err != nil {
+		return ActionResult{}, err
+	}
+	if !state.ActionExists || state.ActionStatus != "cancelled" {
+		return ActionResult{}, releaseActionForRetry(
+			ctx, io, options, message,
+			fmt.Errorf("action %s is not marked cancelled", request.ActionID),
+		)
+	}
+	result := workerResult(options, request, "cancelled", "Cancelled action archived during Resource Reaper rollback; no teardown was attempted.")
+	body, err := json.Marshal(struct {
+		Request ReaperActionRequest `json:"request"`
+		Result  ActionResult        `json:"result"`
+	}{Request: request, Result: result})
+	if err != nil {
+		return ActionResult{}, err
+	}
+	key := "cancelled-actions/" + request.ActionID + ".json"
+	_, err = archive.PutObject(ctx, &s3.PutObjectInput{
+		Bucket: aws.String(archiveBucket), Key: aws.String(key),
+		Body: bytes.NewReader(body), ContentType: aws.String("application/json"),
+		IfNoneMatch: aws.String("*"),
+	})
+	if err != nil && !createOnlyConflict(err) {
+		return ActionResult{}, fmt.Errorf("archive cancelled action: %w", err)
+	}
+	return sendTerminalAndDelete(ctx, io, options, request, message, result)
+}

--- a/live/tests/harness/reaper_worker_test.go
+++ b/live/tests/harness/reaper_worker_test.go
@@ -1,0 +1,754 @@
+package harness
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	ddbtypes "github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+	"github.com/aws/aws-sdk-go-v2/service/sqs"
+	"github.com/aws/smithy-go"
+)
+
+func workerAction() ReaperActionRequest {
+	return ReaperActionRequest{
+		SchemaVersion:   1,
+		ActionID:        "A1",
+		Action:          "sweep",
+		Engine:          "harness",
+		Account:         contractAccount,
+		ScanID:          "scan-1",
+		FindingID:       "sha256:019406da27ce5a07617306ec9f386a2c4fd4d28b97e098426a6f8c3802aaafb8",
+		ExpectedVersion: "sha256:cd817dda89287de462248e01e8e400cb6ed7853723643e4bff0417315457e90d",
+		Identity:        "state-bucket/runs/bi-ha",
+		Actor:           "U1",
+		Reason:          "cleanup",
+		RequestedAt:     900,
+	}
+}
+
+type fakeWorkerIO struct {
+	mu               sync.Mutex
+	message          *ReceivedReaperAction
+	states           []ReaperControlState
+	loadCalls        int
+	loadErrors       []error
+	results          []ActionResult
+	deleted          bool
+	visibilityCalls  int
+	visibilityValues []int32
+	visibilityErrors []error
+}
+
+func newFakeWorkerIO(t *testing.T, states ...ReaperControlState) *fakeWorkerIO {
+	t.Helper()
+	body, err := json.Marshal(workerAction())
+	if err != nil {
+		t.Fatal(err)
+	}
+	return &fakeWorkerIO{
+		message: &ReceivedReaperAction{MessageID: "m1", ReceiptHandle: "receipt-1", Body: string(body)},
+		states:  states,
+	}
+}
+
+func (f *fakeWorkerIO) ReceiveAction(context.Context, string, int32) (*ReceivedReaperAction, error) {
+	return f.message, nil
+}
+
+func (f *fakeWorkerIO) LoadControl(context.Context, string, ReaperActionRequest, int64) (ReaperControlState, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	index := f.loadCalls
+	f.loadCalls++
+	if index < len(f.loadErrors) && f.loadErrors[index] != nil {
+		return ReaperControlState{}, f.loadErrors[index]
+	}
+	if len(f.states) == 0 {
+		return ReaperControlState{}, nil
+	}
+	if index >= len(f.states) {
+		index = len(f.states) - 1
+	}
+	return f.states[index], nil
+}
+
+func (f *fakeWorkerIO) SendResult(_ context.Context, _ string, result ActionResult) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.results = append(f.results, result)
+	return nil
+}
+
+func (f *fakeWorkerIO) DeleteAction(context.Context, string, string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.deleted = true
+	return nil
+}
+
+func (f *fakeWorkerIO) ChangeActionVisibility(_ context.Context, _, _ string, visibility int32) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	index := f.visibilityCalls
+	f.visibilityCalls++
+	f.visibilityValues = append(f.visibilityValues, visibility)
+	if index < len(f.visibilityErrors) {
+		return f.visibilityErrors[index]
+	}
+	return nil
+}
+
+type fakeSelectedSweeper struct {
+	candidate Candidate
+	err       error
+	prefixes  []string
+	delay     time.Duration
+	cancelled bool
+	request   ReaperActionRequest
+	veto      func(context.Context, ReaperActionRequest, Candidate) error
+}
+
+func (f *fakeSelectedSweeper) PrepareReaperAction(request ReaperActionRequest, veto func(context.Context, ReaperActionRequest, Candidate) error) {
+	f.request = request
+	f.veto = veto
+}
+
+func (f *fakeSelectedSweeper) SweepSelected(ctx context.Context, _ *Report, prefix, _ string) (Candidate, error) {
+	f.prefixes = append(f.prefixes, prefix)
+	if f.veto != nil {
+		if err := f.veto(ctx, f.request, f.candidate); err != nil {
+			return f.candidate, err
+		}
+	}
+	if f.delay > 0 {
+		select {
+		case <-time.After(f.delay):
+		case <-ctx.Done():
+			f.cancelled = true
+			return Candidate{}, ctx.Err()
+		}
+	}
+	return f.candidate, f.err
+}
+
+func queuedControl() ReaperControlState {
+	return ReaperControlState{
+		ActionExists: true, ActionStatus: "queued",
+		ActiveActionID: "A1", ActiveExpiresAt: 22600,
+	}
+}
+
+func runningControl() ReaperControlState {
+	state := queuedControl()
+	state.ActionStatus = "running"
+	return state
+}
+
+func workerOptions() ReaperWorkerOptions {
+	return ReaperWorkerOptions{
+		ActionQueueURL: "actions", ResultQueueURL: "results", ControlTable: "control",
+		AccountID: contractAccount, VisibilityTimeoutSeconds: 13500,
+		PollTimeout: time.Second, PollInterval: time.Millisecond,
+		Now: func() time.Time { return time.Unix(1000, 0).UTC() },
+	}
+}
+
+func allowReaperAction(context.Context, ReaperActionRequest, Candidate) error { return nil }
+
+func workerDeps(io ReaperWorkerIO, sweeper SelectedSweeper) ReaperWorkerDeps {
+	return ReaperWorkerDeps{IO: io, Sweeper: sweeper, FinalVeto: allowReaperAction}
+}
+
+func TestReaperWorkerRequiresFinalControlPlaneVeto(t *testing.T) {
+	io := newFakeWorkerIO(t, runningControl())
+	_, err := ProcessReaperAction(
+		context.Background(), ReaperWorkerDeps{IO: io, Sweeper: &fakeSelectedSweeper{}}, workerOptions(),
+	)
+	if err == nil || !strings.Contains(err.Error(), "final veto") || io.loadCalls != 0 {
+		t.Fatalf("err=%v loadCalls=%d", err, io.loadCalls)
+	}
+}
+
+func TestProcessSweepTargetsExactlyOnePrefix(t *testing.T) {
+	io := newFakeWorkerIO(t, queuedControl(), runningControl())
+	sweeper := &fakeSelectedSweeper{candidate: Candidate{State: StateOrphan, SweepResult: sweepResultDestroyed}}
+	result, err := ProcessReaperAction(context.Background(), workerDeps(io, sweeper), workerOptions())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Status != "succeeded" || len(sweeper.prefixes) != 1 || sweeper.prefixes[0] != "runs/bi-ha" {
+		t.Fatalf("result=%+v prefixes=%#v", result, sweeper.prefixes)
+	}
+	if !io.deleted || len(io.results) != 2 || io.results[0].Status != "running" || io.results[1].Status != "succeeded" {
+		t.Fatalf("deleted=%v results=%+v", io.deleted, io.results)
+	}
+}
+
+func TestProcessSweepRejectsChangedFindingVersion(t *testing.T) {
+	io := newFakeWorkerIO(t, queuedControl(), runningControl())
+	sweeper := &fakeSelectedSweeper{err: ErrStale}
+	result, err := ProcessReaperAction(context.Background(), workerDeps(io, sweeper), workerOptions())
+	if err != nil || result.Status != "stale" || !io.deleted {
+		t.Fatalf("result=%+v err=%v deleted=%v", result, err, io.deleted)
+	}
+}
+
+func TestProcessSweepRejectsNewActiveWorkflow(t *testing.T) {
+	io := newFakeWorkerIO(t, queuedControl(), runningControl())
+	sweeper := &fakeSelectedSweeper{err: ErrBlocked}
+	result, err := ProcessReaperAction(context.Background(), workerDeps(io, sweeper), workerOptions())
+	if err != nil || result.Status != "blocked" || !io.deleted {
+		t.Fatalf("result=%+v err=%v deleted=%v", result, err, io.deleted)
+	}
+}
+
+func TestReaperWorkerRejectsHoldAddedAfterQueueing(t *testing.T) {
+	state := queuedControl()
+	state.HoldActive = true
+	io := newFakeWorkerIO(t, state)
+	sweeper := &fakeSelectedSweeper{}
+	result, err := ProcessReaperAction(context.Background(), workerDeps(io, sweeper), workerOptions())
+	if err != nil || result.Status != "blocked" || len(sweeper.prefixes) != 0 || !io.deleted {
+		t.Fatalf("result=%+v err=%v prefixes=%#v deleted=%v", result, err, sweeper.prefixes, io.deleted)
+	}
+}
+
+func TestReaperWorkerFinalVetoSeesHoldAddedDuringFreshScan(t *testing.T) {
+	candidate := selectedCandidate("runs/bi-ha/", StateOrphan)
+	report := contractReport(candidate)
+	var teardownCalls []string
+	janitor := selectedJanitor(&report, &teardownCalls)
+	hold := runningControl()
+	hold.HoldActive = true
+	io := newFakeWorkerIO(t, queuedControl(), runningControl(), hold)
+	finalVeto := func(ctx context.Context, request ReaperActionRequest, _ Candidate) error {
+		state, err := io.LoadControl(ctx, "control", request, 1000)
+		if err != nil {
+			return err
+		}
+		if state.HoldActive {
+			return ErrBlocked
+		}
+		return nil
+	}
+	result, err := ProcessReaperAction(
+		context.Background(),
+		ReaperWorkerDeps{IO: io, Sweeper: janitor, FinalVeto: finalVeto},
+		workerOptions(),
+	)
+	if err != nil || result.Status != "blocked" || len(teardownCalls) != 0 || !io.deleted {
+		t.Fatalf("result=%+v err=%v teardown=%#v deleted=%v", result, err, teardownCalls, io.deleted)
+	}
+}
+
+func TestReaperWorkerDoesNotRunCancelledAction(t *testing.T) {
+	state := queuedControl()
+	state.ActionStatus = "cancelled"
+	io := newFakeWorkerIO(t, state)
+	sweeper := &fakeSelectedSweeper{}
+	result, err := ProcessReaperAction(context.Background(), workerDeps(io, sweeper), workerOptions())
+	if err != nil || result.Status != "cancelled" || len(sweeper.prefixes) != 0 || !io.deleted {
+		t.Fatalf("result=%+v err=%v", result, err)
+	}
+}
+
+func TestReaperWorkerRejectsExpiredOrMismatchedActiveMarker(t *testing.T) {
+	for _, state := range []ReaperControlState{
+		{ActionExists: true, ActionStatus: "queued", ActiveActionID: "A1", ActiveExpiresAt: 999},
+		{ActionExists: true, ActionStatus: "queued", ActiveActionID: "other", ActiveExpiresAt: 22600},
+		{ActionExists: false},
+	} {
+		io := newFakeWorkerIO(t, state)
+		result, err := ProcessReaperAction(context.Background(), workerDeps(io, &fakeSelectedSweeper{}), workerOptions())
+		if err != nil || result.Status != "blocked" || !io.deleted {
+			t.Fatalf("state=%+v result=%+v err=%v deleted=%v", state, result, err, io.deleted)
+		}
+	}
+}
+
+func TestReaperWorkerMapsTerminalSweepOutcomes(t *testing.T) {
+	cases := []struct {
+		name      string
+		candidate Candidate
+		sweepErr  error
+		want      string
+	}{
+		{"already gone", Candidate{}, ErrAlreadyGone, "already_gone"},
+		{"teardown failed", Candidate{}, ErrTeardown, "failed"},
+		{"residue", Candidate{State: StateResidue, Reason: residueIndexLagCaveat}, nil, "partial"},
+		{"post destroy query failed", Candidate{State: StateUnknown, Reason: "old orphan reason", SweepResult: "destroy ran, but the post-destroy query failed"}, nil, "failed"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			io := newFakeWorkerIO(t, queuedControl(), runningControl())
+			result, err := ProcessReaperAction(
+				context.Background(),
+				workerDeps(io, &fakeSelectedSweeper{candidate: tc.candidate, err: tc.sweepErr}),
+				workerOptions(),
+			)
+			if err != nil || result.Status != tc.want || !io.deleted {
+				t.Fatalf("result=%+v err=%v deleted=%v", result, err, io.deleted)
+			}
+			if tc.want == "partial" && result.Evidence["residueIndexLagCaveat"] != residueIndexLagCaveat {
+				t.Fatalf("evidence=%#v", result.Evidence)
+			}
+			if tc.name == "post destroy query failed" && result.Message != tc.candidate.SweepResult {
+				t.Fatalf("message=%q want=%q", result.Message, tc.candidate.SweepResult)
+			}
+			if tc.name == "post destroy query failed" && (result.Evidence["outcome"] != "inconclusive" || result.Evidence["severity"] != "alarm") {
+				t.Fatalf("evidence=%#v", result.Evidence)
+			}
+		})
+	}
+}
+
+func TestReaperWorkerAcknowledgesDuplicateAfterTerminalState(t *testing.T) {
+	state := queuedControl()
+	state.ActionStatus = "succeeded"
+	state.ActiveActionID = ""
+	io := newFakeWorkerIO(t, state)
+	result, err := ProcessReaperAction(context.Background(), workerDeps(io, &fakeSelectedSweeper{}), workerOptions())
+	if err != nil || result.Status != "succeeded" || !io.deleted || len(io.results) != 0 {
+		t.Fatalf("result=%+v err=%v deleted=%v results=%+v", result, err, io.deleted, io.results)
+	}
+}
+
+func TestReaperWorkerRunsRedeliveredRunningActionWithFullLease(t *testing.T) {
+	io := newFakeWorkerIO(t, runningControl())
+	sweeper := &fakeSelectedSweeper{candidate: Candidate{State: StateOrphan, SweepResult: sweepResultDestroyed}}
+	result, err := ProcessReaperAction(
+		context.Background(), workerDeps(io, sweeper), workerOptions(),
+	)
+	if err != nil || result.Status != "succeeded" || len(io.results) != 1 || io.results[0].Status != "succeeded" || !io.deleted {
+		t.Fatalf("result=%+v err=%v results=%+v deleted=%v", result, err, io.results, io.deleted)
+	}
+}
+
+func TestReaperWorkerBlocksRunningRedeliveryWithoutFullExecutionLease(t *testing.T) {
+	state := runningControl()
+	state.ActiveExpiresAt = 1001
+	io := newFakeWorkerIO(t, state)
+	sweeper := &fakeSelectedSweeper{}
+	result, err := ProcessReaperAction(
+		context.Background(), workerDeps(io, sweeper), workerOptions(),
+	)
+	if err != nil || result.Status != "blocked" || len(sweeper.prefixes) != 0 || !io.deleted {
+		t.Fatalf("result=%+v err=%v prefixes=%#v deleted=%v", result, err, sweeper.prefixes, io.deleted)
+	}
+}
+
+func TestReaperWorkerVisibilityLossIsAlarmLevelAndNeverDeletesRequest(t *testing.T) {
+	io := newFakeWorkerIO(t, queuedControl(), runningControl())
+	io.visibilityErrors = []error{errors.New("temporary"), ErrMessageNotInflight}
+	sweeper := &fakeSelectedSweeper{candidate: Candidate{State: StateOrphan, SweepResult: sweepResultDestroyed}, delay: 30 * time.Millisecond}
+	opts := workerOptions()
+	opts.HeartbeatInterval = time.Millisecond
+	opts.HeartbeatRetryInterval = time.Millisecond
+	result, err := ProcessReaperAction(context.Background(), workerDeps(io, sweeper), opts)
+	if err != nil || result.Status != "visibility_lost" || io.deleted || !sweeper.cancelled {
+		t.Fatalf("result=%+v err=%v deleted=%v cancelled=%v", result, err, io.deleted, sweeper.cancelled)
+	}
+	if got := io.results[len(io.results)-1].Status; got != "visibility_lost" {
+		t.Fatalf("last result status = %q, results=%+v", got, io.results)
+	}
+}
+
+func TestReaperWorkerRetriesTransientHeartbeatUntilVisibilityIsActuallyLost(t *testing.T) {
+	io := newFakeWorkerIO(t, queuedControl(), runningControl())
+	io.visibilityErrors = []error{errors.New("temporary one"), errors.New("temporary two")}
+	sweeper := &fakeSelectedSweeper{candidate: Candidate{State: StateOrphan, SweepResult: sweepResultDestroyed}, delay: 10 * time.Millisecond}
+	opts := workerOptions()
+	opts.HeartbeatInterval = time.Millisecond
+	opts.HeartbeatRetryInterval = time.Millisecond
+	result, err := ProcessReaperAction(context.Background(), workerDeps(io, sweeper), opts)
+	if err != nil || result.Status != "succeeded" || io.visibilityCalls < 3 || io.deleted == false {
+		t.Fatalf("result=%+v err=%v visibilityCalls=%d deleted=%v", result, err, io.visibilityCalls, io.deleted)
+	}
+}
+
+func TestReaperWorkerHeartbeatCancellationIsNotVisibilityLoss(t *testing.T) {
+	io := newFakeWorkerIO(t, queuedControl(), runningControl())
+	io.visibilityErrors = []error{errors.New("temporary")}
+	sweeper := &fakeSelectedSweeper{candidate: Candidate{State: StateOrphan, SweepResult: sweepResultDestroyed}, delay: 3 * time.Millisecond}
+	opts := workerOptions()
+	opts.HeartbeatInterval = time.Millisecond
+	opts.HeartbeatRetryInterval = time.Hour
+	result, err := ProcessReaperAction(context.Background(), workerDeps(io, sweeper), opts)
+	if err != nil || result.Status != "succeeded" || !io.deleted {
+		t.Fatalf("result=%+v err=%v deleted=%v results=%+v", result, err, io.deleted, io.results)
+	}
+}
+
+func TestReaperWorkerHeartbeatRunsBeforeHalfTheVisibilityWindow(t *testing.T) {
+	opts := (ReaperWorkerOptions{VisibilityTimeoutSeconds: 13500}).defaults()
+	half := time.Duration(opts.VisibilityTimeoutSeconds) * time.Second / 2
+	if opts.HeartbeatInterval <= 0 || opts.HeartbeatInterval >= half {
+		t.Fatalf("heartbeat=%s half=%s", opts.HeartbeatInterval, half)
+	}
+}
+
+func TestReaperWorkerInvalidMessageIsReleasedQuicklyForDLQ(t *testing.T) {
+	io := newFakeWorkerIO(t)
+	io.message.Body = `{"schema_version":2}`
+	_, err := ProcessReaperAction(context.Background(), workerDeps(io, &fakeSelectedSweeper{}), workerOptions())
+	if err == nil || io.deleted || len(io.results) != 0 || len(io.visibilityValues) != 1 || io.visibilityValues[0] != 30 {
+		t.Fatalf("err=%v deleted=%v results=%+v visibility=%#v", err, io.deleted, io.results, io.visibilityValues)
+	}
+}
+
+func TestReaperWorkerTreatsControlMismatchAsTerminalBlocked(t *testing.T) {
+	io := newFakeWorkerIO(t)
+	io.loadErrors = []error{fmt.Errorf("%w: actor", ErrControlMismatch)}
+	result, err := ProcessReaperAction(context.Background(), workerDeps(io, &fakeSelectedSweeper{}), workerOptions())
+	if err != nil || result.Status != "blocked" || !io.deleted || len(io.visibilityValues) != 0 {
+		t.Fatalf("result=%+v err=%v deleted=%v visibility=%#v", result, err, io.deleted, io.visibilityValues)
+	}
+}
+
+func TestReaperWorkerReleasesMessageAfterRunningPollTimeout(t *testing.T) {
+	io := newFakeWorkerIO(t, queuedControl())
+	opts := workerOptions()
+	opts.PollTimeout = 5 * time.Millisecond
+	_, err := ProcessReaperAction(
+		context.Background(), workerDeps(io, &fakeSelectedSweeper{}), opts,
+	)
+	if err == nil || io.deleted || len(io.visibilityValues) == 0 || io.visibilityValues[len(io.visibilityValues)-1] != 0 {
+		t.Fatalf("err=%v deleted=%v visibility=%#v", err, io.deleted, io.visibilityValues)
+	}
+}
+
+func TestReaperWorkerRequiresTheCommittedSixHourRunningLease(t *testing.T) {
+	short := runningControl()
+	short.ActiveExpiresAt--
+	io := newFakeWorkerIO(t, queuedControl(), short)
+	opts := workerOptions()
+	opts.PollTimeout = 5 * time.Millisecond
+	_, err := ProcessReaperAction(
+		context.Background(), workerDeps(io, &fakeSelectedSweeper{}), opts,
+	)
+	if err == nil || io.deleted || len(io.visibilityValues) == 0 || io.visibilityValues[len(io.visibilityValues)-1] != 0 {
+		t.Fatalf("err=%v deleted=%v visibility=%#v", err, io.deleted, io.visibilityValues)
+	}
+}
+
+func TestReaperWorkerHonorsCancellationWhileWaitingForRunning(t *testing.T) {
+	cancelled := queuedControl()
+	cancelled.ActionStatus = "cancelled"
+	io := newFakeWorkerIO(t, queuedControl(), cancelled)
+	sweeper := &fakeSelectedSweeper{}
+	result, err := ProcessReaperAction(
+		context.Background(), workerDeps(io, sweeper), workerOptions(),
+	)
+	if err != nil || result.Status != "cancelled" || len(sweeper.prefixes) != 0 || !io.deleted {
+		t.Fatalf("result=%+v err=%v prefixes=%#v deleted=%v", result, err, sweeper.prefixes, io.deleted)
+	}
+}
+
+func TestReaperWorkerReleasesMessageAfterPreTeardownScanFailure(t *testing.T) {
+	io := newFakeWorkerIO(t, queuedControl(), runningControl())
+	sweeper := &fakeSelectedSweeper{err: fmt.Errorf("%w: scan unavailable", ErrRetryable)}
+	_, err := ProcessReaperAction(
+		context.Background(), workerDeps(io, sweeper), workerOptions(),
+	)
+	if err == nil || io.deleted || len(io.visibilityValues) == 0 || io.visibilityValues[len(io.visibilityValues)-1] != 0 {
+		t.Fatalf("err=%v deleted=%v visibility=%#v", err, io.deleted, io.visibilityValues)
+	}
+}
+
+func selectedCandidate(prefix string, state CandidateState) Candidate {
+	candidate := contractCandidate(state)
+	candidate.Prefix = prefix
+	candidate.ConfigName = "min_default"
+	candidate.Identifier = "smokeaa-min"
+	candidate.Customer = "smokeaa"
+	return candidate
+}
+
+func selectedJanitor(report *Report, teardownCalls *[]string) *Janitor {
+	return &Janitor{
+		Deps: JanitorDeps{
+			Tags: map[string]TagAPI{
+				"us-east-1": &fakeTagAPI{},
+				"us-west-2": &fakeTagAPI{},
+			},
+			Matrix: testMatrix(),
+			Teardown: func(_ context.Context, params PhaseParams, _ bool) error {
+				*teardownCalls = append(*teardownCalls, params.RunID)
+				return nil
+			},
+		},
+		Options: testOptions(time.Unix(1000, 0).UTC()),
+		ScanFunc: func(context.Context, JanitorDeps, JanitorOptions, JanitorWorkflowList) (*Report, error) {
+			copy := *report
+			copy.Candidates = append([]Candidate(nil), report.Candidates...)
+			return &copy, nil
+		},
+	}
+}
+
+func TestSweepSelectedRejectsChangedFindingVersion(t *testing.T) {
+	report := contractReport(selectedCandidate("runs/bi-ha/", StateOrphan))
+	var teardownCalls []string
+	janitor := selectedJanitor(&report, &teardownCalls)
+	_, err := janitor.SweepSelected(context.Background(), &Report{}, "runs/bi-ha", "sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")
+	if !errors.Is(err, ErrStale) || len(teardownCalls) != 0 {
+		t.Fatalf("err=%v teardown=%#v", err, teardownCalls)
+	}
+}
+
+func TestSweepSelectedRejectsNewActiveWorkflow(t *testing.T) {
+	candidate := selectedCandidate("runs/bi-ha/", StateActive)
+	report := contractReport(candidate)
+	engineReport, err := ToEngineReport(report)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var teardownCalls []string
+	janitor := selectedJanitor(&report, &teardownCalls)
+	_, err = janitor.SweepSelected(context.Background(), &Report{}, "runs/bi-ha", engineReport.CleanupUnits[0].Version)
+	if !errors.Is(err, ErrBlocked) || len(teardownCalls) != 0 {
+		t.Fatalf("err=%v teardown=%#v", err, teardownCalls)
+	}
+}
+
+func TestSweepSelectedTargetsExactlyOnePrefix(t *testing.T) {
+	target := selectedCandidate("runs/run-a/", StateOrphan)
+	target.RunID = "run-a"
+	other := selectedCandidate("runs/run-b/", StateOrphan)
+	other.RunID = "run-b"
+	report := contractReport(target)
+	report.Candidates = []Candidate{target, other}
+	engineReport, err := ToEngineReport(report)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var teardownCalls []string
+	janitor := selectedJanitor(&report, &teardownCalls)
+	var selected Report
+	candidate, err := janitor.SweepSelected(context.Background(), &selected, "runs/run-a", engineReport.CleanupUnits[0].Version)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if candidate.SweepResult != sweepResultDestroyed || len(teardownCalls) != 1 || teardownCalls[0] != "run-a" || len(selected.Candidates) != 1 {
+		t.Fatalf("candidate=%+v teardown=%#v report=%+v", candidate, teardownCalls, selected)
+	}
+}
+
+func TestSweepSelectedRunsFinalVetoAfterFreshScan(t *testing.T) {
+	candidate := selectedCandidate("runs/bi-ha/", StateOrphan)
+	report := contractReport(candidate)
+	engineReport, err := ToEngineReport(report)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var teardownCalls []string
+	janitor := selectedJanitor(&report, &teardownCalls)
+	janitor.FinalVeto = func(context.Context, Candidate) error { return ErrBlocked }
+	_, err = janitor.SweepSelected(context.Background(), &Report{}, "runs/bi-ha", engineReport.CleanupUnits[0].Version)
+	if !errors.Is(err, ErrBlocked) || len(teardownCalls) != 0 {
+		t.Fatalf("err=%v teardown=%#v", err, teardownCalls)
+	}
+}
+
+func TestSweepSelectedRejectsProtectedHeldAndKeptCandidates(t *testing.T) {
+	cases := []Candidate{
+		selectedCandidate("runs/active/", StateBlocked),
+		selectedCandidate("runs/kept/", StateKept),
+		selectedCandidate("runs/protected/", StateOrphan),
+	}
+	cases[2].Identifier = "dev-min"
+	for _, candidate := range cases {
+		report := contractReport(candidate)
+		engineReport, err := ToEngineReport(report)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var teardownCalls []string
+		janitor := selectedJanitor(&report, &teardownCalls)
+		_, err = janitor.SweepSelected(
+			context.Background(), &Report{}, candidate.Prefix,
+			engineReport.CleanupUnits[0].Version,
+		)
+		if !errors.Is(err, ErrBlocked) || len(teardownCalls) != 0 {
+			t.Fatalf("candidate=%+v err=%v teardown=%#v", candidate, err, teardownCalls)
+		}
+	}
+}
+
+func TestReaperWorkerDrainsOnlyCancelledActions(t *testing.T) {
+	state := queuedControl()
+	state.ActionStatus = "cancelled"
+	io := newFakeWorkerIO(t, state)
+	archive := &recordingEngineReportWriter{}
+	result, err := DrainCancelledReaperAction(
+		context.Background(), io, archive, "reaper-reports", workerOptions(),
+	)
+	if err != nil || result.Status != "cancelled" || !io.deleted {
+		t.Fatalf("result=%+v err=%v deleted=%v", result, err, io.deleted)
+	}
+	if archive.input == nil || *archive.input.Key != "cancelled-actions/A1.json" || *archive.input.IfNoneMatch != "*" {
+		t.Fatalf("archive input=%+v", archive.input)
+	}
+	if len(io.results) != 1 || io.results[0].Status != "cancelled" {
+		t.Fatalf("results=%+v", io.results)
+	}
+}
+
+func TestReaperWorkerDrainLeavesNonCancelledActionInQueue(t *testing.T) {
+	io := newFakeWorkerIO(t, queuedControl())
+	archive := &recordingEngineReportWriter{}
+	_, err := DrainCancelledReaperAction(
+		context.Background(), io, archive, "reaper-reports", workerOptions(),
+	)
+	if err == nil || io.deleted || archive.input != nil || len(io.results) != 0 || len(io.visibilityValues) == 0 || io.visibilityValues[len(io.visibilityValues)-1] != 0 {
+		t.Fatalf("err=%v deleted=%v archive=%+v results=%+v visibility=%#v", err, io.deleted, archive.input, io.results, io.visibilityValues)
+	}
+}
+
+type fakeAWSWorkerQueue struct {
+	sent            *sqs.SendMessageInput
+	received        *sqs.ReceiveMessageInput
+	visibilityError error
+}
+
+func (f *fakeAWSWorkerQueue) ReceiveMessage(_ context.Context, input *sqs.ReceiveMessageInput, _ ...func(*sqs.Options)) (*sqs.ReceiveMessageOutput, error) {
+	f.received = input
+	return &sqs.ReceiveMessageOutput{}, nil
+}
+
+func (f *fakeAWSWorkerQueue) SendMessage(_ context.Context, input *sqs.SendMessageInput, _ ...func(*sqs.Options)) (*sqs.SendMessageOutput, error) {
+	f.sent = input
+	return &sqs.SendMessageOutput{}, nil
+}
+
+func (f *fakeAWSWorkerQueue) DeleteMessage(context.Context, *sqs.DeleteMessageInput, ...func(*sqs.Options)) (*sqs.DeleteMessageOutput, error) {
+	return &sqs.DeleteMessageOutput{}, nil
+}
+
+func (f *fakeAWSWorkerQueue) ChangeMessageVisibility(context.Context, *sqs.ChangeMessageVisibilityInput, ...func(*sqs.Options)) (*sqs.ChangeMessageVisibilityOutput, error) {
+	return &sqs.ChangeMessageVisibilityOutput{}, f.visibilityError
+}
+
+type fakeAWSWorkerControl struct {
+	items  map[string]map[string]ddbtypes.AttributeValue
+	inputs []*dynamodb.GetItemInput
+}
+
+func (f *fakeAWSWorkerControl) GetItem(_ context.Context, input *dynamodb.GetItemInput, _ ...func(*dynamodb.Options)) (*dynamodb.GetItemOutput, error) {
+	f.inputs = append(f.inputs, input)
+	pk := input.Key["PK"].(*ddbtypes.AttributeValueMemberS).Value
+	return &dynamodb.GetItemOutput{Item: f.items[pk]}, nil
+}
+
+func stringItem(values map[string]string) map[string]ddbtypes.AttributeValue {
+	item := map[string]ddbtypes.AttributeValue{}
+	for key, value := range values {
+		item[key] = &ddbtypes.AttributeValueMemberS{Value: value}
+	}
+	return item
+}
+
+func TestAWSReaperWorkerIOReadsExactConsistentControlKeys(t *testing.T) {
+	request := workerAction()
+	action := stringItem(map[string]string{
+		"action_id": request.ActionID, "action": request.Action,
+		"engine": request.Engine, "account": request.Account,
+		"scan_id": request.ScanID, "finding_id": request.FindingID,
+		"expected_version": request.ExpectedVersion, "identity": request.Identity,
+		"actor": request.Actor, "reason": request.Reason,
+		"status": "running",
+	})
+	action["requested_at"] = &ddbtypes.AttributeValueMemberN{Value: "900"}
+	active := stringItem(map[string]string{"action_id": request.ActionID})
+	active["ttl_epoch_seconds"] = &ddbtypes.AttributeValueMemberN{Value: "22600"}
+	control := &fakeAWSWorkerControl{items: map[string]map[string]ddbtypes.AttributeValue{
+		"ACTION#A1":                           action,
+		"ACTIVE#harness#" + request.FindingID: active,
+		"HOLD#harness#" + request.FindingID:   {},
+	}}
+	adapter := &AWSReaperWorkerIO{Queue: &fakeAWSWorkerQueue{}, Control: control}
+	state, err := adapter.LoadControl(context.Background(), "control", request, 1000)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if state.ActionStatus != "running" || state.ActiveExpiresAt != 22600 || state.HoldActive {
+		t.Fatalf("state=%+v", state)
+	}
+	if len(control.inputs) != 3 {
+		t.Fatalf("GetItem calls=%d", len(control.inputs))
+	}
+	for _, input := range control.inputs {
+		if !aws.ToBool(input.ConsistentRead) || aws.ToString(input.TableName) != "control" {
+			t.Fatalf("input=%+v", input)
+		}
+	}
+}
+
+func TestAWSReaperWorkerIOSendsFIFOResultIdentifiers(t *testing.T) {
+	queue := &fakeAWSWorkerQueue{}
+	adapter := &AWSReaperWorkerIO{Queue: queue}
+	result := workerResult(workerOptions(), workerAction(), "running", "started")
+	if err := adapter.SendResult(context.Background(), "results", result); err != nil {
+		t.Fatal(err)
+	}
+	if aws.ToString(queue.sent.MessageGroupId) != result.FindingID || aws.ToString(queue.sent.MessageDeduplicationId) != "A1:running" {
+		t.Fatalf("send=%+v", queue.sent)
+	}
+}
+
+func TestAWSReaperWorkerIOUsesLongPolling(t *testing.T) {
+	queue := &fakeAWSWorkerQueue{}
+	adapter := &AWSReaperWorkerIO{Queue: queue}
+	if _, err := adapter.ReceiveAction(context.Background(), "actions", 13500); err != nil {
+		t.Fatal(err)
+	}
+	if queue.received.WaitTimeSeconds < 10 || queue.received.MaxNumberOfMessages != 1 {
+		t.Fatalf("receive=%+v", queue.received)
+	}
+}
+
+func TestAWSReaperWorkerIORejectsControlRecordMismatch(t *testing.T) {
+	request := workerAction()
+	action := stringItem(map[string]string{
+		"action_id": request.ActionID, "action": request.Action,
+		"engine": request.Engine, "account": request.Account,
+		"scan_id": request.ScanID, "finding_id": request.FindingID,
+		"expected_version": request.ExpectedVersion, "identity": "different-bucket/runs/bi-ha",
+		"actor": request.Actor, "reason": request.Reason,
+	})
+	control := &fakeAWSWorkerControl{items: map[string]map[string]ddbtypes.AttributeValue{"ACTION#A1": action}}
+	adapter := &AWSReaperWorkerIO{Queue: &fakeAWSWorkerQueue{}, Control: control}
+	if _, err := adapter.LoadControl(context.Background(), "control", request, 1000); !errors.Is(err, ErrControlMismatch) {
+		t.Fatalf("mismatched control record error=%v", err)
+	}
+}
+
+func TestValidateReaperActionRejectsAccountAndFindingIdentityMismatch(t *testing.T) {
+	request := workerAction()
+	request.Account = "000000000000"
+	if err := validateReaperAction(request, contractAccount); err == nil {
+		t.Fatal("wrong account was accepted")
+	}
+	request = workerAction()
+	request.Identity = "state-bucket/runs/other"
+	if err := validateReaperAction(request, contractAccount); err == nil {
+		t.Fatal("finding id mismatch was accepted")
+	}
+}
+
+func TestAWSReaperWorkerIOClassifiesLostReceiptHandle(t *testing.T) {
+	queue := &fakeAWSWorkerQueue{visibilityError: &smithy.GenericAPIError{Code: "MessageNotInflight", Message: "gone"}}
+	adapter := &AWSReaperWorkerIO{Queue: queue}
+	err := adapter.ChangeActionVisibility(context.Background(), "actions", "receipt", 13500)
+	if !errors.Is(err, ErrMessageNotInflight) {
+		t.Fatalf("err=%v", err)
+	}
+}

--- a/live/tests/harness/testdata/reaper-contract-v1-golden.json
+++ b/live/tests/harness/testdata/reaper-contract-v1-golden.json
@@ -1,0 +1,33 @@
+{
+  "engine": "harness",
+  "account": "076248559428",
+  "state_bucket": "state-bucket",
+  "state_prefix": "/runs/bi-ha/",
+  "canonical_identity": "state-bucket/runs/bi-ha",
+  "run_id": "run-123",
+  "regions": [
+    "us-west-2",
+    "us-east-1"
+  ],
+  "ordered_regions": "us-east-1,us-west-2",
+  "decision": "eligible",
+  "expires_at": "2026-08-07T08:00:00Z",
+  "resource_count": 12,
+  "workflow_phase": "",
+  "keep_on_failure": false,
+  "lock_present": false,
+  "version_fields": [
+    "v1",
+    "state-bucket/runs/bi-ha",
+    "run-123",
+    "us-east-1,us-west-2",
+    "eligible",
+    "2026-08-07T08:00:00Z",
+    "12",
+    "",
+    "false",
+    "false"
+  ],
+  "finding_id": "sha256:019406da27ce5a07617306ec9f386a2c4fd4d28b97e098426a6f8c3802aaafb8",
+  "version": "sha256:cd817dda89287de462248e01e8e400cb6ed7853723643e4bff0417315457e90d"
+}


### PR DESCRIPTION
## Summary

- publish versioned harness cleanup findings for Resource Reaper shadow ingestion
- add a targeted, idempotent SQS action worker that revalidates ownership, locks, lifetime, workflow state, and expected finding version before teardown
- wire Argo scan and worker templates behind independent report, action, and direct-Slack controls
- mark harness-owned resources for the later generic-purge ownership handoff
- add contract golden vectors, worker failure/race tests, manifest invariants, and rollout documentation

The harness worker remains disabled by default. Shadow publishing and direct janitor Slack behavior can be controlled independently, and no manifest or image is deployed by this PR.

## Validation

- `go test ./... -count=1` in `live/tests` - passed across all six packages
- `go vet ./...` in `live/tests` - passed
- `bash -n live/tests/docker-entrypoint.sh` - passed
- `argo lint --offline live/tests/argo/00-phase-templates.yaml live/tests/argo/50-janitor-cron.yaml` - passed
- `pre-commit run --all-files` - passed
- `git diff --check` - passed

## Rollout gates

- publish and pin the immutable harness image before enabling shadow reports
- keep `reaper_actions_enabled=false` through shadow parity validation
- retain direct janitor Slack until the consolidated `#mpc-alerts` report passes the reporting cutover gate
- perform one forced-dry-run action before the bounded ownership handoff and one explicitly approved DDVtest canary afterward
