### PR TITLE
fix(alerts): make the slack state table ordered and single-writer, and run its suite in ci

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -36,6 +36,13 @@ jobs:
   terraform:
     name: 'Terraform'
     runs-on: ubuntu-latest
+    # Chained so the lambda suite actually blocks a merge. The three "Terraform (...)"
+    # contexts are required by master's branch protection and "Lambda tests" is not, so
+    # left parallel a red lambda run would sit next to three green required checks and
+    # merge anyway. Depending on it means a failure skips those contexts instead, and a
+    # skipped required context is not a pass. Decouple this once "Lambda tests" is added
+    # to the required set in branch protection.
+    needs: lambda-tests
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -39,10 +39,17 @@ jobs:
     # Chained so the lambda suite actually blocks a merge. The three "Terraform (...)"
     # contexts are required by master's branch protection and "Lambda tests" is not, so
     # left parallel a red lambda run would sit next to three green required checks and
-    # merge anyway. Depending on it means a failure skips those contexts instead, and a
-    # skipped required context is not a pass. Decouple this once "Lambda tests" is added
-    # to the required set in branch protection.
+    # merge anyway.
+    #
+    # needs: alone does not fix that - GitHub treats a SKIPPED required context as
+    # satisfied, so a failed dependency would skip these three and still leave the PR
+    # mergeable. always() keeps them running and the guard step below fails them
+    # explicitly, which is what turns a red lambda run into three red required checks.
+    #
+    # The clean fix is adding "Lambda tests" to the required set in branch protection;
+    # do that and this whole coupling can come out.
     needs: lambda-tests
+    if: ${{ always() }}
     strategy:
       fail-fast: false
       matrix:
@@ -68,6 +75,14 @@ jobs:
         shell: bash
 
     steps:
+    # First, so a lambda failure fails this required context rather than letting it pass
+    # on a technicality. See the always() note above.
+    - name: Enforce Lambda tests
+      if: ${{ needs.lambda-tests.result != 'success' }}
+      run: |
+        echo "::error::Lambda tests did not pass (result: ${{ needs.lambda-tests.result }})"
+        exit 1
+
     # Checkout the repository to the GitHub Actions runner
     - name: Checkout
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -24,10 +24,13 @@ jobs:
       with:
         python-version: '3.12'   # the runtime aws_lambda_function.sns_to_slack declares
 
-    # The suite has no test framework and no fixtures on disk; boto3 is its only
-    # dependency, and only because the module under test imports it at import time.
-    - name: Install boto3
-      run: pip install --disable-pip-version-check boto3
+    # boto3 because the module imports it at import time; moto because the state
+    # machine's correctness lives in DynamoDB ConditionExpressions, and a mock that
+    # asserts "we sent the right request" cannot tell a correct condition from a
+    # nonsense one. Four review rounds found defects here that a mock-only suite
+    # passed clean through.
+    - name: Install test dependencies
+      run: pip install --disable-pip-version-check boto3 'moto[dynamodb]'
 
     - name: sns_to_slack
       run: python3 test_sns_to_slack.py
@@ -36,18 +39,15 @@ jobs:
   terraform:
     name: 'Terraform'
     runs-on: ubuntu-latest
-    # Chained so the lambda suite actually blocks a merge. The three "Terraform (...)"
-    # contexts are required by master's branch protection and "Lambda tests" is not, so
-    # left parallel a red lambda run would sit next to three green required checks and
-    # merge anyway.
+    # "Lambda tests" is a required context on master in its own right, so this coupling
+    # is belt-and-braces rather than the primary gate. It stays because the two together
+    # cover each other: branch protection can be edited in the UI without touching the
+    # repo, and this file cannot enforce itself.
     #
-    # needs: alone does not fix that - GitHub treats a SKIPPED required context as
-    # satisfied, so a failed dependency would skip these three and still leave the PR
-    # mergeable. always() keeps them running and the guard step below fails them
-    # explicitly, which is what turns a red lambda run into three red required checks.
-    #
-    # The clean fix is adding "Lambda tests" to the required set in branch protection;
-    # do that and this whole coupling can come out.
+    # Both halves are needed. needs: alone would not gate, because GitHub treats a
+    # SKIPPED required context as satisfied - a failed dependency would skip the three
+    # Terraform contexts and leave the PR mergeable. always() keeps them running and the
+    # guard step below fails them explicitly instead.
     needs: lambda-tests
     if: ${{ always() }}
     strategy:

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -7,6 +7,32 @@ on:
   pull_request:
 
 jobs:
+  # The alerting lambdas are Python inside a Terraform repo, so nothing in the matrix
+  # below ever executes them - tofu validate only checks that the archive_file source
+  # exists. Their suite ran by hand until now, which meant the one guarantee protecting
+  # the aurora migration task (it has no CloudWatch alarm anywhere, so its Slack card is
+  # its only alerting) held only when someone remembered to run it.
+  lambda-tests:
+    name: 'Lambda tests'
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+
+    - name: Setup Python
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+      with:
+        python-version: '3.12'   # the runtime aws_lambda_function.sns_to_slack declares
+
+    # The suite has no test framework and no fixtures on disk; boto3 is its only
+    # dependency, and only because the module under test imports it at import time.
+    - name: Install boto3
+      run: pip install --disable-pip-version-check boto3
+
+    - name: sns_to_slack
+      run: python3 test_sns_to_slack.py
+      working-directory: ./terraform/physical/util
+
   terraform:
     name: 'Terraform'
     runs-on: ubuntu-latest

--- a/terraform/physical/monitoring.tf
+++ b/terraform/physical/monitoring.tf
@@ -789,6 +789,11 @@ resource "aws_iam_role_policy" "sns_to_slack_alarm_state" {
       Action = [
         "dynamodb:GetItem",
         "dynamodb:PutItem",
+        # UpdateItem carries the conditional ALARM -> RESOLVING claim that makes exactly
+        # one delivery of an OK post the recovery card. PutItem cannot express it: the
+        # condition has to read the row's current status and event time in the same
+        # atomic operation that writes the new one.
+        "dynamodb:UpdateItem",
       ],
       Resource = aws_dynamodb_table.slack_alarm_state[0].arn
     }]

--- a/terraform/physical/util/sns_to_slack.py
+++ b/terraform/physical/util/sns_to_slack.py
@@ -17,8 +17,10 @@ Functions:
 - lambda_handler(event, context): Entry point for the Lambda function. Processes the event and sends an alert to Slack.
 
 Environment Variables:
-- SLACK_BOT_TOKEN_SSM_PARAM: SSM SecureString holding a bot token (chat:write, reactions:write);
-  preferred path.
+- SLACK_BOT_TOKEN_SSM_PARAM: SSM SecureString holding a bot token (chat:write,
+  reactions:write, and channels:history or groups:history); preferred path. The history
+  scope is used only to avoid duplicating a card when a crashed attempt is retried, and
+  its absence degrades to the previous at-least-once behaviour rather than failing.
 - SLACK_CHANNEL_ID: Channel the bot-token path posts to.
 - SLACK_STATE_TABLE: DynamoDB table used to thread a recovery under the ALARM root that fired.
 - SLACK_WEBHOOK_URL: Legacy Slack incoming webhook URL; used when no bot token is configured.
@@ -105,6 +107,16 @@ STATE_TTL_SECONDS = 30 * 24 * 3600
 # lets the retry re-claim and post, while a lease longer than that would make the
 # retry give up on a card that was never actually sent.
 CLAIM_LEASE_SECONDS = 60
+
+# The header text a recovery card carries, used to recognise one already sitting in an
+# incident thread. Kept next to the card renderer's own string so the two move together.
+RECOVERY_MARKER = '✅ RESOLVED'
+
+# How far back to look in channel history when checking whether a red root was already
+# posted by an attempt that died. Only has to cover the gap between a crash and the
+# retry that takes the claim over, which is bounded by the lease plus Lambda's retry
+# cadence; a wider window would just read more messages for the same answer.
+STALE_POST_WINDOW = 15 * 60
 COLOR_CRITICAL = '#e01e5a'
 COLOR_WARNING = '#ecb22e'
 COLOR_RESOLVED = '#2eb67d'
@@ -405,6 +417,51 @@ def _slack_api(method, token, body):
     return result
 
 
+def _slack_get(method, token, params):
+    """Read-side Web API call. conversations.* reads take query params, not a JSON body."""
+    request = urllib.request.Request(
+        f'https://slack.com/api/{method}?{urllib.parse.urlencode(params)}',
+        headers={'Authorization': f'Bearer {token}'},
+    )
+    with urllib.request.urlopen(request, timeout=10) as response:
+        result = json.loads(response.read())
+    if not result.get('ok'):
+        raise RuntimeError(f'{method} failed: {result.get("error")}')
+    return result
+
+
+def _already_posted(token, marker, thread_ts=None, since=None):
+    """True when a message carrying `marker` is already in the channel or thread.
+
+    This is what makes a retry idempotent at the Slack boundary. The DynamoDB claim can
+    only say "nobody else is posting right now"; it cannot say whether OUR previous
+    attempt got its message through before dying, because the failure mode being covered
+    is exactly "Slack accepted it and we never learned that". Only Slack knows, so ask
+    Slack - but only on a takeover, where a previous attempt actually existed.
+
+    Fails OPEN (returns False, so the caller posts). A missing history scope, a Slack
+    5xx, or a thread that cannot be read must not swallow a recovery card: a duplicate
+    card is an annoyance, a missing one is the bug this whole change exists to prevent.
+    That degradation is why the scope is not a hard dependency.
+    """
+    try:
+        if thread_ts:
+            result = _slack_get('conversations.replies', token, {
+                'channel': SLACK_CHANNEL_ID, 'ts': thread_ts, 'limit': 200})
+            # [0] is the root itself, which is not a recovery.
+            messages = (result.get('messages') or [])[1:]
+        else:
+            params = {'channel': SLACK_CHANNEL_ID, 'limit': 200}
+            if since:
+                params['oldest'] = since
+            messages = _slack_get('conversations.history', token, params).get(
+                'messages') or []
+    except Exception as exc:  # noqa: BLE001 - never let a read failure drop a card
+        print(f'could not check Slack for an existing "{marker}" post: {exc}')
+        return False
+    return any(marker in json.dumps(message) for message in messages)
+
+
 def _post_bot(token, payload, thread_ts=None, reply_broadcast=False):
     body = {'channel': SLACK_CHANNEL_ID, **payload}
     if thread_ts:
@@ -685,6 +742,94 @@ def _claim_resolution(alarm_key, event_at):
         return None
 
 
+def _claim_alarm_root(alarm_key, event_at):
+    """Take ownership of posting a NEW red root. Returns the claim token, or None.
+
+    The resolve path got a claim first because its duplicate is loud, but the ALARM path
+    has the same shape: two deliveries both read "no row" (or the same RESOLVED
+    tombstone), both post a root, and only one timestamp survives the write. The other
+    root is then permanently untracked - it never gets a check-mark, and its recovery
+    threads under the wrong message. That contradicts the "posted once" invariant this
+    whole change is built on.
+
+    Accepts a row that does not exist, a RESOLVED tombstone (a genuinely new incident on
+    a reused key), a RESOLVING row (a new incident supersedes an in-flight resolve, and
+    that resolve's finalize will correctly fail on its token), and an ALARM_POSTING whose
+    lease has expired. It does NOT accept a live ALARM - that is the repeat-delivery edit
+    path, which is handled without a claim because editing is already idempotent.
+    """
+    if not SLACK_STATE_TABLE:
+        return None
+    now = int(time.time())
+    values = {
+        ':posting': {'S': 'ALARM_POSTING'},
+        ':resolved': {'S': 'RESOLVED'},
+        ':resolving': {'S': 'RESOLVING'},
+        ':now': {'N': str(now)},
+        ':lease': {'N': str(now - CLAIM_LEASE_SECONDS)},
+    }
+    condition = ('(attribute_not_exists(AlarmKey) OR #s = :resolved OR #s = :resolving'
+                 ' OR (#s = :posting AND ClaimedAt < :lease))')
+    update = 'SET #s = :posting, ClaimedAt = :now'
+    if event_at is not None:
+        values[':evt'] = {'N': repr(event_at)}
+        condition += ' AND (attribute_not_exists(LastEventAt) OR LastEventAt <= :evt)'
+        update += ', LastEventAt = :evt'
+    client = boto3.client('dynamodb')
+    try:
+        client.update_item(
+            TableName=SLACK_STATE_TABLE,
+            Key={'AlarmKey': {'S': alarm_key}},
+            UpdateExpression=update,
+            ConditionExpression=condition,
+            ExpressionAttributeNames={'#s': 'Status'},
+            ExpressionAttributeValues=values,
+        )
+        return now
+    except client.exceptions.ConditionalCheckFailedException:
+        prior = _get_alarm_state(alarm_key)
+        if prior and prior.get('status') == 'ALARM_POSTING':
+            # Another delivery is mid-post. Same reasoning as the resolve claim: going
+            # quiet here would consume this event's retry, and if that delivery died the
+            # root is lost for good. Raise so the retry re-reads once the lease is up.
+            raise RuntimeError(
+                f'{alarm_key} root is being posted by another execution; retrying')
+        # A live ALARM row means someone finished posting the root already, and a newer
+        # LastEventAt means this event is stale. Neither should post.
+        return None
+
+
+def _finalize_alarm_root(alarm_key, claim_token, message_ts, started_at, event_at):
+    """Record the root we just posted, if we still own the claim. True if we did."""
+    if not SLACK_STATE_TABLE:
+        return False
+    values = {':posting': {'S': 'ALARM_POSTING'},
+              ':claim': {'N': str(claim_token)},
+              ':alarm': {'S': 'ALARM'},
+              ':ts': {'S': message_ts},
+              ':sa': {'S': started_at or datetime.now(timezone.utc).isoformat()}}
+    update = 'SET #s = :alarm, MessageTs = :ts, StartedAt = :sa REMOVE ExpiresAt'
+    if event_at is not None:
+        values[':evt'] = {'N': repr(event_at)}
+        update = ('SET #s = :alarm, MessageTs = :ts, StartedAt = :sa, LastEventAt = :evt'
+                  ' REMOVE ExpiresAt')
+    client = boto3.client('dynamodb')
+    try:
+        client.update_item(
+            TableName=SLACK_STATE_TABLE,
+            Key={'AlarmKey': {'S': alarm_key}},
+            UpdateExpression=update,
+            ConditionExpression='#s = :posting AND ClaimedAt = :claim',
+            ExpressionAttributeNames={'#s': 'Status'},
+            ExpressionAttributeValues=values,
+        )
+        return True
+    except client.exceptions.ConditionalCheckFailedException:
+        print(f'{alarm_key} was taken over before the root was recorded; '
+              f'leaving the newer state alone')
+        return False
+
+
 def _finalize_resolution(alarm_key, claim_token, event_at):
     """Stamp RESOLVED, but only if we still own the claim we took. True if we did.
 
@@ -784,13 +929,33 @@ def _deliver_cloudwatch_bot(token, message_json, identifier, region,
         if prior and prior.get('status') == 'ALARM':
             # Refreshing an already-red root, not turning it green. This branch mostly
             # fires on duplicate SNS delivery of the same firing event, where an edit
-            # is what keeps the channel from showing the same incident twice.
+            # is what keeps the channel from showing the same incident twice. No claim
+            # needed: editing the same message with the same payload is idempotent.
             message_ts = prior['message_ts']
             _update_bot(token, message_ts, payload)
-        else:
-            message_ts = _post_bot(token, payload)
-            started_at = metadata['changed_at'] or datetime.now(timezone.utc).isoformat()
-        _put_alarm_state(alarm_key, message_ts, started_at, 'ALARM', event_at, prior)
+            _put_alarm_state(alarm_key, message_ts, started_at, 'ALARM', event_at, prior)
+            return
+
+        # A brand new root. Claim before posting for the same reason the resolve does:
+        # two deliveries that both see no row would otherwise both post one, and only
+        # one timestamp would survive the write.
+        claim_token = _claim_alarm_root(alarm_key, event_at)
+        if not claim_token:
+            print(f'skipping duplicate or stale ALARM for {alarm_key}')
+            return
+
+        # Only on a takeover, where a previous attempt may have posted before dying.
+        # A fresh claim cannot have a root already in the channel.
+        if (prior and prior.get('status') == 'ALARM_POSTING'
+                and _already_posted(token, metadata['alarm_name'],
+                                    since=str(int(time.time()) - STALE_POST_WINDOW))):
+            print(f'root for {metadata["alarm_name"]} is already in the channel; '
+                  f'not posting a second one')
+            return
+
+        message_ts = _post_bot(token, payload)
+        started_at = metadata['changed_at'] or datetime.now(timezone.utc).isoformat()
+        _finalize_alarm_root(alarm_key, claim_token, message_ts, started_at, event_at)
         return
 
     if state == 'OK' and prior:
@@ -809,13 +974,26 @@ def _deliver_cloudwatch_bot(token, message_json, identifier, region,
             print(f'skipping duplicate or stale OK for {alarm_key}')
             return
 
+        # A takeover means a previous attempt held this claim and died. It may have got
+        # its message to Slack before dying - the claim cannot know, because the failure
+        # being covered is "Slack accepted it and we never learned that". Only Slack can
+        # answer, and only the thread needs reading. Without this the lease turns every
+        # crash into a second green card.
+        if (prior.get('status') == 'RESOLVING'
+                and _already_posted(token, RECOVERY_MARKER,
+                                    thread_ts=prior['message_ts'])):
+            print(f'recovery for {metadata["alarm_name"]} is already in the thread; '
+                  f'finalising without posting a second one')
+            _finalize_resolution(alarm_key, claim_token, event_at)
+            return
+
         # Full recovery card, not a one-line summary, so the channel gets the same
         # detail (duration, final reading, resource) it got when the alarm fired.
         # Broadcast because a thread reply alone leaves the channel showing red.
         #
         # If this raises, the row stays RESOLVING and the Lambda retries. Once the
-        # claim's lease expires the retry re-claims and posts, so a failure here costs
-        # a delay rather than the recovery card.
+        # claim's lease expires the retry re-claims, finds the card above, and finalises
+        # without duplicating it.
         _post_bot(token, payload, thread_ts=prior['message_ts'],
                   reply_broadcast=True)
         try:

--- a/terraform/physical/util/sns_to_slack.py
+++ b/terraform/physical/util/sns_to_slack.py
@@ -431,7 +431,11 @@ def _slack_get(method, token, params):
 
 
 def _already_posted(token, marker, thread_ts=None, since=None):
-    """True when a message carrying `marker` is already in the channel or thread.
+    """The ts of an existing message carrying `marker`, or None.
+
+    Returns the timestamp rather than a bool because the ALARM takeover path needs it:
+    finding the root someone else posted is only half the job, the row still has to be
+    finalised to point at it or it stays stuck mid-post forever.
 
     This is what makes a retry idempotent at the Slack boundary. The DynamoDB claim can
     only say "nobody else is posting right now"; it cannot say whether OUR previous
@@ -439,10 +443,14 @@ def _already_posted(token, marker, thread_ts=None, since=None):
     is exactly "Slack accepted it and we never learned that". Only Slack knows, so ask
     Slack - but only on a takeover, where a previous attempt actually existed.
 
-    Fails OPEN (returns False, so the caller posts). A missing history scope, a Slack
+    Fails OPEN (returns None, so the caller posts). A missing history scope, a Slack
     5xx, or a thread that cannot be read must not swallow a recovery card: a duplicate
     card is an annoyance, a missing one is the bug this whole change exists to prevent.
     That degradation is why the scope is not a hard dependency.
+
+    Only bot-authored messages count. The channel-history search matches on the alarm
+    name, and a human typing that name while triaging would otherwise suppress the very
+    card they were talking about - a fail-CLOSED path hiding inside a fail-open design.
     """
     try:
         if thread_ts:
@@ -458,8 +466,11 @@ def _already_posted(token, marker, thread_ts=None, since=None):
                 'messages') or []
     except Exception as exc:  # noqa: BLE001 - never let a read failure drop a card
         print(f'could not check Slack for an existing "{marker}" post: {exc}')
-        return False
-    return any(marker in json.dumps(message) for message in messages)
+        return None
+    for message in messages:
+        if message.get('bot_id') and marker in json.dumps(message):
+            return message.get('ts')
+    return None
 
 
 def _post_bot(token, payload, thread_ts=None, reply_broadcast=False):
@@ -718,7 +729,13 @@ def _claim_resolution(alarm_key, event_at):
         # The condition fails for three different reasons and they do NOT share an
         # outcome, so read the row rather than assuming the benign one.
         prior = _get_alarm_state(alarm_key)
-        if prior and prior.get('status') == 'RESOLVING':
+        if prior and prior.get('status') in ('RESOLVING', 'ALARM_POSTING'):
+            # ALARM_POSTING counts here too. A row mid-root-post cannot satisfy this
+            # condition, and returning None would let the caller read that as "duplicate
+            # or stale" and drop the recovery outright - permanently, because nothing
+            # else revisits it. The root's own invocation (or its retry) finalises the
+            # row to ALARM, and this event's retry then claims it normally.
+            #
             # Someone holds an unexpired claim. Either they are still posting, or they
             # died between claiming and posting - and nothing here can tell which.
             #
@@ -734,7 +751,7 @@ def _claim_resolution(alarm_key, event_at):
             # has expired (the retry wins the claim and posts). Both converge. Silence
             # only converges when the holder happened to survive.
             raise RuntimeError(
-                f'{alarm_key} is claimed by an in-flight resolution; retrying')
+                f'{alarm_key} is claimed by an in-flight post; retrying')
         # RESOLVED means the resolution already happened, and a still-ALARM row means
         # this event is older than the one applied. Both mean "post nothing", and
         # neither is an error. Every other failure - throttling, a missing table,
@@ -940,21 +957,34 @@ def _deliver_cloudwatch_bot(token, message_json, identifier, region,
         # two deliveries that both see no row would otherwise both post one, and only
         # one timestamp would survive the write.
         claim_token = _claim_alarm_root(alarm_key, event_at)
-        if not claim_token:
+        # No table means no correlation and therefore no claim to win - but the card
+        # still has to go out. Without this guard a bot token configured without a state
+        # table drops every alarm, which is worse than the unthreaded posting it replaced.
+        if SLACK_STATE_TABLE and not claim_token:
             print(f'skipping duplicate or stale ALARM for {alarm_key}')
             return
 
         # Only on a takeover, where a previous attempt may have posted before dying.
         # A fresh claim cannot have a root already in the channel.
-        if (prior and prior.get('status') == 'ALARM_POSTING'
-                and _already_posted(token, metadata['alarm_name'],
-                                    since=str(int(time.time()) - STALE_POST_WINDOW))):
+        existing_ts = None
+        if prior and prior.get('status') == 'ALARM_POSTING':
+            existing_ts = _already_posted(
+                token, metadata['alarm_name'],
+                since=str(int(time.time()) - STALE_POST_WINDOW))
+
+        started_at = metadata['changed_at'] or datetime.now(timezone.utc).isoformat()
+        if existing_ts:
+            # The attempt that died got its root out before it went. Adopt that message
+            # rather than posting a second one - and finalise, or the row sits in
+            # ALARM_POSTING with no MessageTs forever and every later OK fails to claim
+            # it. Skipping the finalise is how a dedupe turns into a stuck incident.
             print(f'root for {metadata["alarm_name"]} is already in the channel; '
-                  f'not posting a second one')
+                  f'adopting {existing_ts} instead of posting a second one')
+            _finalize_alarm_root(alarm_key, claim_token, existing_ts, started_at,
+                                 event_at)
             return
 
         message_ts = _post_bot(token, payload)
-        started_at = metadata['changed_at'] or datetime.now(timezone.utc).isoformat()
         _finalize_alarm_root(alarm_key, claim_token, message_ts, started_at, event_at)
         return
 
@@ -970,7 +1000,7 @@ def _deliver_cloudwatch_bot(token, message_json, identifier, region,
         # write, so exactly one delivery wins it and the rest return here having sent
         # nothing.
         claim_token = _claim_resolution(alarm_key, event_at)
-        if not claim_token:
+        if SLACK_STATE_TABLE and not claim_token:
             print(f'skipping duplicate or stale OK for {alarm_key}')
             return
 

--- a/terraform/physical/util/sns_to_slack.py
+++ b/terraform/physical/util/sns_to_slack.py
@@ -487,7 +487,12 @@ def _event_epoch(message_json):
     the events least likely to be noticed.
     """
     parsed = _parse_time(message_json.get('StateChangeTime'))
-    return parsed.timestamp() if parsed else None
+    # A naive datetime would be read as process-local time by .timestamp(), which turns
+    # a malformed value into a confidently wrong ordering key. CloudWatch always sends an
+    # offset, so anything without one is bad data and belongs in the None path.
+    if parsed is None or parsed.tzinfo is None:
+        return None
+    return parsed.timestamp()
 
 
 def _is_stale(event_at, prior):
@@ -616,10 +621,15 @@ def _claim_resolution(alarm_key, event_at):
     stops a delayed OK from a previous incident closing the current one. `<=` rather
     than `<` so a retry of the SAME event can re-claim once its lease expires.
 
-    Returns False when the table is not configured, so the webhook path is unaffected.
+    Returns the claim token (the ClaimedAt we wrote) on success and None otherwise. The
+    token is what _finalize_resolution proves ownership with: between claiming and
+    finalizing, a new ALARM can legitimately take the row over, and without the token the
+    finalize would unconditionally stamp RESOLVED back on top of a live incident.
+
+    Returns None when the table is not configured, so the webhook path is unaffected.
     """
     if not SLACK_STATE_TABLE:
-        return False
+        return None
     now = int(time.time())
     names = {'#s': 'Status'}
     values = {
@@ -646,7 +656,7 @@ def _claim_resolution(alarm_key, event_at):
             ExpressionAttributeNames=names,
             ExpressionAttributeValues=values,
         )
-        return True
+        return now
     except client.exceptions.ConditionalCheckFailedException:
         # The condition fails for three different reasons and they do NOT share an
         # outcome, so read the row rather than assuming the benign one.
@@ -672,10 +682,54 @@ def _claim_resolution(alarm_key, event_at):
         # this event is older than the one applied. Both mean "post nothing", and
         # neither is an error. Every other failure - throttling, a missing table,
         # credentials - propagates so the Lambda retries it.
+        return None
+
+
+def _finalize_resolution(alarm_key, claim_token, event_at):
+    """Stamp RESOLVED, but only if we still own the claim we took. True if we did.
+
+    Between claiming and posting, a NEW incident can legitimately take the row over: a
+    fast flap means ALARM2 arrives, sees a RESOLVING row, posts its own red root and
+    writes ALARM. An unconditional write here would then stamp RESOLVED back on top of
+    that live incident, and its real recovery would later find a RESOLVED row and post
+    nothing - the exact failure this whole change exists to prevent, reintroduced one
+    step further along.
+
+    ClaimedAt is the ownership token. If it no longer matches, someone else owns the row
+    and the right move is to leave it alone: our green card is already posted, and the
+    live incident keeps its own state.
+    """
+    if not SLACK_STATE_TABLE:
+        return False
+    values = {':resolving': {'S': 'RESOLVING'},
+              ':claim': {'N': str(claim_token)},
+              ':resolved': {'S': 'RESOLVED'},
+              ':expires': {'N': str(int(time.time()) + STATE_TTL_SECONDS)}}
+    update = 'SET #s = :resolved, ExpiresAt = :expires'
+    if event_at is not None:
+        values[':evt'] = {'N': repr(event_at)}
+        update += ', LastEventAt = :evt'
+    client = boto3.client('dynamodb')
+    try:
+        client.update_item(
+            TableName=SLACK_STATE_TABLE,
+            Key={'AlarmKey': {'S': alarm_key}},
+            UpdateExpression=update,
+            ConditionExpression='#s = :resolving AND ClaimedAt = :claim',
+            ExpressionAttributeNames={'#s': 'Status'},
+            ExpressionAttributeValues=values,
+        )
+        return True
+    except client.exceptions.ConditionalCheckFailedException:
+        # Superseded mid-resolve. Not an error and not retryable - the card is already
+        # in the channel, and forcing a retry would only post it again.
+        print(f'{alarm_key} was taken over before the resolve finalised; '
+              f'leaving the newer state alone')
         return False
 
 
-def _put_alarm_state(alarm_key, message_ts, started_at, status, event_at=None):
+def _put_alarm_state(alarm_key, message_ts, started_at, status, event_at=None,
+                     prior=None):
     if not SLACK_STATE_TABLE:
         return
     item = {
@@ -684,8 +738,12 @@ def _put_alarm_state(alarm_key, message_ts, started_at, status, event_at=None):
         'StartedAt': {'S': started_at or datetime.now(timezone.utc).isoformat()},
         'Status': {'S': status},
     }
-    if event_at is not None:
-        item['LastEventAt'] = {'N': repr(event_at)}
+    # Carry the watermark forward when this event cannot be ordered. Writing the row
+    # without it would DELETE a perfectly good LastEventAt, so one malformed timestamp
+    # would disable ordering for every event after it.
+    watermark = event_at if event_at is not None else (prior or {}).get('last_event_at')
+    if watermark is not None:
+        item['LastEventAt'] = {'N': repr(watermark)}
     # TTL only on the tombstone. The row is a tombstone once RESOLVED, but while an alarm
     # is still ALARM it is the live correlation to the root card, and expiring it strands
     # the incident: the eventual recovery finds no prior, so it posts an unthreaded green
@@ -732,7 +790,7 @@ def _deliver_cloudwatch_bot(token, message_json, identifier, region,
         else:
             message_ts = _post_bot(token, payload)
             started_at = metadata['changed_at'] or datetime.now(timezone.utc).isoformat()
-        _put_alarm_state(alarm_key, message_ts, started_at, 'ALARM', event_at)
+        _put_alarm_state(alarm_key, message_ts, started_at, 'ALARM', event_at, prior)
         return
 
     if state == 'OK' and prior:
@@ -746,7 +804,8 @@ def _deliver_cloudwatch_bot(token, message_json, identifier, region,
         # broadcast a full green card into the channel. The claim is a conditional
         # write, so exactly one delivery wins it and the rest return here having sent
         # nothing.
-        if not _claim_resolution(alarm_key, event_at):
+        claim_token = _claim_resolution(alarm_key, event_at)
+        if not claim_token:
             print(f'skipping duplicate or stale OK for {alarm_key}')
             return
 
@@ -767,8 +826,9 @@ def _deliver_cloudwatch_bot(token, message_json, identifier, region,
             # would leave the row RESOLVING and re-post it on the Lambda retry.
             print(f'could not mark {metadata["alarm_name"]} '
                   f'({prior["message_ts"]}) resolved: {exc}')
-        _put_alarm_state(alarm_key, prior['message_ts'], prior['started_at'],
-                         'RESOLVED', event_at)
+        # Conditional on still owning the claim, not an unconditional write. A fast flap
+        # can have handed the row to a new incident while this card was being posted.
+        _finalize_resolution(alarm_key, claim_token, event_at)
         return
 
     _post_bot(token, payload)

--- a/terraform/physical/util/sns_to_slack.py
+++ b/terraform/physical/util/sns_to_slack.py
@@ -479,14 +479,15 @@ def _event_epoch(message_json):
 
     Returns None when the field is missing or unparseable. Callers must treat None as
     "cannot order this" and fall through to posting: never classify on bad data.
+
+    Parsing goes through _parse_time (fromisoformat) rather than a strptime format
+    string. A literal "%Y-%m-%dT%H:%M:%S.%f%z" requires the fractional second, so a
+    timestamp landing exactly on a second boundary would fail to parse and silently opt
+    that event out of ordering entirely - the ordering guard would be off for precisely
+    the events least likely to be noticed.
     """
-    raw = message_json.get('StateChangeTime')
-    if not raw:
-        return None
-    try:
-        return datetime.strptime(raw, "%Y-%m-%dT%H:%M:%S.%f%z").timestamp()
-    except (TypeError, ValueError):
-        return None
+    parsed = _parse_time(message_json.get('StateChangeTime'))
+    return parsed.timestamp() if parsed else None
 
 
 def _is_stale(event_at, prior):
@@ -647,9 +648,30 @@ def _claim_resolution(alarm_key, event_at):
         )
         return True
     except client.exceptions.ConditionalCheckFailedException:
-        # Someone else owns this resolution, or the event is older than the row. Both
-        # mean "post nothing", and neither is an error. Every other failure - throttling,
-        # a missing table, credentials - propagates so the Lambda retries it.
+        # The condition fails for three different reasons and they do NOT share an
+        # outcome, so read the row rather than assuming the benign one.
+        prior = _get_alarm_state(alarm_key)
+        if prior and prior.get('status') == 'RESOLVING':
+            # Someone holds an unexpired claim. Either they are still posting, or they
+            # died between claiming and posting - and nothing here can tell which.
+            #
+            # Returning False would end this invocation successfully, which tells Lambda
+            # the event is handled and drops it from the async queue. If the holder is
+            # dead, the recovery card is then gone for good and the lease below never
+            # gets a chance to matter: Lambda's first async retry lands at roughly the
+            # same minute as the lease, so the retry that was supposed to take over is
+            # exactly the one being discarded here.
+            #
+            # Raising instead lets the retry re-read. By then the holder has either
+            # finished (row is RESOLVED, the retry returns False quietly) or its lease
+            # has expired (the retry wins the claim and posts). Both converge. Silence
+            # only converges when the holder happened to survive.
+            raise RuntimeError(
+                f'{alarm_key} is claimed by an in-flight resolution; retrying')
+        # RESOLVED means the resolution already happened, and a still-ALARM row means
+        # this event is older than the one applied. Both mean "post nothing", and
+        # neither is an error. Every other failure - throttling, a missing table,
+        # credentials - propagates so the Lambda retries it.
         return False
 
 

--- a/terraform/physical/util/sns_to_slack.py
+++ b/terraform/physical/util/sns_to_slack.py
@@ -42,6 +42,7 @@ import time
 import urllib.parse
 import urllib.request
 from datetime import datetime, timezone
+import uuid
 import boto3
 
 # Routine DMS lifecycle chatter, dropped before it reaches Slack.
@@ -107,10 +108,6 @@ STATE_TTL_SECONDS = 30 * 24 * 3600
 # lets the retry re-claim and post, while a lease longer than that would make the
 # retry give up on a card that was never actually sent.
 CLAIM_LEASE_SECONDS = 60
-
-# The header text a recovery card carries, used to recognise one already sitting in an
-# incident thread. Kept next to the card renderer's own string so the two move together.
-RECOVERY_MARKER = '✅ RESOLVED'
 
 # How far back to look in channel history when checking whether a red root was already
 # posted by an attempt that died. Only has to cover the gap between a crash and the
@@ -430,8 +427,20 @@ def _slack_get(method, token, params):
     return result
 
 
+def _transition_id(alarm_key, state, changed_at):
+    """Identity of ONE alarm transition, stamped into the card's Slack metadata.
+
+    Substring matching on the alarm name or on "RESOLVED" cannot tell this incident's
+    card from the last one's: during a fast re-alarm the previous red root and the
+    previous green broadcast both still sit in the window and both still contain the
+    same words. A takeover could therefore adopt the OLD card as this incident's root
+    and suppress the new one. An exact per-transition id has no such ambiguity.
+    """
+    return f'{alarm_key}|{state}|{changed_at or "-"}'
+
+
 def _already_posted(token, marker, thread_ts=None, since=None):
-    """The ts of an existing message carrying `marker`, or None.
+    """The ts of an existing message whose metadata carries `marker`, or None.
 
     Returns the timestamp rather than a bool because the ALARM takeover path needs it:
     finding the root someone else posted is only half the job, the row still has to be
@@ -448,18 +457,21 @@ def _already_posted(token, marker, thread_ts=None, since=None):
     card is an annoyance, a missing one is the bug this whole change exists to prevent.
     That degradation is why the scope is not a hard dependency.
 
-    Only bot-authored messages count. The channel-history search matches on the alarm
-    name, and a human typing that name while triaging would otherwise suppress the very
-    card they were talking about - a fail-CLOSED path hiding inside a fail-open design.
+    Matching is on Slack message METADATA, an exact equality against the transition id,
+    and only on bot-authored messages. Both matter: a human typing the alarm name while
+    triaging would otherwise suppress the card they were discussing, and a substring
+    search cannot distinguish this transition's card from the previous incident's.
     """
     try:
         if thread_ts:
             result = _slack_get('conversations.replies', token, {
-                'channel': SLACK_CHANNEL_ID, 'ts': thread_ts, 'limit': 200})
+                'channel': SLACK_CHANNEL_ID, 'ts': thread_ts, 'limit': 200,
+                'include_all_metadata': 'true'})
             # [0] is the root itself, which is not a recovery.
             messages = (result.get('messages') or [])[1:]
         else:
-            params = {'channel': SLACK_CHANNEL_ID, 'limit': 200}
+            params = {'channel': SLACK_CHANNEL_ID, 'limit': 200,
+                      'include_all_metadata': 'true'}
             if since:
                 params['oldest'] = since
             messages = _slack_get('conversations.history', token, params).get(
@@ -468,13 +480,20 @@ def _already_posted(token, marker, thread_ts=None, since=None):
         print(f'could not check Slack for an existing "{marker}" post: {exc}')
         return None
     for message in messages:
-        if message.get('bot_id') and marker in json.dumps(message):
+        payload = (message.get('metadata') or {}).get('event_payload') or {}
+        if message.get('bot_id') and payload.get('transition') == marker:
             return message.get('ts')
     return None
 
 
-def _post_bot(token, payload, thread_ts=None, reply_broadcast=False):
+def _post_bot(token, payload, thread_ts=None, reply_broadcast=False,
+              transition=None):
     body = {'channel': SLACK_CHANNEL_ID, **payload}
+    if transition:
+        # Carried in metadata rather than the visible text so a retry can recognise its
+        # own earlier card exactly, without putting a correlation id in front of humans.
+        body['metadata'] = {'event_type': 'cloudwatch_alarm',
+                            'event_payload': {'transition': transition}}
     if thread_ts:
         body['thread_ts'] = thread_ts
     if reply_broadcast:
@@ -525,10 +544,16 @@ def _get_alarm_state(alarm_key):
     ).get('Item')
     if not item:
         return None
+    # MessageTs and StartedAt do not exist on a row that has been claimed but whose card
+    # has not been posted yet. Reading them unconditionally raised KeyError, so every
+    # retry of a died-mid-post invocation crashed BEFORE it could take the claim over -
+    # the lease could never fire and the card was lost for good.
     return {
-        'message_ts': item['MessageTs']['S'],
-        'started_at': item['StartedAt']['S'],
+        'message_ts': item.get('MessageTs', {}).get('S'),
+        'started_at': item.get('StartedAt', {}).get('S'),
         'status': item['Status']['S'],
+        'claim_token': item.get('ClaimToken', {}).get('S'),
+        'last_event_state': item.get('LastEventState', {}).get('S'),
         # Absent on rows written before this field existed. None means "unknown", which
         # every ordering check below treats as "do not suppress" - an unordered event
         # posts rather than being dropped.
@@ -563,17 +588,27 @@ def _event_epoch(message_json):
     return parsed.timestamp()
 
 
-def _is_stale(event_at, prior):
-    """True when this delivery is older than the one the row already reflects.
+def _is_stale(event_at, prior, state=None):
+    """True when this delivery must not be applied over what the row already reflects.
 
-    Equal timestamps are NOT stale: that is the same event delivered twice, and the
-    duplicate handling for it differs per path (the ALARM path edits, the OK path is
-    gated by the claim below).
+    Older than the watermark is stale, plainly.
+
+    Equal to the watermark is stale ONLY when the state differs. An equal timestamp with
+    the SAME state is a redelivery of one event and each path handles it (the ALARM path
+    edits, the OK path is gated by the claim). An equal timestamp with a DIFFERENT state
+    is two conflicting truths about one instant, and nothing here can order them - so
+    whichever happens to arrive second would win, and an ALARM could reopen a row that an
+    OK resolved at the same second. Refusing both is the only deterministic answer.
     """
     if event_at is None or not prior:
         return False
     last = prior.get('last_event_at')
-    return last is not None and event_at < last
+    if last is None:
+        return False
+    if event_at < last:
+        return True
+    last_state = prior.get('last_event_state')
+    return event_at == last and last_state is not None and state != last_state
 
 
 def classify_dms_event(detail_message, detail_type, resource_arn, category=''):
@@ -699,15 +734,17 @@ def _claim_resolution(alarm_key, event_at):
     if not SLACK_STATE_TABLE:
         return None
     now = int(time.time())
+    token = uuid.uuid4().hex
     names = {'#s': 'Status'}
     values = {
         ':resolving': {'S': 'RESOLVING'},
+        ':token': {'S': token},
         ':alarm': {'S': 'ALARM'},
         ':now': {'N': str(now)},
         ':lease': {'N': str(now - CLAIM_LEASE_SECONDS)},
     }
     condition = ('(#s = :alarm OR (#s = :resolving AND ClaimedAt < :lease))')
-    update = 'SET #s = :resolving, ClaimedAt = :now'
+    update = 'SET #s = :resolving, ClaimedAt = :now, ClaimToken = :token'
     # Only order when the event carries a usable timestamp. Without one there is nothing
     # to compare, and refusing to claim would drop the recovery entirely.
     if event_at is not None:
@@ -724,7 +761,7 @@ def _claim_resolution(alarm_key, event_at):
             ExpressionAttributeNames=names,
             ExpressionAttributeValues=values,
         )
-        return now
+        return token
     except client.exceptions.ConditionalCheckFailedException:
         # The condition fails for three different reasons and they do NOT share an
         # outcome, so read the row rather than assuming the benign one.
@@ -778,8 +815,10 @@ def _claim_alarm_root(alarm_key, event_at):
     if not SLACK_STATE_TABLE:
         return None
     now = int(time.time())
+    token = uuid.uuid4().hex
     values = {
         ':posting': {'S': 'ALARM_POSTING'},
+        ':token': {'S': token},
         ':resolved': {'S': 'RESOLVED'},
         ':resolving': {'S': 'RESOLVING'},
         ':now': {'N': str(now)},
@@ -787,7 +826,7 @@ def _claim_alarm_root(alarm_key, event_at):
     }
     condition = ('(attribute_not_exists(AlarmKey) OR #s = :resolved OR #s = :resolving'
                  ' OR (#s = :posting AND ClaimedAt < :lease))')
-    update = 'SET #s = :posting, ClaimedAt = :now'
+    update = 'SET #s = :posting, ClaimedAt = :now, ClaimToken = :token'
     if event_at is not None:
         values[':evt'] = {'N': repr(event_at)}
         condition += ' AND (attribute_not_exists(LastEventAt) OR LastEventAt <= :evt)'
@@ -802,7 +841,7 @@ def _claim_alarm_root(alarm_key, event_at):
             ExpressionAttributeNames={'#s': 'Status'},
             ExpressionAttributeValues=values,
         )
-        return now
+        return token
     except client.exceptions.ConditionalCheckFailedException:
         prior = _get_alarm_state(alarm_key)
         if prior and prior.get('status') == 'ALARM_POSTING':
@@ -821,22 +860,24 @@ def _finalize_alarm_root(alarm_key, claim_token, message_ts, started_at, event_a
     if not SLACK_STATE_TABLE:
         return False
     values = {':posting': {'S': 'ALARM_POSTING'},
-              ':claim': {'N': str(claim_token)},
+              ':claim': {'S': str(claim_token)},
               ':alarm': {'S': 'ALARM'},
               ':ts': {'S': message_ts},
+              ':state': {'S': 'ALARM'},
               ':sa': {'S': started_at or datetime.now(timezone.utc).isoformat()}}
-    update = 'SET #s = :alarm, MessageTs = :ts, StartedAt = :sa REMOVE ExpiresAt'
+    update = ('SET #s = :alarm, MessageTs = :ts, StartedAt = :sa,'
+              ' LastEventState = :state REMOVE ExpiresAt')
     if event_at is not None:
         values[':evt'] = {'N': repr(event_at)}
-        update = ('SET #s = :alarm, MessageTs = :ts, StartedAt = :sa, LastEventAt = :evt'
-                  ' REMOVE ExpiresAt')
+        update = ('SET #s = :alarm, MessageTs = :ts, StartedAt = :sa,'
+                  ' LastEventState = :state, LastEventAt = :evt REMOVE ExpiresAt')
     client = boto3.client('dynamodb')
     try:
         client.update_item(
             TableName=SLACK_STATE_TABLE,
             Key={'AlarmKey': {'S': alarm_key}},
             UpdateExpression=update,
-            ConditionExpression='#s = :posting AND ClaimedAt = :claim',
+            ConditionExpression='#s = :posting AND ClaimToken = :claim',
             ExpressionAttributeNames={'#s': 'Status'},
             ExpressionAttributeValues=values,
         )
@@ -864,10 +905,11 @@ def _finalize_resolution(alarm_key, claim_token, event_at):
     if not SLACK_STATE_TABLE:
         return False
     values = {':resolving': {'S': 'RESOLVING'},
-              ':claim': {'N': str(claim_token)},
+              ':claim': {'S': str(claim_token)},
               ':resolved': {'S': 'RESOLVED'},
+              ':state': {'S': 'OK'},
               ':expires': {'N': str(int(time.time()) + STATE_TTL_SECONDS)}}
-    update = 'SET #s = :resolved, ExpiresAt = :expires'
+    update = 'SET #s = :resolved, ExpiresAt = :expires, LastEventState = :state'
     if event_at is not None:
         values[':evt'] = {'N': repr(event_at)}
         update += ', LastEventAt = :evt'
@@ -877,7 +919,7 @@ def _finalize_resolution(alarm_key, claim_token, event_at):
             TableName=SLACK_STATE_TABLE,
             Key={'AlarmKey': {'S': alarm_key}},
             UpdateExpression=update,
-            ConditionExpression='#s = :resolving AND ClaimedAt = :claim',
+            ConditionExpression='#s = :resolving AND ClaimToken = :claim',
             ExpressionAttributeNames={'#s': 'Status'},
             ExpressionAttributeValues=values,
         )
@@ -890,31 +932,43 @@ def _finalize_resolution(alarm_key, claim_token, event_at):
         return False
 
 
-def _put_alarm_state(alarm_key, message_ts, started_at, status, event_at=None,
-                     prior=None):
-    if not SLACK_STATE_TABLE:
-        return
-    item = {
-        'AlarmKey': {'S': alarm_key},
-        'MessageTs': {'S': message_ts},
-        'StartedAt': {'S': started_at or datetime.now(timezone.utc).isoformat()},
-        'Status': {'S': status},
-    }
-    # Carry the watermark forward when this event cannot be ordered. Writing the row
-    # without it would DELETE a perfectly good LastEventAt, so one malformed timestamp
-    # would disable ordering for every event after it.
-    watermark = event_at if event_at is not None else (prior or {}).get('last_event_at')
-    if watermark is not None:
-        item['LastEventAt'] = {'N': repr(watermark)}
-    # TTL only on the tombstone. The row is a tombstone once RESOLVED, but while an alarm
-    # is still ALARM it is the live correlation to the root card, and expiring it strands
-    # the incident: the eventual recovery finds no prior, so it posts an unthreaded green
-    # root with DURATION: Unknown and no reaction - the exact record loss this change
-    # exists to stop, just on a slower clock. An alarm can legitimately burn longer than
-    # the TTL, so the row must outlive it.
-    if status != 'ALARM':
-        item['ExpiresAt'] = {'N': str(int(time.time()) + STATE_TTL_SECONDS)}
-    boto3.client('dynamodb').put_item(TableName=SLACK_STATE_TABLE, Item=item)
+def _touch_alarm_watermark(alarm_key, message_ts, event_at):
+    """Advance the watermark on a repeat ALARM. True if the row was still ours to touch.
+
+    This was a whole-item PutItem, which is how a paused duplicate of an OLD incident
+    could resurrect it: read the row, pause, the incident resolves, a new incident claims
+    and finalises its own root, then the duplicate lands and replaces the whole row with
+    the old root and the old event time. The regressed watermark then made a delayed OK
+    look newer than the live incident, and it closed it.
+
+    A duplicate needs nothing written except the watermark, so touch only that - and only
+    while the row still holds the same root in the same state. Losing that condition is
+    not an error: the edit we just made was to a message that is still correct history,
+    and whatever superseded us is the state that should stand.
+    """
+    if not SLACK_STATE_TABLE or event_at is None:
+        return False
+    client = boto3.client('dynamodb')
+    try:
+        client.update_item(
+            TableName=SLACK_STATE_TABLE,
+            Key={'AlarmKey': {'S': alarm_key}},
+            UpdateExpression='SET LastEventAt = :evt, LastEventState = :state',
+            ConditionExpression=('#s = :alarm AND MessageTs = :ts'
+                                 ' AND (attribute_not_exists(LastEventAt)'
+                                 ' OR LastEventAt <= :evt)'),
+            ExpressionAttributeNames={'#s': 'Status'},
+            ExpressionAttributeValues={
+                ':alarm': {'S': 'ALARM'},
+                ':ts': {'S': message_ts},
+                ':state': {'S': 'ALARM'},
+                ':evt': {'N': repr(event_at)},
+            },
+        )
+        return True
+    except client.exceptions.ConditionalCheckFailedException:
+        print(f'{alarm_key} moved on before the duplicate ALARM could touch it')
+        return False
 
 
 def _deliver_cloudwatch_bot(token, message_json, identifier, region,
@@ -929,9 +983,24 @@ def _deliver_cloudwatch_bot(token, message_json, identifier, region,
     # describes has already been superseded. Applying it would rewrite history with an
     # older truth: a stale ALARM reopens an incident that closed, a stale OK closes one
     # that is still burning and then suppresses its real recovery.
-    if _is_stale(event_at, prior):
+    if _is_stale(event_at, prior, state):
         print(f'skipping stale {state} for {alarm_key} '
               f'(event {event_at} older than {prior.get("last_event_at")})')
+        return
+
+    # An event with no usable timestamp cannot be placed against the row at all. It used
+    # to fall straight through into the claim, which meant a delayed unparseable OK could
+    # close a live incident and suppress its real recovery - the very thing ordering was
+    # added to stop, walking in through the unordered door. Fail open for VISIBILITY
+    # only: post it so nothing is lost, but do not claim, react to, or rewrite the
+    # incident row. There is nothing to correlate it to.
+    if event_at is None and prior and prior.get('status') in ('ALARM', 'ALARM_POSTING',
+                                                              'RESOLVING'):
+        print(f'{alarm_key}: {state} carries no usable StateChangeTime; posting '
+              f'uncorrelated rather than mutating a live incident')
+        payload, _ = cloudwatch_card(
+            message_json, identifier, region, account_id, account_alias, None)
+        _post_bot(token, payload)
         return
 
     # A newly firing incident may reuse an alarm key whose last row is a resolved
@@ -941,6 +1010,7 @@ def _deliver_cloudwatch_bot(token, message_json, identifier, region,
                   (state != 'ALARM' or prior.get('status') == 'ALARM') else None)
     payload, metadata = cloudwatch_card(
         message_json, identifier, region, account_id, account_alias, started_at)
+    transition = _transition_id(alarm_key, state, metadata['changed_at'])
 
     if state == 'ALARM':
         if prior and prior.get('status') == 'ALARM':
@@ -950,7 +1020,7 @@ def _deliver_cloudwatch_bot(token, message_json, identifier, region,
             # needed: editing the same message with the same payload is idempotent.
             message_ts = prior['message_ts']
             _update_bot(token, message_ts, payload)
-            _put_alarm_state(alarm_key, message_ts, started_at, 'ALARM', event_at, prior)
+            _touch_alarm_watermark(alarm_key, message_ts, event_at)
             return
 
         # A brand new root. Claim before posting for the same reason the resolve does:
@@ -969,7 +1039,7 @@ def _deliver_cloudwatch_bot(token, message_json, identifier, region,
         existing_ts = None
         if prior and prior.get('status') == 'ALARM_POSTING':
             existing_ts = _already_posted(
-                token, metadata['alarm_name'],
+                token, transition,
                 since=str(int(time.time()) - STALE_POST_WINDOW))
 
         started_at = metadata['changed_at'] or datetime.now(timezone.utc).isoformat()
@@ -984,7 +1054,7 @@ def _deliver_cloudwatch_bot(token, message_json, identifier, region,
                                  event_at)
             return
 
-        message_ts = _post_bot(token, payload)
+        message_ts = _post_bot(token, payload, transition=transition)
         _finalize_alarm_root(alarm_key, claim_token, message_ts, started_at, event_at)
         return
 
@@ -1010,10 +1080,17 @@ def _deliver_cloudwatch_bot(token, message_json, identifier, region,
         # answer, and only the thread needs reading. Without this the lease turns every
         # crash into a second green card.
         if (prior.get('status') == 'RESOLVING'
-                and _already_posted(token, RECOVERY_MARKER,
+                and _already_posted(token, transition,
                                     thread_ts=prior['message_ts'])):
             print(f'recovery for {metadata["alarm_name"]} is already in the thread; '
                   f'finalising without posting a second one')
+            # The attempt that died may have posted the card and gone before reacting,
+            # so the root would keep its red-only scrollback forever. reactions.add is
+            # idempotent enough for this - already_reacted is caught like any other.
+            try:
+                _add_reaction(token, prior['message_ts'], 'white_check_mark')
+            except Exception as exc:  # noqa: BLE001 - a reaction is decoration
+                print(f'could not mark {metadata["alarm_name"]} resolved: {exc}')
             _finalize_resolution(alarm_key, claim_token, event_at)
             return
 
@@ -1025,7 +1102,7 @@ def _deliver_cloudwatch_bot(token, message_json, identifier, region,
         # claim's lease expires the retry re-claims, finds the card above, and finalises
         # without duplicating it.
         _post_bot(token, payload, thread_ts=prior['message_ts'],
-                  reply_broadcast=True)
+                  reply_broadcast=True, transition=transition)
         try:
             _add_reaction(token, prior['message_ts'], 'white_check_mark')
         except Exception as exc:  # noqa: BLE001 - a reaction is decoration

--- a/terraform/physical/util/sns_to_slack.py
+++ b/terraform/physical/util/sns_to_slack.py
@@ -95,6 +95,16 @@ SLACK_CHANNEL_ID = os.environ.get('SLACK_CHANNEL_ID', '')
 SLACK_STATE_TABLE = os.environ.get('SLACK_STATE_TABLE', '')
 
 STATE_TTL_SECONDS = 30 * 24 * 3600
+
+# How long a resolve claim is honoured before another invocation may take it over.
+#
+# The claim exists so that exactly one delivery of an OK posts the recovery card. The
+# lease exists so that a claim whose posting step then died does not silence the
+# recovery forever. Sized against the retry cadence rather than the posting time: SNS
+# and Lambda async retries are a minute or more apart, so a lease shorter than that
+# lets the retry re-claim and post, while a lease longer than that would make the
+# retry give up on a card that was never actually sent.
+CLAIM_LEASE_SECONDS = 60
 COLOR_CRITICAL = '#e01e5a'
 COLOR_WARNING = '#ecb22e'
 COLOR_RESOLVED = '#2eb67d'
@@ -451,7 +461,45 @@ def _get_alarm_state(alarm_key):
         'message_ts': item['MessageTs']['S'],
         'started_at': item['StartedAt']['S'],
         'status': item['Status']['S'],
+        # Absent on rows written before this field existed. None means "unknown", which
+        # every ordering check below treats as "do not suppress" - an unordered event
+        # posts rather than being dropped.
+        'last_event_at': (float(item['LastEventAt']['N'])
+                          if 'LastEventAt' in item else None),
     }
+
+
+def _event_epoch(message_json):
+    """Epoch seconds for the alarm transition this message describes.
+
+    CloudWatch stamps every state change with StateChangeTime, and that - not arrival
+    order - is the only thing that says which of two deliveries happened first. SNS is
+    at-least-once and unordered, so without it a delayed OK from a previous incident
+    looks exactly like the recovery of the current one.
+
+    Returns None when the field is missing or unparseable. Callers must treat None as
+    "cannot order this" and fall through to posting: never classify on bad data.
+    """
+    raw = message_json.get('StateChangeTime')
+    if not raw:
+        return None
+    try:
+        return datetime.strptime(raw, "%Y-%m-%dT%H:%M:%S.%f%z").timestamp()
+    except (TypeError, ValueError):
+        return None
+
+
+def _is_stale(event_at, prior):
+    """True when this delivery is older than the one the row already reflects.
+
+    Equal timestamps are NOT stale: that is the same event delivered twice, and the
+    duplicate handling for it differs per path (the ALARM path edits, the OK path is
+    gated by the claim below).
+    """
+    if event_at is None or not prior:
+        return False
+    last = prior.get('last_event_at')
+    return last is not None and event_at < last
 
 
 def classify_dms_event(detail_message, detail_type, resource_arn, category=''):
@@ -549,7 +597,63 @@ def _pick_dms_arn(resources):
     return resources[0] if resources else 'N/A'
 
 
-def _put_alarm_state(alarm_key, message_ts, started_at, status):
+def _claim_resolution(alarm_key, event_at):
+    """Atomically take ownership of resolving this incident. True if we own it.
+
+    This is the whole concurrency fix. Two deliveries of the same OK used to both read
+    `status == 'ALARM'` and both post; with `reply_broadcast` that is two full green
+    cards in the channel, not two thread lines. Now they both attempt this conditional
+    transition and DynamoDB picks exactly one winner - the loser returns False and
+    posts nothing.
+
+    The condition accepts two starting states:
+      * ALARM - the normal case, an incident that is still open.
+      * RESOLVING whose claim has outlived CLAIM_LEASE_SECONDS - a previous invocation
+        took the claim and died before posting, so the recovery would otherwise be lost.
+
+    and requires the event not be older than the row already reflects, which is what
+    stops a delayed OK from a previous incident closing the current one. `<=` rather
+    than `<` so a retry of the SAME event can re-claim once its lease expires.
+
+    Returns False when the table is not configured, so the webhook path is unaffected.
+    """
+    if not SLACK_STATE_TABLE:
+        return False
+    now = int(time.time())
+    names = {'#s': 'Status'}
+    values = {
+        ':resolving': {'S': 'RESOLVING'},
+        ':alarm': {'S': 'ALARM'},
+        ':now': {'N': str(now)},
+        ':lease': {'N': str(now - CLAIM_LEASE_SECONDS)},
+    }
+    condition = ('(#s = :alarm OR (#s = :resolving AND ClaimedAt < :lease))')
+    update = 'SET #s = :resolving, ClaimedAt = :now'
+    # Only order when the event carries a usable timestamp. Without one there is nothing
+    # to compare, and refusing to claim would drop the recovery entirely.
+    if event_at is not None:
+        values[':evt'] = {'N': repr(event_at)}
+        condition += (' AND (attribute_not_exists(LastEventAt) OR LastEventAt <= :evt)')
+        update += ', LastEventAt = :evt'
+    client = boto3.client('dynamodb')
+    try:
+        client.update_item(
+            TableName=SLACK_STATE_TABLE,
+            Key={'AlarmKey': {'S': alarm_key}},
+            UpdateExpression=update,
+            ConditionExpression=condition,
+            ExpressionAttributeNames=names,
+            ExpressionAttributeValues=values,
+        )
+        return True
+    except client.exceptions.ConditionalCheckFailedException:
+        # Someone else owns this resolution, or the event is older than the row. Both
+        # mean "post nothing", and neither is an error. Every other failure - throttling,
+        # a missing table, credentials - propagates so the Lambda retries it.
+        return False
+
+
+def _put_alarm_state(alarm_key, message_ts, started_at, status, event_at=None):
     if not SLACK_STATE_TABLE:
         return
     item = {
@@ -558,6 +662,8 @@ def _put_alarm_state(alarm_key, message_ts, started_at, status):
         'StartedAt': {'S': started_at or datetime.now(timezone.utc).isoformat()},
         'Status': {'S': status},
     }
+    if event_at is not None:
+        item['LastEventAt'] = {'N': repr(event_at)}
     # TTL only on the tombstone. The row is a tombstone once RESOLVED, but while an alarm
     # is still ALARM it is the live correlation to the root card, and expiring it strands
     # the incident: the eventual recovery finds no prior, so it posts an unthreaded green
@@ -575,6 +681,17 @@ def _deliver_cloudwatch_bot(token, message_json, identifier, region,
         f'{identifier}:{region}:{message_json.get("AlarmName", "Unknown alarm")}')
     prior = _get_alarm_state(alarm_key)
     state = message_json.get('NewStateValue', 'UNKNOWN')
+    event_at = _event_epoch(message_json)
+
+    # SNS is at-least-once and unordered, so a delivery can arrive after the incident it
+    # describes has already been superseded. Applying it would rewrite history with an
+    # older truth: a stale ALARM reopens an incident that closed, a stale OK closes one
+    # that is still burning and then suppresses its real recovery.
+    if _is_stale(event_at, prior):
+        print(f'skipping stale {state} for {alarm_key} '
+              f'(event {event_at} older than {prior.get("last_event_at")})')
+        return
+
     # A newly firing incident may reuse an alarm key whose last row is a resolved
     # idempotency tombstone; only carry its start into a recovery or a duplicate
     # ALARM update, never into the next distinct incident.
@@ -593,7 +710,7 @@ def _deliver_cloudwatch_bot(token, message_json, identifier, region,
         else:
             message_ts = _post_bot(token, payload)
             started_at = metadata['changed_at'] or datetime.now(timezone.utc).isoformat()
-        _put_alarm_state(alarm_key, message_ts, started_at, 'ALARM')
+        _put_alarm_state(alarm_key, message_ts, started_at, 'ALARM', event_at)
         return
 
     if state == 'OK' and prior:
@@ -601,21 +718,35 @@ def _deliver_cloudwatch_bot(token, message_json, identifier, region,
         # green destroyed the only record that the incident happened: an audit of one
         # week found 10 firing records overwritten, 2 of which left no trace at all.
         # The red root stays red; recovery is a new message, not a rewrite.
-        if prior.get('status') != 'RESOLVED':
-            # Full recovery card, not a one-line summary, so the channel gets the same
-            # detail (duration, final reading, resource) it got when the alarm fired.
-            # Broadcast because a thread reply alone leaves the channel showing red.
-            _post_bot(token, payload, thread_ts=prior['message_ts'],
-                      reply_broadcast=True)
-            try:
-                _add_reaction(token, prior['message_ts'], 'white_check_mark')
-            except Exception as exc:  # noqa: BLE001 - a reaction is decoration
-                # Never let a reactions failure (scope, already_reacted, Slack 5xx)
-                # bubble up: the recovery card is already posted, and raising here
-                # would skip the tombstone below and re-post it on the Lambda retry.
-                print(f'could not mark {metadata["alarm_name"]} '
-                      f'({prior["message_ts"]}) resolved: {exc}')
-        _put_alarm_state(alarm_key, prior['message_ts'], prior['started_at'], 'RESOLVED')
+        #
+        # Claim BEFORE posting, not after. The old order read the status, posted, then
+        # wrote the tombstone, so two concurrent deliveries both saw ALARM and both
+        # broadcast a full green card into the channel. The claim is a conditional
+        # write, so exactly one delivery wins it and the rest return here having sent
+        # nothing.
+        if not _claim_resolution(alarm_key, event_at):
+            print(f'skipping duplicate or stale OK for {alarm_key}')
+            return
+
+        # Full recovery card, not a one-line summary, so the channel gets the same
+        # detail (duration, final reading, resource) it got when the alarm fired.
+        # Broadcast because a thread reply alone leaves the channel showing red.
+        #
+        # If this raises, the row stays RESOLVING and the Lambda retries. Once the
+        # claim's lease expires the retry re-claims and posts, so a failure here costs
+        # a delay rather than the recovery card.
+        _post_bot(token, payload, thread_ts=prior['message_ts'],
+                  reply_broadcast=True)
+        try:
+            _add_reaction(token, prior['message_ts'], 'white_check_mark')
+        except Exception as exc:  # noqa: BLE001 - a reaction is decoration
+            # Never let a reactions failure (scope, already_reacted, Slack 5xx)
+            # bubble up: the recovery card is already posted, and raising here
+            # would leave the row RESOLVING and re-post it on the Lambda retry.
+            print(f'could not mark {metadata["alarm_name"]} '
+                  f'({prior["message_ts"]}) resolved: {exc}')
+        _put_alarm_state(alarm_key, prior['message_ts'], prior['started_at'],
+                         'RESOLVED', event_at)
         return
 
     _post_bot(token, payload)

--- a/terraform/physical/util/test_sns_to_slack.py
+++ b/terraform/physical/util/test_sns_to_slack.py
@@ -799,12 +799,26 @@ except ImportError:  # pragma: no cover - the CI job installs it
     _MOTO = False
 
 
+# Hermetic by construction. The module under test builds its clients with a bare
+# boto3.client('dynamodb'), which in the real Lambda picks the region up from the
+# runtime - but on a machine with no AWS config that raises NoRegionError, so the suite
+# would pass for whoever happened to have a region set and fail in CI. Pinning fake
+# values here means these checks never touch a real account and never depend on one.
+_FAKE_AWS_ENV = {
+    'AWS_DEFAULT_REGION': 'us-east-1',
+    'AWS_REGION': 'us-east-1',
+    'AWS_ACCESS_KEY_ID': 'testing',
+    'AWS_SECRET_ACCESS_KEY': 'testing',
+    'AWS_SECURITY_TOKEN': 'testing',
+    'AWS_SESSION_TOKEN': 'testing',
+}
+
+
 def _with_table(fn):
     """Run fn(client, table) against a fresh in-memory DynamoDB table."""
     import boto3
-    with moto.mock_aws():
-        client = boto3.client('dynamodb', region_name='us-east-1',
-                              aws_access_key_id='x', aws_secret_access_key='x')
+    with mock.patch.dict(os.environ, _FAKE_AWS_ENV), moto.mock_aws():
+        client = boto3.client('dynamodb', region_name='us-east-1')
         client.create_table(
             TableName='slack-alarm-state',
             KeySchema=[{'AttributeName': 'AlarmKey', 'KeyType': 'HASH'}],
@@ -1046,7 +1060,8 @@ def dynamo_checks():
 
     # The no-table configuration must be a no-op rather than an error, so the webhook
     # and tokened-but-tableless paths keep posting.
-    with mock.patch.object(sns_to_slack, 'SLACK_STATE_TABLE', ''):
+    with mock.patch.dict(os.environ, _FAKE_AWS_ENV), \
+         mock.patch.object(sns_to_slack, 'SLACK_STATE_TABLE', ''):
         checks.extend([
             ("no table means no root claim", sns_to_slack._claim_alarm_root('k', 1.0) is None),
             ("no table means no resolve claim", sns_to_slack._claim_resolution('k', 1.0) is None),

--- a/terraform/physical/util/test_sns_to_slack.py
+++ b/terraform/physical/util/test_sns_to_slack.py
@@ -40,6 +40,7 @@ import os
 import sys
 import time
 import importlib.util
+from types import SimpleNamespace
 from unittest import mock
 
 _HERE = os.path.dirname(os.path.abspath(__file__))
@@ -265,7 +266,7 @@ def run_dms_event(detail_message, resource_arn,
 
 
 def deliver_cloudwatch(state, prior, reaction_error=None, claim=True,
-                       changed_at=None):
+                       changed_at=None, already_posted=False):
     """Run _deliver_cloudwatch_bot with every Slack and DynamoDB call captured.
 
     claim stands in for the conditional write's verdict: True means this delivery won
@@ -276,6 +277,7 @@ def deliver_cloudwatch(state, prior, reaction_error=None, claim=True,
     separately in claim_checks().
     """
     updates, posts, states, reactions, claims, finals = [], [], [], [], [], []
+    root_claims, root_finals, dedupes = [], [], []
 
     def _post(token, payload, thread_ts=None, reply_broadcast=False):
         posts.append({'payload': payload, 'thread_ts': thread_ts,
@@ -295,6 +297,18 @@ def deliver_cloudwatch(state, prior, reaction_error=None, claim=True,
         finals.append((alarm_key, claim_token, event_at))
         return True
 
+    def _claim_root(alarm_key, event_at):
+        root_claims.append((alarm_key, event_at))
+        return 1754049600 if claim else None
+
+    def _finalize_root(alarm_key, claim_token, message_ts, started_at, event_at):
+        root_finals.append((alarm_key, claim_token, message_ts))
+        return True
+
+    def _posted(token, marker, thread_ts=None, since=None):
+        dedupes.append((marker, thread_ts))
+        return already_posted
+
     fixture = alarm_fixture(state)
     if changed_at is not None:
         fixture['StateChangeTime'] = changed_at
@@ -306,11 +320,17 @@ def deliver_cloudwatch(state, prior, reaction_error=None, claim=True,
          mock.patch.object(sns_to_slack, '_add_reaction', side_effect=_react), \
          mock.patch.object(sns_to_slack, '_claim_resolution', side_effect=_claim), \
          mock.patch.object(sns_to_slack, '_finalize_resolution', side_effect=_finalize), \
+         mock.patch.object(sns_to_slack, '_claim_alarm_root', side_effect=_claim_root), \
+         mock.patch.object(sns_to_slack, '_finalize_alarm_root', side_effect=_finalize_root), \
+         mock.patch.object(sns_to_slack, '_already_posted', side_effect=_posted), \
          mock.patch.object(sns_to_slack, '_put_alarm_state',
                            side_effect=lambda *args: states.append(args)):
         sns_to_slack._deliver_cloudwatch_bot(
             'xoxb', fixture, 'acme-prod', 'us-east-1', '111', 'prod')
-    return updates, posts, states, reactions, claims, finals
+    return SimpleNamespace(
+        updates=updates, posts=posts, states=states, reactions=reactions,
+        claims=claims, finals=finals, root_claims=root_claims,
+        root_finals=root_finals, dedupes=dedupes)
 
 
 def slack_body_checks():
@@ -493,77 +513,128 @@ def lifecycle_checks():
     firing = {"message_ts": "111.222", "started_at": "2026-08-01T12:00:00.000+0000",
               "status": "ALARM"}
 
-    updates, posts, states, reactions, claims, finals = deliver_cloudwatch("OK", firing)
-    card = str(posts[0]['payload']) if posts else ''
+    r = deliver_cloudwatch("OK", firing)
+    card = str(r.posts[0]['payload']) if r.posts else ''
     checks.extend([
-        ("resolution posts one card", len(posts) == 1),
+        ("resolution posts one card", len(r.posts) == 1),
         ("resolution card is the full green card",
-         posts and posts[0]['payload'].get('attachments', [{}])[0].get('color')
+         r.posts and r.posts[0]['payload'].get('attachments', [{}])[0].get('color')
          == sns_to_slack.COLOR_RESOLVED
          and all(x in card for x in ('✅ RESOLVED', 'OUTCOME', 'DURATION', '8m'))),
-        ("resolution threads under the root", posts and posts[0]['thread_ts'] == "111.222"),
-        ("resolution broadcasts to the channel", posts and posts[0]['broadcast'] is True),
+        ("resolution threads under the root", r.posts and r.posts[0]['thread_ts'] == "111.222"),
+        ("resolution broadcasts to the channel", r.posts and r.posts[0]['broadcast'] is True),
         # The audit that motivated this: 10 firing records overwritten in one week.
-        ("resolution never edits the red root", updates == []),
-        ("resolution reacts on the root", reactions == [("111.222", "white_check_mark")]),
+        ("resolution never edits the red root", r.updates == []),
+        ("resolution reacts on the root", r.reactions == [("111.222", "white_check_mark")]),
         # Finalizing is now a conditional write of its own, not a blind PutItem, so it
         # has to carry the token proving we still own the claim we took.
         ("resolution finalises with the claim token it was given",
-         finals == [(finals[0][0], 1754049600, finals[0][2])] if finals else False),
-        ("resolution writes no unconditional state", states == []),
-        ("resolution claims before it posts", len(claims) == 1),
+         r.finals == [(r.finals[0][0], 1754049600, r.finals[0][2])] if r.finals else False),
+        ("resolution writes no unconditional state", r.states == []),
+        ("resolution claims before it posts", len(r.claims) == 1),
     ])
 
     # reactions:write can be revoked, the root can be too old, Slack can 5xx. None of
     # that may cost us the resolution card, so the failure is swallowed at the call site
     # rather than allowed out of _deliver_cloudwatch_bot.
     try:
-        updates, posts, states, reactions, claims, finals = deliver_cloudwatch(
+        r = deliver_cloudwatch(
             "OK", firing, reaction_error="missing_scope")
         escaped = False
     except Exception:  # noqa: BLE001 - the point of the check is that this cannot happen
-        updates, posts, states, reactions, finals = [], [], [], [], []
+        r = SimpleNamespace(updates=[], posts=[], states=[], reactions=[],
+                            claims=[], finals=[], root_claims=[],
+                            root_finals=[], dedupes=[])
         escaped = True
     checks.extend([
         ("reaction failure does not escape the handler", not escaped),
-        ("reaction failure still posts the resolution card", len(posts) == 1),
-        ("reaction failure does not edit the root", updates == []),
+        ("reaction failure still posts the resolution card", len(r.posts) == 1),
+        ("reaction failure does not edit the root", r.updates == []),
         # If this raised, the row would stay RESOLVING and the retry would re-post.
-        ("reaction failure still finalises the resolution", len(finals) == 1),
+        ("reaction failure still finalises the resolution", len(r.finals) == 1),
     ])
 
     # The claim losing is what a duplicate or already-resolved OK looks like from here:
     # DynamoDB refused the ALARM -> RESOLVING transition. Nothing may be sent after that.
-    updates, posts, states, reactions, claims, finals = deliver_cloudwatch(
+    r = deliver_cloudwatch(
         "OK", dict(firing, status="RESOLVED"), claim=False)
     checks.extend([
-        ("a lost claim posts no card", posts == []),
-        ("a lost claim adds no reaction", reactions == []),
-        ("a lost claim edits nothing", updates == []),
+        ("a lost claim posts no card", r.posts == []),
+        ("a lost claim adds no reaction", r.reactions == []),
+        ("a lost claim edits nothing", r.updates == []),
         # Previously this rewrote the tombstone on every duplicate, pushing its TTL out
         # each time. Now it writes nothing at all.
-        ("a lost claim writes no state", states == [] and finals == []),
-        ("a lost claim still attempted the claim", len(claims) == 1),
+        ("a lost claim writes no state", r.states == [] and r.finals == []),
+        ("a lost claim still attempted the claim", len(r.claims) == 1),
     ])
 
     # Repeat ALARM keeps editing: it is duplicate SNS delivery of the same firing event,
     # and the edit is what stops the same incident appearing twice. It never goes green.
-    updates, posts, states, reactions, claims, finals = deliver_cloudwatch("ALARM", firing)
+    r = deliver_cloudwatch("ALARM", firing)
     checks.extend([
-        ("repeat ALARM edits the root", len(updates) == 1 and updates[0][0] == "111.222"),
-        ("repeat ALARM posts nothing new", posts == []),
-        ("repeat ALARM adds no reaction", reactions == []),
-        ("repeat ALARM stays ALARM", bool(states) and states[0][3] == "ALARM"),
-        ("repeat ALARM never claims a resolution", claims == []),
+        ("repeat ALARM edits the root", len(r.updates) == 1 and r.updates[0][0] == "111.222"),
+        ("repeat ALARM posts nothing new", r.posts == []),
+        ("repeat ALARM adds no reaction", r.reactions == []),
+        ("repeat ALARM stays ALARM", bool(r.states) and r.states[0][3] == "ALARM"),
+        ("repeat ALARM never claims a resolution", r.claims == []),
     ])
 
-    updates, posts, states, reactions, claims, finals = deliver_cloudwatch("ALARM", None)
+    r = deliver_cloudwatch("ALARM", None)
     checks.extend([
         ("first ALARM posts a root, unthreaded",
-         len(posts) == 1 and posts[0]['thread_ts'] is None
-         and posts[0]['broadcast'] is False),
-        ("first ALARM edits nothing", updates == []),
+         len(r.posts) == 1 and r.posts[0]['thread_ts'] is None
+         and r.posts[0]['broadcast'] is False),
+        ("first ALARM edits nothing", r.updates == []),
+        # Same reasoning as the resolve: two deliveries that both see no row would
+        # otherwise both post a root, and only one timestamp would survive the write.
+        ("first ALARM claims before it posts", len(r.root_claims) == 1),
+        ("first ALARM finalises with its claim token",
+         r.root_finals == [(r.root_finals[0][0], 1754049600, '333.444')]
+         if r.root_finals else False),
+        ("first ALARM writes no unconditional state", r.states == []),
+        # A fresh claim cannot have a root already in the channel, so no read is spent.
+        ("first ALARM does not read Slack history", r.dedupes == []),
     ])
+
+    r = deliver_cloudwatch("ALARM", None, claim=False)
+    checks.extend([
+        ("a lost root claim posts nothing", r.posts == []),
+        ("a lost root claim finalises nothing", r.root_finals == []),
+    ])
+
+    # Taking over an ALARM_POSTING claim means a previous attempt died. It may have got
+    # its root into the channel first, and only Slack can say.
+    posting = {"message_ts": "", "started_at": "2026-08-01T12:00:00.000+0000",
+               "status": "ALARM_POSTING"}
+    r = deliver_cloudwatch("ALARM", posting, already_posted=True)
+    checks.extend([
+        ("a takeover checks Slack before reposting the root", len(r.dedupes) == 1),
+        ("a root already in the channel is not posted twice", r.posts == []),
+    ])
+
+    r = deliver_cloudwatch("ALARM", posting, already_posted=False)
+    checks.append(("a takeover with no root in the channel posts one", len(r.posts) == 1))
+
+    # The resolve half of the same problem: the lease turns every crash into a second
+    # green card unless the thread is checked first.
+    resolving = {"message_ts": "111.222", "started_at": "2026-08-01T12:00:00.000+0000",
+                 "status": "RESOLVING"}
+    r = deliver_cloudwatch("OK", resolving, already_posted=True)
+    checks.extend([
+        ("a resolve takeover checks the thread", r.dedupes == [("✅ RESOLVED", "111.222")]),
+        ("a recovery already in the thread is not posted twice", r.posts == []),
+        ("a recovery already in the thread still finalises", len(r.finals) == 1),
+        ("a recovery already in the thread adds no second reaction", r.reactions == []),
+    ])
+
+    r = deliver_cloudwatch("OK", resolving, already_posted=False)
+    checks.append(("a resolve takeover with an empty thread posts the card",
+                   len(r.posts) == 1))
+
+    # The common path must not spend a Slack read: a claim taken from a live ALARM row
+    # is a first attempt, and nothing can already be in the thread.
+    r = deliver_cloudwatch("OK", firing)
+    checks.append(("a first-attempt resolve does not read the thread", r.dedupes == []))
     return checks
 
 
@@ -587,45 +658,45 @@ def ordering_checks():
     open_incident = {"message_ts": "999.888", "started_at": newer,
                      "status": "ALARM", "last_event_at": newer_epoch}
 
-    updates, posts, states, reactions, claims, finals = deliver_cloudwatch(
+    r = deliver_cloudwatch(
         "OK", open_incident, changed_at=older)
     checks.extend([
-        ("a stale OK posts nothing", posts == []),
-        ("a stale OK does not react on the live root", reactions == []),
-        ("a stale OK does not close the live incident", states == []),
+        ("a stale OK posts nothing", r.posts == []),
+        ("a stale OK does not react on the live root", r.reactions == []),
+        ("a stale OK does not close the live incident", r.states == []),
         # Dropped before the claim, so it costs no conditional write either.
-        ("a stale OK never reaches the claim", claims == []),
+        ("a stale OK never reaches the claim", r.claims == []),
     ])
 
-    updates, posts, states, reactions, claims, finals = deliver_cloudwatch(
+    r = deliver_cloudwatch(
         "ALARM", open_incident, changed_at=older)
     checks.extend([
-        ("a stale ALARM posts nothing", posts == []),
-        ("a stale ALARM edits nothing", updates == []),
-        ("a stale ALARM writes no state", states == []),
+        ("a stale ALARM posts nothing", r.posts == []),
+        ("a stale ALARM edits nothing", r.updates == []),
+        ("a stale ALARM writes no state", r.states == []),
     ])
 
     # Same timestamp is a duplicate, not a stale event, and the two paths handle it
     # differently: ALARM edits the root, OK is gated by the claim. Neither is dropped
     # here, or a redelivery of the only OK we get would be lost.
-    updates, posts, states, reactions, claims, finals = deliver_cloudwatch(
+    r = deliver_cloudwatch(
         "OK", open_incident, changed_at=newer)
-    checks.append(("an equal-timestamp OK still reaches the claim", len(claims) == 1))
+    checks.append(("an equal-timestamp OK still reaches the claim", len(r.claims) == 1))
 
     # A row written before LastEventAt existed, or an event with no parseable
     # StateChangeTime, cannot be ordered. Both must fall through to posting rather than
     # being suppressed: never classify on missing data.
     legacy = {"message_ts": "111.222", "started_at": older, "status": "ALARM"}
-    updates, posts, states, reactions, claims, finals = deliver_cloudwatch(
+    r = deliver_cloudwatch(
         "OK", legacy, changed_at=older)
-    checks.append(("a row with no recorded event time still resolves", len(posts) == 1))
+    checks.append(("a row with no recorded event time still resolves", len(r.posts) == 1))
 
-    updates, posts, states, reactions, claims, finals = deliver_cloudwatch(
+    r = deliver_cloudwatch(
         "OK", open_incident, changed_at="not a timestamp")
     checks.extend([
-        ("an unparseable event time still resolves", len(posts) == 1),
+        ("an unparseable event time still resolves", len(r.posts) == 1),
         ("an unparseable event time claims with None",
-         claims == [(claims[0][0], None)] if claims else False),
+         r.claims == [(r.claims[0][0], None)] if r.claims else False),
     ])
 
     checks.extend([
@@ -669,7 +740,7 @@ def claim_checks():
     """The conditional write _claim_resolution actually sends.
 
     DynamoDB evaluates the condition, not this suite, so what is pinned here is the
-    request: the states it will accept, the lease comparison that lets a dead claim be
+    request: the r.states it will accept, the lease comparison that lets a dead claim be
     taken over, and the event-time guard. A fake client stands in for the service and
     reports whether the condition would have been checked at all.
     """
@@ -788,8 +859,8 @@ def claim_checks():
 def finalize_checks():
     """Finalizing a resolution must not clobber an incident that superseded it.
 
-    The flap this exists for: OK1 claims ALARM1 and starts posting; ALARM2 arrives, sees
-    a RESOLVING row, posts its own red root and writes ALARM; OK1 then finishes. An
+    The flap this exists for: OK1 r.claims ALARM1 and starts posting; ALARM2 arrives, sees
+    a RESOLVING row, r.posts its own red root and writes ALARM; OK1 then finishes. An
     unconditional write there would stamp RESOLVED over the live ALARM2, and ALARM2's
     real recovery would later find RESOLVED and post nothing - the original bug, moved
     one step later.
@@ -854,6 +925,48 @@ def finalize_checks():
         sns_to_slack._finalize_resolution('alarm-key', 1754049600, None)
     checks.append(("an unorderable finalise leaves the watermark alone",
                    'LastEventAt' not in calls[0]['UpdateExpression'] if calls else False))
+
+    # The ALARM root has the same shape and the same hazard: between claiming and
+    # recording the root, a resolve or a newer incident can take the row. Recording it
+    # unconditionally would put a stale MessageTs back on a row that moved on, and every
+    # later recovery would thread under the wrong message.
+    calls.clear()
+    with mock.patch.object(sns_to_slack, 'SLACK_STATE_TABLE', 'state-table'), \
+         mock.patch.object(sns_to_slack.boto3, 'client', return_value=_FakeDDB()):
+        root_ok = sns_to_slack._finalize_alarm_root(
+            'alarm-key', 1754049600, '111.222', '2026-08-01T12:00:00+00:00', 1754049601.0)
+    root_sent = calls[0] if calls else {}
+    root_cond = root_sent.get('ConditionExpression', '')
+    root_update = root_sent.get('UpdateExpression', '')
+    root_values = root_sent.get('ExpressionAttributeValues', {})
+    checks.extend([
+        ("finalising an owned root claim succeeds", root_ok is True),
+        ("finalising a root requires the row still be ALARM_POSTING",
+         '#s = :posting' in root_cond),
+        ("finalising a root requires the same claim token",
+         'ClaimedAt = :claim' in root_cond),
+        ("finalising a root records the posted message ts",
+         root_values.get(':ts') == {'S': '111.222'} and 'MessageTs = :ts' in root_update),
+        ("finalising a root flips the row to ALARM", '#s = :alarm' in root_update),
+        # A live incident must not inherit the tombstone TTL from the row it replaced.
+        ("finalising a root clears any tombstone TTL", 'REMOVE ExpiresAt' in root_update),
+    ])
+
+    calls.clear()
+    raised = False
+    try:
+        with mock.patch.object(sns_to_slack, 'SLACK_STATE_TABLE', 'state-table'), \
+             mock.patch.object(sns_to_slack.boto3, 'client',
+                               return_value=_FakeDDB(fail=True)):
+            root_lost = sns_to_slack._finalize_alarm_root(
+                'alarm-key', 1754049600, '111.222', 'x', 1.0)
+    except Exception:  # noqa: BLE001
+        raised = True
+        root_lost = None
+    checks.extend([
+        ("a superseded root finalise reports False", root_lost is False),
+        ("a superseded root finalise does not raise", not raised),
+    ])
     return checks
 
 
@@ -893,7 +1006,7 @@ def state_ttl_checks():
     """Only the tombstone carries a TTL.
 
     An ALARM row is the live correlation to the red root, not a tombstone. Expiring it
-    strands the incident: the eventual recovery finds no prior and posts an unthreaded
+    strands the incident: the eventual recovery finds no prior and r.posts an unthreaded
     green root with DURATION: Unknown - the same record loss this change exists to stop,
     on a slower clock. These drive the real _put_alarm_state and read the item it builds.
     """

--- a/terraform/physical/util/test_sns_to_slack.py
+++ b/terraform/physical/util/test_sns_to_slack.py
@@ -629,6 +629,18 @@ def ordering_checks():
          sns_to_slack._event_epoch({}) is None),
         ("_event_epoch returns None on garbage",
          sns_to_slack._event_epoch({"StateChangeTime": "yesterday"}) is None),
+        # A strptime format string with %f rejects this, which would have opted every
+        # whole-second transition out of ordering without anything failing.
+        ("_event_epoch parses a whole-second timestamp",
+         sns_to_slack._event_epoch({"StateChangeTime": "2026-08-01T12:00:00+0000"})
+         is not None),
+        ("_event_epoch parses a Z suffix",
+         sns_to_slack._event_epoch({"StateChangeTime": "2026-08-01T12:00:00.000Z"})
+         is not None),
+        ("whole-second and fractional forms of one instant agree",
+         sns_to_slack._event_epoch({"StateChangeTime": "2026-08-01T12:00:00+0000"})
+         == sns_to_slack._event_epoch(
+             {"StateChangeTime": "2026-08-01T12:00:00.000+0000"})),
         ("_is_stale is False without a prior row",
          sns_to_slack._is_stale(newer_epoch, None) is False),
         ("_is_stale is False when the row has no recorded time",
@@ -686,12 +698,41 @@ def claim_checks():
         ("the claim records the event time", values.get(':evt') is not None),
     ])
 
-    calls.clear()
-    with mock.patch.object(sns_to_slack, 'SLACK_STATE_TABLE', 'state-table'), \
-         mock.patch.object(sns_to_slack.boto3, 'client',
-                           return_value=_FakeDDB(fail=True)):
-        lost = sns_to_slack._claim_resolution('alarm-key', 1754049600.0)
-    checks.append(("a rejected condition loses the claim, without raising", lost is False))
+    # A rejected condition has three possible causes and only two of them mean "post
+    # nothing". Which one applies is read off the row, so each is driven separately.
+    def claim_against(row):
+        calls.clear()
+        with mock.patch.object(sns_to_slack, 'SLACK_STATE_TABLE', 'state-table'), \
+             mock.patch.object(sns_to_slack.boto3, 'client',
+                               return_value=_FakeDDB(fail=True)), \
+             mock.patch.object(sns_to_slack, '_get_alarm_state', return_value=row):
+            return sns_to_slack._claim_resolution('alarm-key', 1754049600.0)
+
+    resolved_row = {'message_ts': '1.2', 'started_at': 'x', 'status': 'RESOLVED',
+                    'last_event_at': 1754049600.0}
+    still_firing = dict(resolved_row, status='ALARM')
+    checks.extend([
+        ("an already-RESOLVED row loses the claim without raising",
+         claim_against(resolved_row) is False),
+        ("a stale event against a live ALARM row loses the claim without raising",
+         claim_against(still_firing) is False),
+        ("a vanished row loses the claim without raising",
+         claim_against(None) is False),
+    ])
+
+    # THE one that matters. An unexpired RESOLVING claim means another execution owns
+    # this resolution and may have died mid-post. Returning False here would end the
+    # invocation successfully, which drops the event from Lambda's async retry queue -
+    # and Lambda's first retry lands at about the same minute as the lease, so the very
+    # retry meant to take the claim over is the one that would be discarded. The card
+    # would be lost for good. It must raise so the retry gets to re-read.
+    held = dict(resolved_row, status='RESOLVING')
+    raised = False
+    try:
+        claim_against(held)
+    except RuntimeError:
+        raised = True
+    checks.append(("an unexpired RESOLVING claim raises so Lambda retries", raised))
 
     # No event time: there is nothing to order by, so the guard must come off entirely
     # rather than compare against a missing value and reject every claim.

--- a/terraform/physical/util/test_sns_to_slack.py
+++ b/terraform/physical/util/test_sns_to_slack.py
@@ -266,7 +266,8 @@ def run_dms_event(detail_message, resource_arn,
 
 
 def deliver_cloudwatch(state, prior, reaction_error=None, claim=True,
-                       changed_at=None, already_posted=False):
+                       changed_at=None, already_posted=False,
+                       state_table='state-table'):
     """Run _deliver_cloudwatch_bot with every Slack and DynamoDB call captured.
 
     claim stands in for the conditional write's verdict: True means this delivery won
@@ -307,13 +308,14 @@ def deliver_cloudwatch(state, prior, reaction_error=None, claim=True,
 
     def _posted(token, marker, thread_ts=None, since=None):
         dedupes.append((marker, thread_ts))
-        return already_posted
+        return '888.999' if already_posted else None
 
     fixture = alarm_fixture(state)
     if changed_at is not None:
         fixture['StateChangeTime'] = changed_at
 
-    with mock.patch.object(sns_to_slack, '_get_alarm_state', return_value=prior), \
+    with mock.patch.object(sns_to_slack, 'SLACK_STATE_TABLE', state_table), \
+         mock.patch.object(sns_to_slack, '_get_alarm_state', return_value=prior), \
          mock.patch.object(sns_to_slack, '_update_bot',
                            side_effect=lambda token, ts, payload: updates.append((ts, payload))), \
          mock.patch.object(sns_to_slack, '_post_bot', side_effect=_post), \
@@ -635,6 +637,29 @@ def lifecycle_checks():
     # is a first attempt, and nothing can already be in the thread.
     r = deliver_cloudwatch("OK", firing)
     checks.append(("a first-attempt resolve does not read the thread", r.dedupes == []))
+
+    # Adopting a root someone else posted is only half the job. Without the finalise the
+    # row sits in ALARM_POSTING with no MessageTs forever, and every later OK fails to
+    # claim it - a dedupe that quietly bricks the incident.
+    r = deliver_cloudwatch("ALARM", posting, already_posted=True)
+    checks.extend([
+        ("an adopted root is still finalised", len(r.root_finals) == 1),
+        ("the adopted root's ts is what gets recorded",
+         r.root_finals[0][2] == '888.999' if r.root_finals else False),
+    ])
+
+    # A bot token with no state table is a valid configuration: no correlation, no
+    # claims, but the cards still have to go out. Guarding on the claim alone turned
+    # this into a total blackout, which is far worse than the unthreaded posting it
+    # replaced.
+    r = deliver_cloudwatch("ALARM", None, claim=False, state_table='')
+    checks.extend([
+        ("no state table still posts the ALARM root", len(r.posts) == 1),
+        ("no state table writes no state", r.root_finals == [] or True),
+    ])
+
+    r = deliver_cloudwatch("OK", firing, claim=False, state_table='')
+    checks.append(("no state table still posts the recovery", len(r.posts) == 1))
     return checks
 
 
@@ -803,6 +828,18 @@ def claim_checks():
          claim_against(None) is None),
     ])
 
+    # A row mid-root-post cannot satisfy the resolve condition either, and returning
+    # quietly would let the caller read that as "duplicate or stale" and drop the
+    # recovery permanently - nothing else revisits it.
+    posting_row = dict(resolved_row, status='ALARM_POSTING')
+    raised_posting = False
+    try:
+        claim_against(posting_row)
+    except RuntimeError:
+        raised_posting = True
+    checks.append(("an in-flight ALARM_POSTING row raises rather than dropping the OK",
+                   raised_posting))
+
     # THE one that matters. An unexpired RESOLVING claim means another execution owns
     # this resolution and may have died mid-post. Returning False here would end the
     # invocation successfully, which drops the event from Lambda's async retry queue -
@@ -853,6 +890,37 @@ def claim_checks():
     except RuntimeError:
         raised = True
     checks.append(("a non-condition failure propagates", raised))
+
+    # Human chatter must not suppress an incident card. The channel search matches on
+    # the alarm name, so someone typing that name while triaging would otherwise stop
+    # the very card they were talking about - a fail-CLOSED path inside a fail-open
+    # design. Only the bot's own messages count.
+    def read_returning(messages):
+        with mock.patch.object(sns_to_slack, 'SLACK_CHANNEL_ID', 'C1'), \
+             mock.patch.object(sns_to_slack, '_slack_get',
+                               return_value={'messages': messages}):
+            return sns_to_slack._already_posted('xoxb', 'acme-prod-api-5xx')
+
+    checks.extend([
+        ("a human mentioning the alarm name does not count as a posted card",
+         read_returning([{'user': 'U123', 'ts': '9.9',
+                          'text': 'is acme-prod-api-5xx still firing?'}])
+         is None),
+        ("the bot's own card does count, and returns its ts",
+         read_returning([{'bot_id': 'B1', 'ts': '5.6',
+                          'text': 'CRITICAL acme-prod-api-5xx'}]) == '5.6'),
+        ("an unrelated bot post does not count",
+         read_returning([{'bot_id': 'B1', 'ts': '5.6', 'text': 'some other alarm'}])
+         is None),
+    ])
+
+    # A read failure must fail OPEN - returning a ts would suppress a card that was
+    # never sent.
+    with mock.patch.object(sns_to_slack, 'SLACK_CHANNEL_ID', 'C1'), \
+         mock.patch.object(sns_to_slack, '_slack_get',
+                           side_effect=RuntimeError('missing_scope')):
+        checks.append(("a failed history read fails open",
+                       sns_to_slack._already_posted('xoxb', 'x') is None))
     return checks
 
 

--- a/terraform/physical/util/test_sns_to_slack.py
+++ b/terraform/physical/util/test_sns_to_slack.py
@@ -280,9 +280,9 @@ def deliver_cloudwatch(state, prior, reaction_error=None, claim=True,
     updates, posts, states, reactions, claims, finals = [], [], [], [], [], []
     root_claims, root_finals, dedupes = [], [], []
 
-    def _post(token, payload, thread_ts=None, reply_broadcast=False):
+    def _post(token, payload, thread_ts=None, reply_broadcast=False, transition=None):
         posts.append({'payload': payload, 'thread_ts': thread_ts,
-                      'broadcast': reply_broadcast})
+                      'broadcast': reply_broadcast, 'transition': transition})
         return '333.444'
 
     def _react(token, message_ts, name):
@@ -325,8 +325,8 @@ def deliver_cloudwatch(state, prior, reaction_error=None, claim=True,
          mock.patch.object(sns_to_slack, '_claim_alarm_root', side_effect=_claim_root), \
          mock.patch.object(sns_to_slack, '_finalize_alarm_root', side_effect=_finalize_root), \
          mock.patch.object(sns_to_slack, '_already_posted', side_effect=_posted), \
-         mock.patch.object(sns_to_slack, '_put_alarm_state',
-                           side_effect=lambda *args: states.append(args)):
+         mock.patch.object(sns_to_slack, '_touch_alarm_watermark',
+                           side_effect=lambda *args: states.append(args) or True):
         sns_to_slack._deliver_cloudwatch_bot(
             'xoxb', fixture, 'acme-prod', 'us-east-1', '111', 'prod')
     return SimpleNamespace(
@@ -577,7 +577,11 @@ def lifecycle_checks():
         ("repeat ALARM edits the root", len(r.updates) == 1 and r.updates[0][0] == "111.222"),
         ("repeat ALARM posts nothing new", r.posts == []),
         ("repeat ALARM adds no reaction", r.reactions == []),
-        ("repeat ALARM stays ALARM", bool(r.states) and r.states[0][3] == "ALARM"),
+        # The blind whole-item write is gone: a duplicate now touches ONLY the
+        # watermark, conditional on the row still holding this same root.
+        ("repeat ALARM touches only the watermark, for its own root",
+         r.states == [(r.states[0][0], "111.222", r.states[0][2])]
+         if r.states else False),
         ("repeat ALARM never claims a resolution", r.claims == []),
     ])
 
@@ -623,10 +627,18 @@ def lifecycle_checks():
                  "status": "RESOLVING"}
     r = deliver_cloudwatch("OK", resolving, already_posted=True)
     checks.extend([
-        ("a resolve takeover checks the thread", r.dedupes == [("✅ RESOLVED", "111.222")]),
+        # Matched on the transition id in message metadata, not on "RESOLVED" text:
+        # a substring cannot tell this incident's card from the previous one's.
+        ("a resolve takeover checks the thread for THIS transition",
+         len(r.dedupes) == 1 and r.dedupes[0][1] == "111.222"
+         and r.dedupes[0][0].startswith("arn:aws:cloudwatch")
+         and r.dedupes[0][0].endswith("|OK|2026-08-01T12:08:00.000+0000")),
         ("a recovery already in the thread is not posted twice", r.posts == []),
         ("a recovery already in the thread still finalises", len(r.finals) == 1),
-        ("a recovery already in the thread adds no second reaction", r.reactions == []),
+        # The attempt that died may have posted and gone before reacting, leaving the
+        # root red forever in scrollback. reactions.add tolerates already_reacted.
+        ("a recovery already in the thread is still reacted to",
+         r.reactions == [("111.222", "white_check_mark")]),
     ])
 
     r = deliver_cloudwatch("OK", resolving, already_posted=False)
@@ -655,7 +667,11 @@ def lifecycle_checks():
     r = deliver_cloudwatch("ALARM", None, claim=False, state_table='')
     checks.extend([
         ("no state table still posts the ALARM root", len(r.posts) == 1),
-        ("no state table writes no state", r.root_finals == [] or True),
+        # This previously read `r.root_finals == [] or True`, which can never fail. The
+        # real no-op with no table is asserted against DynamoDB in dynamo_checks; what
+        # matters HERE is only that the card still goes out.
+        ("no state table still posts unthreaded",
+         r.posts and r.posts[0]['thread_ts'] is None),
     ])
 
     r = deliver_cloudwatch("OK", firing, claim=False, state_table='')
@@ -716,12 +732,17 @@ def ordering_checks():
         "OK", legacy, changed_at=older)
     checks.append(("a row with no recorded event time still resolves", len(r.posts) == 1))
 
-    r = deliver_cloudwatch(
-        "OK", open_incident, changed_at="not a timestamp")
+    # An event with no usable timestamp cannot be placed against the row, so it fails
+    # open for VISIBILITY only: post it, but do not claim, react to, or rewrite a live
+    # incident. Letting it through to the claim is how a delayed unparseable OK used to
+    # close an incident that was still burning.
+    r = deliver_cloudwatch("OK", open_incident, changed_at="not a timestamp")
     checks.extend([
-        ("an unparseable event time still resolves", len(r.posts) == 1),
-        ("an unparseable event time claims with None",
-         r.claims == [(r.claims[0][0], None)] if r.claims else False),
+        ("an unparseable event time still posts something", len(r.posts) == 1),
+        ("it posts uncorrelated, not threaded", r.posts[0]['thread_ts'] is None),
+        ("it never claims the live incident", r.claims == []),
+        ("it does not react on the live root", r.reactions == []),
+        ("it writes no state", r.states == [] and r.finals == []),
     ])
 
     checks.extend([
@@ -761,342 +782,293 @@ def ordering_checks():
     return checks
 
 
-def claim_checks():
-    """The conditional write _claim_resolution actually sends.
+# --- DynamoDB-backed checks -------------------------------------------------------
+#
+# Everything above this line runs on mocks, which is right for routing and rendering.
+# The state machine is different: its correctness lives in ConditionExpressions that
+# DynamoDB evaluates, and a mock that asserts "we sent the right request" cannot tell a
+# correct condition from a nonsense one. Four review rounds found defects here that the
+# mock suite passed clean through - a same-second token collision, a row shape no reader
+# could parse, a blind write that resurrected a closed incident. All of them are only
+# visible when something actually executes the condition, so these run against moto.
 
-    DynamoDB evaluates the condition, not this suite, so what is pinned here is the
-    request: the r.states it will accept, the lease comparison that lets a dead claim be
-    taken over, and the event-time guard. A fake client stands in for the service and
-    reports whether the condition would have been checked at all.
-    """
-    checks = []
-    calls = []
+try:
+    import moto
+    _MOTO = True
+except ImportError:  # pragma: no cover - the CI job installs it
+    _MOTO = False
 
-    class _FakeDDB:
-        exceptions = _FakeExceptions()
 
-        def __init__(self, fail=False):
-            self.fail = fail
+def _with_table(fn):
+    """Run fn(client, table) against a fresh in-memory DynamoDB table."""
+    import boto3
+    with moto.mock_aws():
+        client = boto3.client('dynamodb', region_name='us-east-1',
+                              aws_access_key_id='x', aws_secret_access_key='x')
+        client.create_table(
+            TableName='slack-alarm-state',
+            KeySchema=[{'AttributeName': 'AlarmKey', 'KeyType': 'HASH'}],
+            AttributeDefinitions=[{'AttributeName': 'AlarmKey',
+                                   'AttributeType': 'S'}],
+            BillingMode='PAY_PER_REQUEST')
+        with mock.patch.object(sns_to_slack, 'SLACK_STATE_TABLE', 'slack-alarm-state'):
+            return fn(client, 'slack-alarm-state')
 
-        def update_item(self, **kwargs):
-            calls.append(kwargs)
-            if self.fail:
-                raise _ConditionalCheckFailedException("condition not met")
 
-    with mock.patch.object(sns_to_slack, 'SLACK_STATE_TABLE', 'state-table'), \
-         mock.patch.object(sns_to_slack.boto3, 'client', return_value=_FakeDDB()):
-        won = sns_to_slack._claim_resolution('alarm-key', 1754049600.0)
+def _row(client):
+    got = client.get_item(TableName='slack-alarm-state',
+                          Key={'AlarmKey': {'S': 'k'}}).get('Item') or {}
+    return {k: list(v.values())[0] for k, v in got.items()}
 
-    sent = calls[0] if calls else {}
-    condition = sent.get('ConditionExpression', '')
-    values = sent.get('ExpressionAttributeValues', {})
-    checks.extend([
-        ("a satisfied condition returns a claim token", bool(won) and won is not True),
-        ("the claim writes RESOLVING",
-         ':resolving' in values and values[':resolving'] == {'S': 'RESOLVING'}),
-        ("the claim accepts an open ALARM", '#s = :alarm' in condition),
-        ("the claim accepts a RESOLVING whose lease expired",
-         '#s = :resolving AND ClaimedAt < :lease' in condition),
-        ("the lease cutoff is CLAIM_LEASE_SECONDS old",
-         int(values[':now']['N']) - int(values[':lease']['N'])
-         == sns_to_slack.CLAIM_LEASE_SECONDS),
-        ("the claim refuses an older event", 'LastEventAt <= :evt' in condition),
-        ("the claim tolerates a row that predates LastEventAt",
-         'attribute_not_exists(LastEventAt)' in condition),
-        ("the claim records the event time", values.get(':evt') is not None),
-    ])
 
-    # A rejected condition has three possible causes and only two of them mean "post
-    # nothing". Which one applies is read off the row, so each is driven separately.
-    def claim_against(row):
-        calls.clear()
-        with mock.patch.object(sns_to_slack, 'SLACK_STATE_TABLE', 'state-table'), \
-             mock.patch.object(sns_to_slack.boto3, 'client',
-                               return_value=_FakeDDB(fail=True)), \
-             mock.patch.object(sns_to_slack, '_get_alarm_state', return_value=row):
-            return sns_to_slack._claim_resolution('alarm-key', 1754049600.0)
-
-    resolved_row = {'message_ts': '1.2', 'started_at': 'x', 'status': 'RESOLVED',
-                    'last_event_at': 1754049600.0}
-    still_firing = dict(resolved_row, status='ALARM')
-    checks.extend([
-        ("an already-RESOLVED row loses the claim without raising",
-         claim_against(resolved_row) is None),
-        ("a stale event against a live ALARM row loses the claim without raising",
-         claim_against(still_firing) is None),
-        ("a vanished row loses the claim without raising",
-         claim_against(None) is None),
-    ])
-
-    # A row mid-root-post cannot satisfy the resolve condition either, and returning
-    # quietly would let the caller read that as "duplicate or stale" and drop the
-    # recovery permanently - nothing else revisits it.
-    posting_row = dict(resolved_row, status='ALARM_POSTING')
-    raised_posting = False
-    try:
-        claim_against(posting_row)
-    except RuntimeError:
-        raised_posting = True
-    checks.append(("an in-flight ALARM_POSTING row raises rather than dropping the OK",
-                   raised_posting))
-
-    # THE one that matters. An unexpired RESOLVING claim means another execution owns
-    # this resolution and may have died mid-post. Returning False here would end the
-    # invocation successfully, which drops the event from Lambda's async retry queue -
-    # and Lambda's first retry lands at about the same minute as the lease, so the very
-    # retry meant to take the claim over is the one that would be discarded. The card
-    # would be lost for good. It must raise so the retry gets to re-read.
-    held = dict(resolved_row, status='RESOLVING')
-    raised = False
-    try:
-        claim_against(held)
-    except RuntimeError:
-        raised = True
-    checks.append(("an unexpired RESOLVING claim raises so Lambda retries", raised))
-
-    # No event time: there is nothing to order by, so the guard must come off entirely
-    # rather than compare against a missing value and reject every claim.
-    calls.clear()
-    with mock.patch.object(sns_to_slack, 'SLACK_STATE_TABLE', 'state-table'), \
-         mock.patch.object(sns_to_slack.boto3, 'client', return_value=_FakeDDB()):
-        sns_to_slack._claim_resolution('alarm-key', None)
-    unordered = calls[0]['ConditionExpression'] if calls else ''
-    checks.extend([
-        ("an unorderable event drops the time guard", 'LastEventAt' not in unordered),
-        ("an unorderable event still checks the status", '#s = :alarm' in unordered),
-    ])
-
-    # The webhook path has no table. Claiming must be a no-op rather than an error, and
-    # must report False so nothing downstream believes it owns a resolution.
-    calls.clear()
-    with mock.patch.object(sns_to_slack, 'SLACK_STATE_TABLE', ''):
-        checks.append(("no table configured means no claim and no call",
-                       sns_to_slack._claim_resolution('k', 1.0) is None and calls == []))
-
-    # A real service error is not a lost claim and must not be swallowed into one.
-    calls.clear()
-
-    class _BrokenDDB:
-        exceptions = _FakeExceptions()
-
-        def update_item(self, **kwargs):
-            raise RuntimeError("ProvisionedThroughputExceededException")
-
-    raised = False
-    try:
-        with mock.patch.object(sns_to_slack, 'SLACK_STATE_TABLE', 'state-table'), \
-             mock.patch.object(sns_to_slack.boto3, 'client', return_value=_BrokenDDB()):
-            sns_to_slack._claim_resolution('k', 1.0)
-    except RuntimeError:
-        raised = True
-    checks.append(("a non-condition failure propagates", raised))
-
-    # Human chatter must not suppress an incident card. The channel search matches on
-    # the alarm name, so someone typing that name while triaging would otherwise stop
-    # the very card they were talking about - a fail-CLOSED path inside a fail-open
-    # design. Only the bot's own messages count.
-    def read_returning(messages):
+def dedupe_checks():
+    """What _already_posted will and will not treat as an existing card."""
+    def read_returning(messages, marker='arn:k|ALARM|T1'):
         with mock.patch.object(sns_to_slack, 'SLACK_CHANNEL_ID', 'C1'), \
              mock.patch.object(sns_to_slack, '_slack_get',
                                return_value={'messages': messages}):
-            return sns_to_slack._already_posted('xoxb', 'acme-prod-api-5xx')
+            return sns_to_slack._already_posted('xoxb', marker)
 
-    checks.extend([
-        ("a human mentioning the alarm name does not count as a posted card",
-         read_returning([{'user': 'U123', 'ts': '9.9',
-                          'text': 'is acme-prod-api-5xx still firing?'}])
-         is None),
-        ("the bot's own card does count, and returns its ts",
-         read_returning([{'bot_id': 'B1', 'ts': '5.6',
-                          'text': 'CRITICAL acme-prod-api-5xx'}]) == '5.6'),
-        ("an unrelated bot post does not count",
-         read_returning([{'bot_id': 'B1', 'ts': '5.6', 'text': 'some other alarm'}])
-         is None),
-    ])
+    def bot_card(transition, ts='5.6'):
+        return {'bot_id': 'B1', 'ts': ts, 'text': 'CRITICAL acme-prod-api-5xx',
+                'metadata': {'event_type': 'cloudwatch_alarm',
+                             'event_payload': {'transition': transition}}}
 
-    # A read failure must fail OPEN - returning a ts would suppress a card that was
-    # never sent.
+    checks = [
+        ("this transition's own card is found, and its ts returned",
+         read_returning([bot_card('arn:k|ALARM|T1')]) == '5.6'),
+        # The reason substring matching had to go: during a fast re-alarm the previous
+        # incident's red root and green broadcast are both still in the window and both
+        # still contain the alarm name. Adopting one of those as this incident's root
+        # suppresses the card that actually needed sending.
+        ("the PREVIOUS firing's card is not adopted",
+         read_returning([bot_card('arn:k|ALARM|T0')]) is None),
+        ("a recovery card is not adopted as a root",
+         read_returning([bot_card('arn:k|OK|T1')]) is None),
+        # A human typing the alarm name while triaging must not suppress the card they
+        # are talking about - fail-closed hiding inside a fail-open design.
+        ("a human message is never a match",
+         read_returning([{'user': 'U1', 'ts': '9.9',
+                          'text': 'is acme-prod-api-5xx still firing?',
+                          'metadata': {'event_payload':
+                                       {'transition': 'arn:k|ALARM|T1'}}}]) is None),
+        # Matching must be equality on the metadata field, not "does this id appear
+        # anywhere in the message". A card that merely QUOTES another transition's id -
+        # or whose own id contains this one as a prefix - is not this transition's card.
+        ("an id quoted in the text is not a match when the metadata differs",
+         read_returning([{'bot_id': 'B1', 'ts': '7.7',
+                          'text': 'retrying arn:k|ALARM|T1',
+                          'metadata': {'event_payload':
+                                       {'transition': 'arn:k|ALARM|T9'}}}]) is None),
+        ("a longer id containing this one as a prefix is not a match",
+         read_returning([bot_card('arn:k|ALARM|T10')], marker='arn:k|ALARM|T1') is None),
+        ("a bot message with no metadata is not a match",
+         read_returning([{'bot_id': 'B1', 'ts': '5.6', 'text': 'acme-prod-api-5xx'}])
+         is None),
+    ]
+
+    # A read failure must fail OPEN: returning a ts would suppress a card never sent.
     with mock.patch.object(sns_to_slack, 'SLACK_CHANNEL_ID', 'C1'), \
          mock.patch.object(sns_to_slack, '_slack_get',
                            side_effect=RuntimeError('missing_scope')):
         checks.append(("a failed history read fails open",
                        sns_to_slack._already_posted('xoxb', 'x') is None))
-    return checks
 
-
-def finalize_checks():
-    """Finalizing a resolution must not clobber an incident that superseded it.
-
-    The flap this exists for: OK1 r.claims ALARM1 and starts posting; ALARM2 arrives, sees
-    a RESOLVING row, r.posts its own red root and writes ALARM; OK1 then finishes. An
-    unconditional write there would stamp RESOLVED over the live ALARM2, and ALARM2's
-    real recovery would later find RESOLVED and post nothing - the original bug, moved
-    one step later.
-    """
-    checks = []
-    calls = []
-
-    class _FakeDDB:
-        exceptions = _FakeExceptions()
-
-        def __init__(self, fail=False):
-            self.fail = fail
-
-        def update_item(self, **kwargs):
-            calls.append(kwargs)
-            if self.fail:
-                raise _ConditionalCheckFailedException("superseded")
-
-    with mock.patch.object(sns_to_slack, 'SLACK_STATE_TABLE', 'state-table'), \
-         mock.patch.object(sns_to_slack.boto3, 'client', return_value=_FakeDDB()):
-        ok = sns_to_slack._finalize_resolution('alarm-key', 1754049600, 1754049601.0)
-
-    sent = calls[0] if calls else {}
-    condition = sent.get('ConditionExpression', '')
-    values = sent.get('ExpressionAttributeValues', {})
-    update = sent.get('UpdateExpression', '')
+    # The read has to ask for metadata or the match can never succeed.
+    asked = {}
+    with mock.patch.object(sns_to_slack, 'SLACK_CHANNEL_ID', 'C1'), \
+         mock.patch.object(sns_to_slack, '_slack_get',
+                           side_effect=lambda m, t, params: asked.update(
+                               {m: params}) or {'messages': []}):
+        sns_to_slack._already_posted('xoxb', 'x')
+        sns_to_slack._already_posted('xoxb', 'x', thread_ts='1.1')
     checks.extend([
-        ("finalising an owned claim succeeds", ok is True),
-        ("finalising requires the row still be RESOLVING", '#s = :resolving' in condition),
-        ("finalising requires the same claim token", 'ClaimedAt = :claim' in condition),
-        ("the token is the one the claim returned",
-         values.get(':claim') == {'N': '1754049600'}),
-        ("finalising writes RESOLVED", ':resolved' in values and '#s = :resolved' in update),
-        ("finalising sets the tombstone TTL", 'ExpiresAt = :expires' in update),
-        ("the TTL is STATE_TTL_SECONDS out",
-         int(values[':expires']['N']) - int(time.time())
-         > sns_to_slack.STATE_TTL_SECONDS - 60),
-        ("finalising advances the watermark", 'LastEventAt = :evt' in update),
-    ])
-
-    # Superseded: the card is already in the channel, so this is neither an error nor
-    # retryable. Raising would only re-post it; writing anyway would eat the incident.
-    calls.clear()
-    raised = False
-    try:
-        with mock.patch.object(sns_to_slack, 'SLACK_STATE_TABLE', 'state-table'), \
-             mock.patch.object(sns_to_slack.boto3, 'client',
-                               return_value=_FakeDDB(fail=True)):
-            superseded = sns_to_slack._finalize_resolution('alarm-key', 1754049600, 1.0)
-    except Exception:  # noqa: BLE001 - the point is that this cannot happen
-        raised = True
-        superseded = None
-    checks.extend([
-        ("a superseded finalise reports False", superseded is False),
-        ("a superseded finalise does not raise", not raised),
-    ])
-
-    # An unorderable event must not advance or erase the watermark.
-    calls.clear()
-    with mock.patch.object(sns_to_slack, 'SLACK_STATE_TABLE', 'state-table'), \
-         mock.patch.object(sns_to_slack.boto3, 'client', return_value=_FakeDDB()):
-        sns_to_slack._finalize_resolution('alarm-key', 1754049600, None)
-    checks.append(("an unorderable finalise leaves the watermark alone",
-                   'LastEventAt' not in calls[0]['UpdateExpression'] if calls else False))
-
-    # The ALARM root has the same shape and the same hazard: between claiming and
-    # recording the root, a resolve or a newer incident can take the row. Recording it
-    # unconditionally would put a stale MessageTs back on a row that moved on, and every
-    # later recovery would thread under the wrong message.
-    calls.clear()
-    with mock.patch.object(sns_to_slack, 'SLACK_STATE_TABLE', 'state-table'), \
-         mock.patch.object(sns_to_slack.boto3, 'client', return_value=_FakeDDB()):
-        root_ok = sns_to_slack._finalize_alarm_root(
-            'alarm-key', 1754049600, '111.222', '2026-08-01T12:00:00+00:00', 1754049601.0)
-    root_sent = calls[0] if calls else {}
-    root_cond = root_sent.get('ConditionExpression', '')
-    root_update = root_sent.get('UpdateExpression', '')
-    root_values = root_sent.get('ExpressionAttributeValues', {})
-    checks.extend([
-        ("finalising an owned root claim succeeds", root_ok is True),
-        ("finalising a root requires the row still be ALARM_POSTING",
-         '#s = :posting' in root_cond),
-        ("finalising a root requires the same claim token",
-         'ClaimedAt = :claim' in root_cond),
-        ("finalising a root records the posted message ts",
-         root_values.get(':ts') == {'S': '111.222'} and 'MessageTs = :ts' in root_update),
-        ("finalising a root flips the row to ALARM", '#s = :alarm' in root_update),
-        # A live incident must not inherit the tombstone TTL from the row it replaced.
-        ("finalising a root clears any tombstone TTL", 'REMOVE ExpiresAt' in root_update),
-    ])
-
-    calls.clear()
-    raised = False
-    try:
-        with mock.patch.object(sns_to_slack, 'SLACK_STATE_TABLE', 'state-table'), \
-             mock.patch.object(sns_to_slack.boto3, 'client',
-                               return_value=_FakeDDB(fail=True)):
-            root_lost = sns_to_slack._finalize_alarm_root(
-                'alarm-key', 1754049600, '111.222', 'x', 1.0)
-    except Exception:  # noqa: BLE001
-        raised = True
-        root_lost = None
-    checks.extend([
-        ("a superseded root finalise reports False", root_lost is False),
-        ("a superseded root finalise does not raise", not raised),
+        ("the history read requests metadata",
+         asked.get('conversations.history', {}).get('include_all_metadata') == 'true'),
+        ("the thread read requests metadata",
+         asked.get('conversations.replies', {}).get('include_all_metadata') == 'true'),
     ])
     return checks
 
 
-def watermark_checks():
-    """A malformed event must never delete a good ordering watermark.
-
-    _put_alarm_state replaces the whole item, so writing a row for an event that could
-    not be ordered would drop LastEventAt entirely - and one bad timestamp would then
-    disable ordering for every event after it.
-    """
-    written = []
-
-    class _FakeDDB:
-        def put_item(self, **kwargs):
-            written.append(kwargs['Item'])
-
-    prior = {'message_ts': '1.2', 'started_at': 'x', 'status': 'ALARM',
-             'last_event_at': 1754049600.0}
-    with mock.patch.object(sns_to_slack, 'SLACK_STATE_TABLE', 'state-table'), \
-         mock.patch.object(sns_to_slack.boto3, 'client', return_value=_FakeDDB()):
-        sns_to_slack._put_alarm_state('k', '1.2', 'x', 'ALARM', None, prior)
-        sns_to_slack._put_alarm_state('k', '1.2', 'x', 'ALARM', 1754049999.0, prior)
-        sns_to_slack._put_alarm_state('k', '1.2', 'x', 'ALARM', None, None)
-
-    carried, advanced, fresh = written
-    return [
-        ("an unorderable event keeps the previous watermark",
-         carried.get('LastEventAt') == {'N': '1754049600.0'}),
-        ("an orderable event advances the watermark",
-         advanced.get('LastEventAt') == {'N': '1754049999.0'}),
-        ("a first row with no orderable event writes no watermark",
-         'LastEventAt' not in fresh),
-    ]
-
-
-def state_ttl_checks():
-    """Only the tombstone carries a TTL.
-
-    An ALARM row is the live correlation to the red root, not a tombstone. Expiring it
-    strands the incident: the eventual recovery finds no prior and r.posts an unthreaded
-    green root with DURATION: Unknown - the same record loss this change exists to stop,
-    on a slower clock. These drive the real _put_alarm_state and read the item it builds.
-    """
-    written = []
-
-    class _FakeDDB:
-        def put_item(self, **kwargs):
-            written.append(kwargs['Item'])
-
+def dynamo_checks():
+    """The state machine, executed against a real DynamoDB implementation."""
+    if not _MOTO:
+        # Deliberately a FAILURE, not a skip. Without moto none of the conditional
+        # writes are exercised at all, and a suite that silently drops its only real
+        # coverage of them while still reporting green is how this got here.
+        return [("moto is installed so the state machine can be tested for real", False)]
     checks = []
-    with mock.patch.object(sns_to_slack, 'SLACK_STATE_TABLE', 'state-table'), \
-         mock.patch.object(sns_to_slack.boto3, 'client', return_value=_FakeDDB()):
-        sns_to_slack._put_alarm_state('k', '111.222', '2026-08-01T12:00:00+00:00', 'ALARM')
-        sns_to_slack._put_alarm_state('k', '111.222', '2026-08-01T12:00:00+00:00', 'RESOLVED')
 
-    alarm_item, resolved_item = written
+    # A claimed-but-unposted row has no MessageTs. Reading it used to raise KeyError,
+    # which crashed every retry BEFORE it could take the claim over - so a died-mid-post
+    # root was lost permanently and the lease never got to matter.
+    def pending_read(client, table):
+        token = sns_to_slack._claim_alarm_root('k', 100.0)
+        return token, sns_to_slack._get_alarm_state('k'), _row(client)
+    token, state, row = _with_table(pending_read)
     checks.extend([
-        ("an ALARM row carries no TTL", 'ExpiresAt' not in alarm_item),
-        ("an ALARM row still records its root ts", alarm_item['MessageTs']['S'] == '111.222'),
-        ("a RESOLVED row carries a TTL", 'ExpiresAt' in resolved_item),
-        ("the RESOLVED TTL is in the future",
-         int(resolved_item['ExpiresAt']['N']) > int(time.time())),
+        ("a fresh root claim succeeds", bool(token)),
+        ("the pending row it writes is readable", state is not None),
+        ("a pending row reports no message ts", state and state['message_ts'] is None),
+        ("a pending row reports its status", state and state['status'] == 'ALARM_POSTING'),
+        ("the claim token is a uuid, not a timestamp",
+         len(token) == 32 and not token.isdigit()),
+        ("the row carries that token", row.get('ClaimToken') == token),
+    ])
+
+    # Two claims inside one wall-clock second must not share an identity. ClaimedAt is
+    # whole seconds, so using it as the token let a stale finalizer satisfy a condition
+    # written for a claim it never held, and close someone else's incident.
+    def two_claims(client, table):
+        a = sns_to_slack._claim_alarm_root('k', 100.0)
+        client.update_item(TableName=table, Key={'AlarmKey': {'S': 'k'}},
+                           UpdateExpression='SET #s = :a',
+                           ExpressionAttributeNames={'#s': 'Status'},
+                           ExpressionAttributeValues={':a': {'S': 'RESOLVED'}})
+        b = sns_to_slack._claim_alarm_root('k', 101.0)
+        return a, b
+    a, b = _with_table(two_claims)
+    checks.append(("two claims in the same second get different tokens", a != b))
+
+    # A finalizer holding a superseded token must not win.
+    def stale_finalize(client, table):
+        first = sns_to_slack._claim_alarm_root('k', 100.0)
+        sns_to_slack._finalize_alarm_root('k', first, '1.1', 'start', 100.0)
+        # A second incident takes the row over. It has to resolve first - a row still
+        # in ALARM is the repeat-delivery path, not a new incident.
+        ok = sns_to_slack._claim_resolution('k', 150.0)
+        sns_to_slack._finalize_resolution('k', ok, 150.0)
+        second = sns_to_slack._claim_alarm_root('k', 200.0)
+        # The first claim's finaliser arrives late.
+        late = sns_to_slack._finalize_alarm_root('k', first, '9.9', 'start', 100.0)
+        return late, second, _row(client)
+    late, second, row = _with_table(stale_finalize)
+    checks.extend([
+        ("a superseded finaliser is rejected", late is False),
+        ("the newer claim still owns the row", row.get('ClaimToken') == second),
+        ("the superseded finaliser did not write its message ts",
+         row.get('MessageTs') != '9.9'),
+    ])
+
+    # The interleaving Codex reproduced: a paused duplicate ALARM must not resurrect an
+    # incident that has since resolved and been replaced.
+    def duplicate_overwrite(client, table):
+        first = sns_to_slack._claim_alarm_root('k', 100.0)
+        sns_to_slack._finalize_alarm_root('k', first, 'root-1', 'start', 100.0)
+        ok = sns_to_slack._claim_resolution('k', 200.0)
+        sns_to_slack._finalize_resolution('k', ok, 200.0)
+        second = sns_to_slack._claim_alarm_root('k', 300.0)
+        sns_to_slack._finalize_alarm_root('k', second, 'root-2', 'start', 300.0)
+        # The paused duplicate of incident ONE finally lands.
+        touched = sns_to_slack._touch_alarm_watermark('k', 'root-1', 100.0)
+        return touched, _row(client)
+    touched, row = _with_table(duplicate_overwrite)
+    checks.extend([
+        ("a stale duplicate ALARM cannot touch the row", touched is False),
+        ("the live incident keeps its root", row.get('MessageTs') == 'root-2'),
+        ("the live incident keeps its watermark", float(row.get('LastEventAt')) == 300.0),
+    ])
+
+    # A duplicate of the CURRENT incident may advance the watermark.
+    def live_duplicate(client, table):
+        first = sns_to_slack._claim_alarm_root('k', 100.0)
+        sns_to_slack._finalize_alarm_root('k', first, 'root-1', 'start', 100.0)
+        return sns_to_slack._touch_alarm_watermark('k', 'root-1', 150.0), _row(client)
+    touched, row = _with_table(live_duplicate)
+    checks.extend([
+        ("a duplicate of the live incident is applied", touched is True),
+        ("it advances the watermark", float(row.get('LastEventAt')) == 150.0),
+    ])
+
+    # Ordering, evaluated by the service rather than asserted as a substring.
+    def stale_resolve(client, table):
+        first = sns_to_slack._claim_alarm_root('k', 300.0)
+        sns_to_slack._finalize_alarm_root('k', first, 'root-1', 'start', 300.0)
+        return sns_to_slack._claim_resolution('k', 200.0)
+    checks.append(("an OK older than the watermark cannot claim",
+                   _with_table(stale_resolve) is None))
+
+    def lease(client, table):
+        sns_to_slack._claim_alarm_root('k', 100.0)
+        client.update_item(TableName=table, Key={'AlarmKey': {'S': 'k'}},
+                           UpdateExpression='SET ClaimedAt = :old',
+                           ExpressionAttributeValues={':old': {'N': str(
+                               int(time.time()) - sns_to_slack.CLAIM_LEASE_SECONDS - 5)}})
+        return sns_to_slack._claim_alarm_root('k', 101.0)
+    checks.append(("an expired claim can be taken over", bool(_with_table(lease))))
+
+    def unexpired(client, table):
+        sns_to_slack._claim_alarm_root('k', 100.0)
+        try:
+            sns_to_slack._claim_alarm_root('k', 101.0)
+            return 'no raise'
+        except RuntimeError:
+            return 'raised'
+    checks.append(("an unexpired claim raises instead of dropping the event",
+                   _with_table(unexpired) == 'raised'))
+
+    # TTL: a live incident must never inherit the tombstone's expiry.
+    def ttl(client, table):
+        first = sns_to_slack._claim_alarm_root('k', 100.0)
+        sns_to_slack._finalize_alarm_root('k', first, 'root-1', 'start', 100.0)
+        live = _row(client)
+        ok = sns_to_slack._claim_resolution('k', 200.0)
+        sns_to_slack._finalize_resolution('k', ok, 200.0)
+        return live, _row(client)
+    live, resolved = _with_table(ttl)
+    checks.extend([
+        ("a live ALARM row carries no TTL", 'ExpiresAt' not in live),
+        ("a RESOLVED row carries one", 'ExpiresAt' in resolved),
+        ("the resolved row records the state its watermark belongs to",
+         resolved.get('LastEventState') == 'OK'),
+    ])
+
+    # Equal timestamps with CONFLICTING states are two truths about one instant and
+    # nothing can order them, so whichever arrived second used to win. An ALARM could
+    # reopen a row an OK had resolved at the same second, and the reverse arrival order
+    # gave the opposite answer - the outcome depended purely on delivery race.
+    def equal_conflict(client, table):
+        first = sns_to_slack._claim_alarm_root('k', 100.0)
+        sns_to_slack._finalize_alarm_root('k', first, 'root-1', 'start', 100.0)
+        ok = sns_to_slack._claim_resolution('k', 200.0)
+        sns_to_slack._finalize_resolution('k', ok, 200.0)
+        return sns_to_slack._get_alarm_state('k')
+    resolved_state = _with_table(equal_conflict)
+    checks.extend([
+        ("an equal-timestamp ALARM against a resolved OK is stale",
+         sns_to_slack._is_stale(200.0, resolved_state, 'ALARM') is True),
+        ("an equal-timestamp redelivery of the SAME state is not stale",
+         sns_to_slack._is_stale(200.0, resolved_state, 'OK') is False),
+        ("a newer ALARM after that resolve is not stale",
+         sns_to_slack._is_stale(300.0, resolved_state, 'ALARM') is False),
+    ])
+
+    # The no-table configuration must be a no-op rather than an error, so the webhook
+    # and tokened-but-tableless paths keep posting.
+    with mock.patch.object(sns_to_slack, 'SLACK_STATE_TABLE', ''):
+        checks.extend([
+            ("no table means no root claim", sns_to_slack._claim_alarm_root('k', 1.0) is None),
+            ("no table means no resolve claim", sns_to_slack._claim_resolution('k', 1.0) is None),
+            ("no table means no root finalise",
+             sns_to_slack._finalize_alarm_root('k', 't', '1.1', 's', 1.0) is False),
+            ("no table means no resolve finalise",
+             sns_to_slack._finalize_resolution('k', 't', 1.0) is False),
+            ("no table means no watermark touch",
+             sns_to_slack._touch_alarm_watermark('k', '1.1', 1.0) is False),
+        ])
+
+    # The transition id has to distinguish this incident's card from the previous one's,
+    # which is the whole reason the dedupe stopped matching on the alarm name.
+    a1 = sns_to_slack._transition_id('arn:k', 'ALARM', '2026-08-01T12:00:00.000+0000')
+    a2 = sns_to_slack._transition_id('arn:k', 'ALARM', '2026-08-01T13:00:00.000+0000')
+    ok1 = sns_to_slack._transition_id('arn:k', 'OK', '2026-08-01T12:00:00.000+0000')
+    checks.extend([
+        ("two firings of one alarm get different transition ids", a1 != a2),
+        ("the ALARM and OK of one instant differ", a1 != ok1),
+        ("the same transition is stable across retries",
+         a1 == sns_to_slack._transition_id('arn:k', 'ALARM',
+                                           '2026-08-01T12:00:00.000+0000')),
     ])
     return checks
 
@@ -1158,8 +1130,8 @@ def main():
             failures.append((message, expected, got, f"serverless: {why}"))
 
     checks = (renderer_checks() + slack_body_checks() + dms_routing_checks()
-              + lifecycle_checks() + state_ttl_checks() + ordering_checks()
-              + claim_checks() + finalize_checks() + watermark_checks())
+              + lifecycle_checks() + ordering_checks() + dedupe_checks()
+              + dynamo_checks())
     for name, passed in checks:
         if not passed:
             failures.append((name, "PASS", "FAIL", "renderer/routing/lifecycle contract"))

--- a/terraform/physical/util/test_sns_to_slack.py
+++ b/terraform/physical/util/test_sns_to_slack.py
@@ -54,6 +54,21 @@ _spec.loader.exec_module(sns_to_slack)
 
 DROP = sns_to_slack.DMS_ROUTINE_MESSAGES
 
+
+class _ConditionalCheckFailedException(Exception):
+    """Stand-in for botocore's dynamically generated error class.
+
+    The real one only exists on a live client's `exceptions` namespace, which is exactly
+    how _claim_resolution catches it. The fake client below exposes this under the same
+    attribute so the production code path is the one under test, rather than a
+    name-matching shortcut written for the suite's benefit.
+    """
+
+
+class _FakeExceptions:
+    ConditionalCheckFailedException = _ConditionalCheckFailedException
+
+
 # The aurora migration task and the BI serverless replication, which are the two producers
 # behind the single EventBridge rule that feeds this lambda.
 TASK_ARN = "arn:aws:dms:us-east-1:111:replication-task:EXAMPLETASKID"
@@ -249,9 +264,18 @@ def run_dms_event(detail_message, resource_arn,
     return posted, lookups
 
 
-def deliver_cloudwatch(state, prior, reaction_error=None):
-    """Run _deliver_cloudwatch_bot with every Slack and DynamoDB call captured."""
-    updates, posts, states, reactions = [], [], [], []
+def deliver_cloudwatch(state, prior, reaction_error=None, claim=True,
+                       changed_at=None):
+    """Run _deliver_cloudwatch_bot with every Slack and DynamoDB call captured.
+
+    claim stands in for the conditional write's verdict: True means this delivery won
+    the ALARM -> RESOLVING transition, False means DynamoDB rejected it because another
+    delivery already owns the resolve or the event is older than the row. The condition
+    itself is DynamoDB's to evaluate - what these checks pin is that we ask before
+    posting and honour the answer. _claim_resolution's request shape is asserted
+    separately in claim_checks().
+    """
+    updates, posts, states, reactions, claims = [], [], [], [], []
 
     def _post(token, payload, thread_ts=None, reply_broadcast=False):
         posts.append({'payload': payload, 'thread_ts': thread_ts,
@@ -263,16 +287,25 @@ def deliver_cloudwatch(state, prior, reaction_error=None):
         if reaction_error:
             raise RuntimeError(reaction_error)
 
+    def _claim(alarm_key, event_at):
+        claims.append((alarm_key, event_at))
+        return claim
+
+    fixture = alarm_fixture(state)
+    if changed_at is not None:
+        fixture['StateChangeTime'] = changed_at
+
     with mock.patch.object(sns_to_slack, '_get_alarm_state', return_value=prior), \
          mock.patch.object(sns_to_slack, '_update_bot',
                            side_effect=lambda token, ts, payload: updates.append((ts, payload))), \
          mock.patch.object(sns_to_slack, '_post_bot', side_effect=_post), \
          mock.patch.object(sns_to_slack, '_add_reaction', side_effect=_react), \
+         mock.patch.object(sns_to_slack, '_claim_resolution', side_effect=_claim), \
          mock.patch.object(sns_to_slack, '_put_alarm_state',
                            side_effect=lambda *args: states.append(args)):
         sns_to_slack._deliver_cloudwatch_bot(
-            'xoxb', alarm_fixture(state), 'acme-prod', 'us-east-1', '111', 'prod')
-    return updates, posts, states, reactions
+            'xoxb', fixture, 'acme-prod', 'us-east-1', '111', 'prod')
+    return updates, posts, states, reactions, claims
 
 
 def slack_body_checks():
@@ -455,7 +488,7 @@ def lifecycle_checks():
     firing = {"message_ts": "111.222", "started_at": "2026-08-01T12:00:00.000+0000",
               "status": "ALARM"}
 
-    updates, posts, states, reactions = deliver_cloudwatch("OK", firing)
+    updates, posts, states, reactions, claims = deliver_cloudwatch("OK", firing)
     card = str(posts[0]['payload']) if posts else ''
     checks.extend([
         ("resolution posts one card", len(posts) == 1),
@@ -469,14 +502,15 @@ def lifecycle_checks():
         ("resolution never edits the red root", updates == []),
         ("resolution reacts on the root", reactions == [("111.222", "white_check_mark")]),
         ("resolution keeps idempotency tombstone",
-         bool(states) and states[0][1] == "111.222" and states[0][-1] == "RESOLVED"),
+         bool(states) and states[0][1] == "111.222" and states[0][3] == "RESOLVED"),
+        ("resolution claims before it posts", len(claims) == 1),
     ])
 
     # reactions:write can be revoked, the root can be too old, Slack can 5xx. None of
     # that may cost us the resolution card, so the failure is swallowed at the call site
     # rather than allowed out of _deliver_cloudwatch_bot.
     try:
-        updates, posts, states, reactions = deliver_cloudwatch(
+        updates, posts, states, reactions, claims = deliver_cloudwatch(
             "OK", firing, reaction_error="missing_scope")
         escaped = False
     except Exception:  # noqa: BLE001 - the point of the check is that this cannot happen
@@ -486,39 +520,215 @@ def lifecycle_checks():
         ("reaction failure does not escape the handler", not escaped),
         ("reaction failure still posts the resolution card", len(posts) == 1),
         ("reaction failure does not edit the root", updates == []),
-        # If this raised, the tombstone would never be written and the Lambda retry
-        # would post a second green card.
+        # If this raised, the row would stay RESOLVING and the retry would re-post.
         ("reaction failure still writes the tombstone",
-         bool(states) and states[0][-1] == "RESOLVED"),
+         bool(states) and states[0][3] == "RESOLVED"),
     ])
 
-    resolved = dict(firing, status="RESOLVED")
-    updates, posts, states, reactions = deliver_cloudwatch("OK", resolved)
+    # The claim losing is what a duplicate or already-resolved OK looks like from here:
+    # DynamoDB refused the ALARM -> RESOLVING transition. Nothing may be sent after that.
+    updates, posts, states, reactions, claims = deliver_cloudwatch(
+        "OK", dict(firing, status="RESOLVED"), claim=False)
     checks.extend([
-        ("duplicate OK posts no second card", posts == []),
-        ("duplicate OK adds no second reaction", reactions == []),
-        ("duplicate OK edits nothing", updates == []),
-        ("duplicate OK rewrites the tombstone only",
-         bool(states) and states[0][-1] == "RESOLVED"),
+        ("a lost claim posts no card", posts == []),
+        ("a lost claim adds no reaction", reactions == []),
+        ("a lost claim edits nothing", updates == []),
+        # Previously this rewrote the tombstone on every duplicate, pushing its TTL out
+        # each time. Now it writes nothing at all.
+        ("a lost claim writes no state", states == []),
+        ("a lost claim still attempted the claim", len(claims) == 1),
     ])
 
     # Repeat ALARM keeps editing: it is duplicate SNS delivery of the same firing event,
     # and the edit is what stops the same incident appearing twice. It never goes green.
-    updates, posts, states, reactions = deliver_cloudwatch("ALARM", firing)
+    updates, posts, states, reactions, claims = deliver_cloudwatch("ALARM", firing)
     checks.extend([
         ("repeat ALARM edits the root", len(updates) == 1 and updates[0][0] == "111.222"),
         ("repeat ALARM posts nothing new", posts == []),
         ("repeat ALARM adds no reaction", reactions == []),
-        ("repeat ALARM stays ALARM", bool(states) and states[0][-1] == "ALARM"),
+        ("repeat ALARM stays ALARM", bool(states) and states[0][3] == "ALARM"),
+        ("repeat ALARM never claims a resolution", claims == []),
     ])
 
-    updates, posts, states, reactions = deliver_cloudwatch("ALARM", None)
+    updates, posts, states, reactions, claims = deliver_cloudwatch("ALARM", None)
     checks.extend([
         ("first ALARM posts a root, unthreaded",
          len(posts) == 1 and posts[0]['thread_ts'] is None
          and posts[0]['broadcast'] is False),
         ("first ALARM edits nothing", updates == []),
     ])
+    return checks
+
+
+def ordering_checks():
+    """Out-of-order delivery must not rewrite history with an older truth.
+
+    SNS is at-least-once and unordered. The sequence that motivated this:
+
+        ALARM1 -> OK1 -> ALARM2 -> (delayed) OK1
+
+    the delayed OK1 used to thread a green card under ALARM2, react to it, and mark it
+    RESOLVED - closing a live incident. The real OK2 was then suppressed because the row
+    already said RESOLVED, so the incident that mattered never got a recovery at all.
+    """
+    checks = []
+    # StateChangeTime of the row's last applied event, and one an hour older.
+    newer = "2026-08-01T13:00:00.000+0000"
+    older = "2026-08-01T12:00:00.000+0000"
+    newer_epoch = sns_to_slack._event_epoch({"StateChangeTime": newer})
+
+    open_incident = {"message_ts": "999.888", "started_at": newer,
+                     "status": "ALARM", "last_event_at": newer_epoch}
+
+    updates, posts, states, reactions, claims = deliver_cloudwatch(
+        "OK", open_incident, changed_at=older)
+    checks.extend([
+        ("a stale OK posts nothing", posts == []),
+        ("a stale OK does not react on the live root", reactions == []),
+        ("a stale OK does not close the live incident", states == []),
+        # Dropped before the claim, so it costs no conditional write either.
+        ("a stale OK never reaches the claim", claims == []),
+    ])
+
+    updates, posts, states, reactions, claims = deliver_cloudwatch(
+        "ALARM", open_incident, changed_at=older)
+    checks.extend([
+        ("a stale ALARM posts nothing", posts == []),
+        ("a stale ALARM edits nothing", updates == []),
+        ("a stale ALARM writes no state", states == []),
+    ])
+
+    # Same timestamp is a duplicate, not a stale event, and the two paths handle it
+    # differently: ALARM edits the root, OK is gated by the claim. Neither is dropped
+    # here, or a redelivery of the only OK we get would be lost.
+    updates, posts, states, reactions, claims = deliver_cloudwatch(
+        "OK", open_incident, changed_at=newer)
+    checks.append(("an equal-timestamp OK still reaches the claim", len(claims) == 1))
+
+    # A row written before LastEventAt existed, or an event with no parseable
+    # StateChangeTime, cannot be ordered. Both must fall through to posting rather than
+    # being suppressed: never classify on missing data.
+    legacy = {"message_ts": "111.222", "started_at": older, "status": "ALARM"}
+    updates, posts, states, reactions, claims = deliver_cloudwatch(
+        "OK", legacy, changed_at=older)
+    checks.append(("a row with no recorded event time still resolves", len(posts) == 1))
+
+    updates, posts, states, reactions, claims = deliver_cloudwatch(
+        "OK", open_incident, changed_at="not a timestamp")
+    checks.extend([
+        ("an unparseable event time still resolves", len(posts) == 1),
+        ("an unparseable event time claims with None",
+         claims == [(claims[0][0], None)] if claims else False),
+    ])
+
+    checks.extend([
+        ("_event_epoch parses CloudWatch's format", newer_epoch is not None),
+        ("_event_epoch orders two timestamps",
+         sns_to_slack._event_epoch({"StateChangeTime": older}) < newer_epoch),
+        ("_event_epoch returns None on a missing field",
+         sns_to_slack._event_epoch({}) is None),
+        ("_event_epoch returns None on garbage",
+         sns_to_slack._event_epoch({"StateChangeTime": "yesterday"}) is None),
+        ("_is_stale is False without a prior row",
+         sns_to_slack._is_stale(newer_epoch, None) is False),
+        ("_is_stale is False when the row has no recorded time",
+         sns_to_slack._is_stale(newer_epoch, {"status": "ALARM"}) is False),
+        ("_is_stale is False for an equal timestamp",
+         sns_to_slack._is_stale(newer_epoch, open_incident) is False),
+        ("_is_stale is True for an older event",
+         sns_to_slack._is_stale(newer_epoch - 1, open_incident) is True),
+    ])
+    return checks
+
+
+def claim_checks():
+    """The conditional write _claim_resolution actually sends.
+
+    DynamoDB evaluates the condition, not this suite, so what is pinned here is the
+    request: the states it will accept, the lease comparison that lets a dead claim be
+    taken over, and the event-time guard. A fake client stands in for the service and
+    reports whether the condition would have been checked at all.
+    """
+    checks = []
+    calls = []
+
+    class _FakeDDB:
+        exceptions = _FakeExceptions()
+
+        def __init__(self, fail=False):
+            self.fail = fail
+
+        def update_item(self, **kwargs):
+            calls.append(kwargs)
+            if self.fail:
+                raise _ConditionalCheckFailedException("condition not met")
+
+    with mock.patch.object(sns_to_slack, 'SLACK_STATE_TABLE', 'state-table'), \
+         mock.patch.object(sns_to_slack.boto3, 'client', return_value=_FakeDDB()):
+        won = sns_to_slack._claim_resolution('alarm-key', 1754049600.0)
+
+    sent = calls[0] if calls else {}
+    condition = sent.get('ConditionExpression', '')
+    values = sent.get('ExpressionAttributeValues', {})
+    checks.extend([
+        ("a satisfied condition wins the claim", won is True),
+        ("the claim writes RESOLVING",
+         ':resolving' in values and values[':resolving'] == {'S': 'RESOLVING'}),
+        ("the claim accepts an open ALARM", '#s = :alarm' in condition),
+        ("the claim accepts a RESOLVING whose lease expired",
+         '#s = :resolving AND ClaimedAt < :lease' in condition),
+        ("the lease cutoff is CLAIM_LEASE_SECONDS old",
+         int(values[':now']['N']) - int(values[':lease']['N'])
+         == sns_to_slack.CLAIM_LEASE_SECONDS),
+        ("the claim refuses an older event", 'LastEventAt <= :evt' in condition),
+        ("the claim tolerates a row that predates LastEventAt",
+         'attribute_not_exists(LastEventAt)' in condition),
+        ("the claim records the event time", values.get(':evt') is not None),
+    ])
+
+    calls.clear()
+    with mock.patch.object(sns_to_slack, 'SLACK_STATE_TABLE', 'state-table'), \
+         mock.patch.object(sns_to_slack.boto3, 'client',
+                           return_value=_FakeDDB(fail=True)):
+        lost = sns_to_slack._claim_resolution('alarm-key', 1754049600.0)
+    checks.append(("a rejected condition loses the claim, without raising", lost is False))
+
+    # No event time: there is nothing to order by, so the guard must come off entirely
+    # rather than compare against a missing value and reject every claim.
+    calls.clear()
+    with mock.patch.object(sns_to_slack, 'SLACK_STATE_TABLE', 'state-table'), \
+         mock.patch.object(sns_to_slack.boto3, 'client', return_value=_FakeDDB()):
+        sns_to_slack._claim_resolution('alarm-key', None)
+    unordered = calls[0]['ConditionExpression'] if calls else ''
+    checks.extend([
+        ("an unorderable event drops the time guard", 'LastEventAt' not in unordered),
+        ("an unorderable event still checks the status", '#s = :alarm' in unordered),
+    ])
+
+    # The webhook path has no table. Claiming must be a no-op rather than an error, and
+    # must report False so nothing downstream believes it owns a resolution.
+    calls.clear()
+    with mock.patch.object(sns_to_slack, 'SLACK_STATE_TABLE', ''):
+        checks.append(("no table configured means no claim and no call",
+                       sns_to_slack._claim_resolution('k', 1.0) is False and calls == []))
+
+    # A real service error is not a lost claim and must not be swallowed into one.
+    calls.clear()
+
+    class _BrokenDDB:
+        exceptions = _FakeExceptions()
+
+        def update_item(self, **kwargs):
+            raise RuntimeError("ProvisionedThroughputExceededException")
+
+    raised = False
+    try:
+        with mock.patch.object(sns_to_slack, 'SLACK_STATE_TABLE', 'state-table'), \
+             mock.patch.object(sns_to_slack.boto3, 'client', return_value=_BrokenDDB()):
+            sns_to_slack._claim_resolution('k', 1.0)
+    except RuntimeError:
+        raised = True
+    checks.append(("a non-condition failure propagates", raised))
     return checks
 
 
@@ -610,7 +820,8 @@ def main():
             failures.append((message, expected, got, f"serverless: {why}"))
 
     checks = (renderer_checks() + slack_body_checks() + dms_routing_checks()
-              + lifecycle_checks() + state_ttl_checks())
+              + lifecycle_checks() + state_ttl_checks() + ordering_checks()
+              + claim_checks())
     for name, passed in checks:
         if not passed:
             failures.append((name, "PASS", "FAIL", "renderer/routing/lifecycle contract"))

--- a/terraform/physical/util/test_sns_to_slack.py
+++ b/terraform/physical/util/test_sns_to_slack.py
@@ -275,7 +275,7 @@ def deliver_cloudwatch(state, prior, reaction_error=None, claim=True,
     posting and honour the answer. _claim_resolution's request shape is asserted
     separately in claim_checks().
     """
-    updates, posts, states, reactions, claims = [], [], [], [], []
+    updates, posts, states, reactions, claims, finals = [], [], [], [], [], []
 
     def _post(token, payload, thread_ts=None, reply_broadcast=False):
         posts.append({'payload': payload, 'thread_ts': thread_ts,
@@ -289,7 +289,11 @@ def deliver_cloudwatch(state, prior, reaction_error=None, claim=True,
 
     def _claim(alarm_key, event_at):
         claims.append((alarm_key, event_at))
-        return claim
+        return 1754049600 if claim else None
+
+    def _finalize(alarm_key, claim_token, event_at):
+        finals.append((alarm_key, claim_token, event_at))
+        return True
 
     fixture = alarm_fixture(state)
     if changed_at is not None:
@@ -301,11 +305,12 @@ def deliver_cloudwatch(state, prior, reaction_error=None, claim=True,
          mock.patch.object(sns_to_slack, '_post_bot', side_effect=_post), \
          mock.patch.object(sns_to_slack, '_add_reaction', side_effect=_react), \
          mock.patch.object(sns_to_slack, '_claim_resolution', side_effect=_claim), \
+         mock.patch.object(sns_to_slack, '_finalize_resolution', side_effect=_finalize), \
          mock.patch.object(sns_to_slack, '_put_alarm_state',
                            side_effect=lambda *args: states.append(args)):
         sns_to_slack._deliver_cloudwatch_bot(
             'xoxb', fixture, 'acme-prod', 'us-east-1', '111', 'prod')
-    return updates, posts, states, reactions, claims
+    return updates, posts, states, reactions, claims, finals
 
 
 def slack_body_checks():
@@ -488,7 +493,7 @@ def lifecycle_checks():
     firing = {"message_ts": "111.222", "started_at": "2026-08-01T12:00:00.000+0000",
               "status": "ALARM"}
 
-    updates, posts, states, reactions, claims = deliver_cloudwatch("OK", firing)
+    updates, posts, states, reactions, claims, finals = deliver_cloudwatch("OK", firing)
     card = str(posts[0]['payload']) if posts else ''
     checks.extend([
         ("resolution posts one card", len(posts) == 1),
@@ -501,8 +506,11 @@ def lifecycle_checks():
         # The audit that motivated this: 10 firing records overwritten in one week.
         ("resolution never edits the red root", updates == []),
         ("resolution reacts on the root", reactions == [("111.222", "white_check_mark")]),
-        ("resolution keeps idempotency tombstone",
-         bool(states) and states[0][1] == "111.222" and states[0][3] == "RESOLVED"),
+        # Finalizing is now a conditional write of its own, not a blind PutItem, so it
+        # has to carry the token proving we still own the claim we took.
+        ("resolution finalises with the claim token it was given",
+         finals == [(finals[0][0], 1754049600, finals[0][2])] if finals else False),
+        ("resolution writes no unconditional state", states == []),
         ("resolution claims before it posts", len(claims) == 1),
     ])
 
@@ -510,24 +518,23 @@ def lifecycle_checks():
     # that may cost us the resolution card, so the failure is swallowed at the call site
     # rather than allowed out of _deliver_cloudwatch_bot.
     try:
-        updates, posts, states, reactions, claims = deliver_cloudwatch(
+        updates, posts, states, reactions, claims, finals = deliver_cloudwatch(
             "OK", firing, reaction_error="missing_scope")
         escaped = False
     except Exception:  # noqa: BLE001 - the point of the check is that this cannot happen
-        updates, posts, states, reactions = [], [], [], []
+        updates, posts, states, reactions, finals = [], [], [], [], []
         escaped = True
     checks.extend([
         ("reaction failure does not escape the handler", not escaped),
         ("reaction failure still posts the resolution card", len(posts) == 1),
         ("reaction failure does not edit the root", updates == []),
         # If this raised, the row would stay RESOLVING and the retry would re-post.
-        ("reaction failure still writes the tombstone",
-         bool(states) and states[0][3] == "RESOLVED"),
+        ("reaction failure still finalises the resolution", len(finals) == 1),
     ])
 
     # The claim losing is what a duplicate or already-resolved OK looks like from here:
     # DynamoDB refused the ALARM -> RESOLVING transition. Nothing may be sent after that.
-    updates, posts, states, reactions, claims = deliver_cloudwatch(
+    updates, posts, states, reactions, claims, finals = deliver_cloudwatch(
         "OK", dict(firing, status="RESOLVED"), claim=False)
     checks.extend([
         ("a lost claim posts no card", posts == []),
@@ -535,13 +542,13 @@ def lifecycle_checks():
         ("a lost claim edits nothing", updates == []),
         # Previously this rewrote the tombstone on every duplicate, pushing its TTL out
         # each time. Now it writes nothing at all.
-        ("a lost claim writes no state", states == []),
+        ("a lost claim writes no state", states == [] and finals == []),
         ("a lost claim still attempted the claim", len(claims) == 1),
     ])
 
     # Repeat ALARM keeps editing: it is duplicate SNS delivery of the same firing event,
     # and the edit is what stops the same incident appearing twice. It never goes green.
-    updates, posts, states, reactions, claims = deliver_cloudwatch("ALARM", firing)
+    updates, posts, states, reactions, claims, finals = deliver_cloudwatch("ALARM", firing)
     checks.extend([
         ("repeat ALARM edits the root", len(updates) == 1 and updates[0][0] == "111.222"),
         ("repeat ALARM posts nothing new", posts == []),
@@ -550,7 +557,7 @@ def lifecycle_checks():
         ("repeat ALARM never claims a resolution", claims == []),
     ])
 
-    updates, posts, states, reactions, claims = deliver_cloudwatch("ALARM", None)
+    updates, posts, states, reactions, claims, finals = deliver_cloudwatch("ALARM", None)
     checks.extend([
         ("first ALARM posts a root, unthreaded",
          len(posts) == 1 and posts[0]['thread_ts'] is None
@@ -580,7 +587,7 @@ def ordering_checks():
     open_incident = {"message_ts": "999.888", "started_at": newer,
                      "status": "ALARM", "last_event_at": newer_epoch}
 
-    updates, posts, states, reactions, claims = deliver_cloudwatch(
+    updates, posts, states, reactions, claims, finals = deliver_cloudwatch(
         "OK", open_incident, changed_at=older)
     checks.extend([
         ("a stale OK posts nothing", posts == []),
@@ -590,7 +597,7 @@ def ordering_checks():
         ("a stale OK never reaches the claim", claims == []),
     ])
 
-    updates, posts, states, reactions, claims = deliver_cloudwatch(
+    updates, posts, states, reactions, claims, finals = deliver_cloudwatch(
         "ALARM", open_incident, changed_at=older)
     checks.extend([
         ("a stale ALARM posts nothing", posts == []),
@@ -601,7 +608,7 @@ def ordering_checks():
     # Same timestamp is a duplicate, not a stale event, and the two paths handle it
     # differently: ALARM edits the root, OK is gated by the claim. Neither is dropped
     # here, or a redelivery of the only OK we get would be lost.
-    updates, posts, states, reactions, claims = deliver_cloudwatch(
+    updates, posts, states, reactions, claims, finals = deliver_cloudwatch(
         "OK", open_incident, changed_at=newer)
     checks.append(("an equal-timestamp OK still reaches the claim", len(claims) == 1))
 
@@ -609,11 +616,11 @@ def ordering_checks():
     # StateChangeTime, cannot be ordered. Both must fall through to posting rather than
     # being suppressed: never classify on missing data.
     legacy = {"message_ts": "111.222", "started_at": older, "status": "ALARM"}
-    updates, posts, states, reactions, claims = deliver_cloudwatch(
+    updates, posts, states, reactions, claims, finals = deliver_cloudwatch(
         "OK", legacy, changed_at=older)
     checks.append(("a row with no recorded event time still resolves", len(posts) == 1))
 
-    updates, posts, states, reactions, claims = deliver_cloudwatch(
+    updates, posts, states, reactions, claims, finals = deliver_cloudwatch(
         "OK", open_incident, changed_at="not a timestamp")
     checks.extend([
         ("an unparseable event time still resolves", len(posts) == 1),
@@ -629,6 +636,11 @@ def ordering_checks():
          sns_to_slack._event_epoch({}) is None),
         ("_event_epoch returns None on garbage",
          sns_to_slack._event_epoch({"StateChangeTime": "yesterday"}) is None),
+        # fromisoformat happily parses a value with no offset, and .timestamp() would
+        # then read it as process-local time - a confidently wrong ordering key built
+        # from bad data. CloudWatch always sends an offset, so this belongs in None.
+        ("_event_epoch rejects a timezone-naive timestamp",
+         sns_to_slack._event_epoch({"StateChangeTime": "2026-08-01T12:00:00"}) is None),
         # A strptime format string with %f rejects this, which would have opted every
         # whole-second transition out of ordering without anything failing.
         ("_event_epoch parses a whole-second timestamp",
@@ -683,7 +695,7 @@ def claim_checks():
     condition = sent.get('ConditionExpression', '')
     values = sent.get('ExpressionAttributeValues', {})
     checks.extend([
-        ("a satisfied condition wins the claim", won is True),
+        ("a satisfied condition returns a claim token", bool(won) and won is not True),
         ("the claim writes RESOLVING",
          ':resolving' in values and values[':resolving'] == {'S': 'RESOLVING'}),
         ("the claim accepts an open ALARM", '#s = :alarm' in condition),
@@ -713,11 +725,11 @@ def claim_checks():
     still_firing = dict(resolved_row, status='ALARM')
     checks.extend([
         ("an already-RESOLVED row loses the claim without raising",
-         claim_against(resolved_row) is False),
+         claim_against(resolved_row) is None),
         ("a stale event against a live ALARM row loses the claim without raising",
-         claim_against(still_firing) is False),
+         claim_against(still_firing) is None),
         ("a vanished row loses the claim without raising",
-         claim_against(None) is False),
+         claim_against(None) is None),
     ])
 
     # THE one that matters. An unexpired RESOLVING claim means another execution owns
@@ -751,7 +763,7 @@ def claim_checks():
     calls.clear()
     with mock.patch.object(sns_to_slack, 'SLACK_STATE_TABLE', ''):
         checks.append(("no table configured means no claim and no call",
-                       sns_to_slack._claim_resolution('k', 1.0) is False and calls == []))
+                       sns_to_slack._claim_resolution('k', 1.0) is None and calls == []))
 
     # A real service error is not a lost claim and must not be swallowed into one.
     calls.clear()
@@ -771,6 +783,110 @@ def claim_checks():
         raised = True
     checks.append(("a non-condition failure propagates", raised))
     return checks
+
+
+def finalize_checks():
+    """Finalizing a resolution must not clobber an incident that superseded it.
+
+    The flap this exists for: OK1 claims ALARM1 and starts posting; ALARM2 arrives, sees
+    a RESOLVING row, posts its own red root and writes ALARM; OK1 then finishes. An
+    unconditional write there would stamp RESOLVED over the live ALARM2, and ALARM2's
+    real recovery would later find RESOLVED and post nothing - the original bug, moved
+    one step later.
+    """
+    checks = []
+    calls = []
+
+    class _FakeDDB:
+        exceptions = _FakeExceptions()
+
+        def __init__(self, fail=False):
+            self.fail = fail
+
+        def update_item(self, **kwargs):
+            calls.append(kwargs)
+            if self.fail:
+                raise _ConditionalCheckFailedException("superseded")
+
+    with mock.patch.object(sns_to_slack, 'SLACK_STATE_TABLE', 'state-table'), \
+         mock.patch.object(sns_to_slack.boto3, 'client', return_value=_FakeDDB()):
+        ok = sns_to_slack._finalize_resolution('alarm-key', 1754049600, 1754049601.0)
+
+    sent = calls[0] if calls else {}
+    condition = sent.get('ConditionExpression', '')
+    values = sent.get('ExpressionAttributeValues', {})
+    update = sent.get('UpdateExpression', '')
+    checks.extend([
+        ("finalising an owned claim succeeds", ok is True),
+        ("finalising requires the row still be RESOLVING", '#s = :resolving' in condition),
+        ("finalising requires the same claim token", 'ClaimedAt = :claim' in condition),
+        ("the token is the one the claim returned",
+         values.get(':claim') == {'N': '1754049600'}),
+        ("finalising writes RESOLVED", ':resolved' in values and '#s = :resolved' in update),
+        ("finalising sets the tombstone TTL", 'ExpiresAt = :expires' in update),
+        ("the TTL is STATE_TTL_SECONDS out",
+         int(values[':expires']['N']) - int(time.time())
+         > sns_to_slack.STATE_TTL_SECONDS - 60),
+        ("finalising advances the watermark", 'LastEventAt = :evt' in update),
+    ])
+
+    # Superseded: the card is already in the channel, so this is neither an error nor
+    # retryable. Raising would only re-post it; writing anyway would eat the incident.
+    calls.clear()
+    raised = False
+    try:
+        with mock.patch.object(sns_to_slack, 'SLACK_STATE_TABLE', 'state-table'), \
+             mock.patch.object(sns_to_slack.boto3, 'client',
+                               return_value=_FakeDDB(fail=True)):
+            superseded = sns_to_slack._finalize_resolution('alarm-key', 1754049600, 1.0)
+    except Exception:  # noqa: BLE001 - the point is that this cannot happen
+        raised = True
+        superseded = None
+    checks.extend([
+        ("a superseded finalise reports False", superseded is False),
+        ("a superseded finalise does not raise", not raised),
+    ])
+
+    # An unorderable event must not advance or erase the watermark.
+    calls.clear()
+    with mock.patch.object(sns_to_slack, 'SLACK_STATE_TABLE', 'state-table'), \
+         mock.patch.object(sns_to_slack.boto3, 'client', return_value=_FakeDDB()):
+        sns_to_slack._finalize_resolution('alarm-key', 1754049600, None)
+    checks.append(("an unorderable finalise leaves the watermark alone",
+                   'LastEventAt' not in calls[0]['UpdateExpression'] if calls else False))
+    return checks
+
+
+def watermark_checks():
+    """A malformed event must never delete a good ordering watermark.
+
+    _put_alarm_state replaces the whole item, so writing a row for an event that could
+    not be ordered would drop LastEventAt entirely - and one bad timestamp would then
+    disable ordering for every event after it.
+    """
+    written = []
+
+    class _FakeDDB:
+        def put_item(self, **kwargs):
+            written.append(kwargs['Item'])
+
+    prior = {'message_ts': '1.2', 'started_at': 'x', 'status': 'ALARM',
+             'last_event_at': 1754049600.0}
+    with mock.patch.object(sns_to_slack, 'SLACK_STATE_TABLE', 'state-table'), \
+         mock.patch.object(sns_to_slack.boto3, 'client', return_value=_FakeDDB()):
+        sns_to_slack._put_alarm_state('k', '1.2', 'x', 'ALARM', None, prior)
+        sns_to_slack._put_alarm_state('k', '1.2', 'x', 'ALARM', 1754049999.0, prior)
+        sns_to_slack._put_alarm_state('k', '1.2', 'x', 'ALARM', None, None)
+
+    carried, advanced, fresh = written
+    return [
+        ("an unorderable event keeps the previous watermark",
+         carried.get('LastEventAt') == {'N': '1754049600.0'}),
+        ("an orderable event advances the watermark",
+         advanced.get('LastEventAt') == {'N': '1754049999.0'}),
+        ("a first row with no orderable event writes no watermark",
+         'LastEventAt' not in fresh),
+    ]
 
 
 def state_ttl_checks():
@@ -862,7 +978,7 @@ def main():
 
     checks = (renderer_checks() + slack_body_checks() + dms_routing_checks()
               + lifecycle_checks() + state_ttl_checks() + ordering_checks()
-              + claim_checks())
+              + claim_checks() + finalize_checks() + watermark_checks())
     for name, passed in checks:
         if not passed:
             failures.append((name, "PASS", "FAIL", "renderer/routing/lifecycle contract"))


### PR DESCRIPTION
The two follow-ups logged against #460. They are independent; either could be reverted without the other.

## 1. The state table is ordered and single-writer

The row was an unconditional `PutItem` that recorded no sense of *when*, which left two holes. Both were pre-existing, and #460 made the first one louder rather than causing it.

**Concurrent resolutions.** Two deliveries of the same OK both read `status='ALARM'` and both posted. Before #460 the duplicate was a thin thread reply; after it, `reply_broadcast` puts two full green cards in the channel.

**Out-of-order delivery.** SNS is at-least-once and unordered. Given `ALARM1 -> OK1 -> ALARM2 -> delayed OK1`, the stale OK threaded a green card under ALARM2, reacted to it, and marked it RESOLVED - closing an incident that was still burning. The real OK2 was then suppressed, because the row already said RESOLVED. So the incident that mattered got no recovery at all.

What changed:

- The row carries **`LastEventAt`**, taken from CloudWatch's `StateChangeTime`. That field, not arrival order, is the only thing that says which of two deliveries happened first.
- A delivery **older** than the one already applied is dropped before it reaches Slack, on both paths. An **equal** timestamp is a duplicate rather than a stale event and is not dropped - the two paths already handle duplicates differently, and dropping it would lose a redelivery of the only OK we get.
- Resolving is **claimed before posting**, via a conditional `ALARM -> RESOLVING` update. DynamoDB picks exactly one winner; the losers return having sent nothing. The old order read, posted, then wrote, which is precisely the window that produced the duplicate.
- A claim whose posting step then died can be **taken over** once `CLAIM_LEASE_SECONDS` (60s) has passed. That only works because a claim blocked by an *unexpired* `RESOLVING` **raises** rather than returning quietly: returning would end the invocation successfully and drop the event from Lambda's async retry queue, and Lambda's first retry lands at about the same minute as the lease - so the very retry meant to take the claim over would be the one discarded. Raising lets the retry re-read, by which point the holder has either finished (row is RESOLVED, the retry is quiet) or its lease expired (the retry posts).
- Finalizing is **conditional on still owning the claim**, using the `ClaimedAt` value as an ownership token. A fast flap can hand the row to a new incident mid-post - OK1 claims, ALARM2 arrives and writes ALARM, OK1 finishes - and an unconditional write there would stamp RESOLVED over the live incident, whose own recovery would then find RESOLVED and post nothing. Losing that race is neither an error nor retryable, so it logs and leaves the newer state alone.
- An event that cannot be ordered **carries the existing watermark forward**. `_put_alarm_state` replaces the whole item, so writing without it would delete a good `LastEventAt` and disable ordering for everything after it.
- `_event_epoch` **rejects timezone-naive values**. `fromisoformat` parses them and `.timestamp()` would read them as process-local time, which turns bad data into a confidently wrong ordering key.
- Both guards **fall through to posting** when the timestamp is missing or unparseable, and when the row predates the field. Never classify on bad data - the existing `alarm_recently_configured` sets the same precedent.

A duplicate OK now also writes nothing at all, where it used to rewrite the tombstone and push its TTL out each time.

### IAM

Adds `dynamodb:UpdateItem`. `PutItem` cannot express a condition that reads the row it is replacing, and the claim has to read status and event time in the same atomic operation that writes the new ones.

## 2. The ALARM root is claimed too

Two deliveries could both read no row, both post a red root, and only one timestamp would survive the write. The other root was then permanently untracked - it never got a check-mark, and its recovery threaded under the wrong message, which contradicts the posted-once invariant the whole change rests on.

The root is now claimed before posting, with the same lease and the same raise-on-held-claim as the resolve, and recording it is conditional on still owning that claim. The repeat-ALARM path keeps editing without a claim, because editing the same message with the same payload is already idempotent.

## 3. A retried card is deduped against Slack

The claim stops a *concurrent* duplicate. It cannot stop a *retry* duplicate: if a crash lands between posting and finalizing, the row stays `RESOLVING`, and the retry that takes the claim over posts the card again. The claim has no way to know whether the previous attempt got its message through, because the failure being covered is precisely "Slack accepted it and we never learned that".

Only Slack can answer, so on a takeover - and only on a takeover, so the common path spends no extra API call - the incident thread is read for an existing recovery, and channel history for an existing root.

**Both reads fail open.** A missing scope, a Slack 5xx, an unreadable thread: log and post. A duplicate card is an annoyance; a missing one is the bug this change exists to prevent.

### Slack scopes

`channels:history` (or `groups:history`) on the bot token, alongside `chat:write` and `reactions:write`. **Granted 2026-08-08.** Without it the dedupe reads fail, get logged, and the behaviour degrades to what shipped before, so it was never a deploy blocker - but the exactly-once property only exists with it.

## 4. The suite runs in CI

It was hand-run only. That is a poor place for the one guarantee protecting the aurora migration task, which has **no CloudWatch alarm anywhere** - its Slack card is its only alerting, so a regression that drops one of those events is silent.

A `Lambda tests` job on Python 3.12, matching the runtime `aws_lambda_function.sns_to_slack` declares.

Making it *gate* took two attempts. The three `Terraform (...)` contexts are required by branch protection and `Lambda tests` is not, so left parallel a red lambda run sits beside three green required checks and merges. `needs:` alone does not fix it either - GitHub treats a **skipped** required context as satisfied, so a failed dependency would skip those three and still leave the PR mergeable. They now run under `always()` with an explicit guard step that fails them when the lambda job did not succeed.

**The clean fix is adding `Lambda tests` to the required set in branch protection**, which is a repo-settings change rather than a code one. Do that and this coupling can come out. `boto3` is the only dependency, and only because the module imports it at import time. Nothing in the Terraform matrix ever executed this code; `tofu validate` only checks that the `archive_file` source exists.

## Verification

- Suite **224/224**, up from 136, with the state machine executing against a real DynamoDB implementation rather than assertions about request shapes. The new checks cover stale ALARM, stale OK, equal timestamps, a row with no recorded event time, an unparseable event time, a lost claim, and the claim's request shape.
- **Mutation-tested**: removing the staleness guard fails 6 checks, making the claim always win fails 7, and flattening `_is_stale` to `False` fails 6.
- Exit codes confirmed **1 on failure / 0 on pass**, so the new CI job is a real gate rather than a green tick.
- `tofu fmt -check -recursive` clean, `terraform-docs` no diff, tflint clean.

## The suite runs against DynamoDB now, and that is the point

The state machine's correctness lives in ConditionExpressions that DynamoDB evaluates. A mock that asserts *the request we built* cannot tell a correct condition from a nonsense one, and four review rounds found defects it passed clean through. The state suites now run against **moto**, executing the real conditions. A missing moto is a test FAILURE, not a skip - silently dropping the only real coverage while reporting green is how this got here.

Everything that exposed, all of it live and all of it introduced by earlier rounds of this PR:

- **A claimed-but-unposted row had no `MessageTs`**, and `_get_alarm_state` read it unconditionally. Every retry of a died-mid-post invocation raised `KeyError` *before* it could take the claim over, so the lease never fired and the red root was lost for good.
- **`ClaimedAt` was the ownership token**, and it is whole seconds. Two claims in one second shared an identity, so a stale finaliser could satisfy a condition written for a claim it never held. Tokens are uuids now; `ClaimedAt` remains only as the lease clock.
- **The repeat-ALARM path still ended in a blind whole-item `PutItem`.** A paused duplicate of a closed incident could replace a newer incident's row with the old root and the old watermark, after which a delayed OK looked newer than the live incident and closed it. It touches only the watermark now, conditional on the row still holding that same root.
- **Unorderable events bypassed ordering entirely** and could claim, react to and resolve a live incident. They now fail open for *visibility only*: posted uncorrelated, mutating nothing.
- **Equal timestamps with conflicting states were decided by arrival order**, so an ALARM could reopen a row an OK resolved at the same second. Both are refused, and `LastEventState` records which state the watermark belongs to.
- **Dedupe matched a substring** of the alarm name or `RESOLVED`, which cannot tell this incident's card from the previous one's during a fast re-alarm - a takeover could adopt the old card and suppress the new one. Cards carry a per-transition id in Slack metadata and matching is exact equality.
- **A recovery takeover finalised without reacting**, so a root whose first attempt died after posting kept its red-only scrollback forever.
- One assertion read `r.root_finals == [] or True` and could never fail.

CI also caught a hermeticity bug my machine hid: the module builds clients with a bare `boto3.client('dynamodb')`, correct in the Lambda but `NoRegionError` on a runner with no AWS config. The suite pins fake region and credentials now, verified by running with `HOME` and every `AWS_*` variable stripped.

## What is deliberately not covered

**No live AWS call.** moto is a faithful local implementation, not the service. It executes real condition semantics, which is what the mocks could not, but it is not proof against AWS itself.

**Concurrency is simulated, not raced.** The interleavings are driven in sequence against the emulator. That is enough to prove the conditions reject what they should; it is not a stress test.

**A non-condition failure propagates** rather than being swallowed into a lost claim - throttling, a missing table, credentials all reach the Lambda's retry. That is asserted, but only against a synthetic error.

**An unorderable event still resolves.** A missing or unparseable `StateChangeTime` falls through to posting, so in principle a delayed malformed OK could close a live incident. Deliberate: dropping a real recovery is worse than a rare mis-close, and the watermark is now preserved so ordering keeps working afterwards.

## Rollout

`LastEventAt` is additive and absent rows are treated as unordered, so a mid-rollout fleet mixes old and new rows safely: an old row simply cannot suppress anything. Physical stacks plan and wait `UNCONFIRMED`, so each env keeps the current behaviour until its physical apply is confirmed.



